### PR TITLE
fix for unlocking calculation

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -14,6 +14,15 @@ export const planckToUnit: any = (val: any, units: number) => {
   return val / (10 ** units);
 }
 
+export const getTotalUnlocking: any = (unlocking: any, units:any):number => {
+  let totalUnlocking = 0;
+  for (let i = 0; i < unlocking.length; i++) {
+    const unlockingVal = planckToUnit(unlocking[i].val?.toNumber() || 0, units);
+    totalUnlocking += unlockingVal;
+  }
+  return totalUnlocking;
+}
+
 export const fiatAmount: any = (val: any) => {
   return val.toFixed(2);
 }

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { planckToUnit } from '../../../Utils';
+import { getTotalUnlocking, planckToUnit } from '../../../Utils';
 import BondedGraph from './BondedGraph';
 import { useApi } from '../../../contexts/Api';
 import { useConnect } from '../../../contexts/Connect';
@@ -24,11 +24,7 @@ export const ManageBond = () => {
   const { active, total } = ledger;
 
   let { unlocking } = ledger;
-  let totalUnlocking = 0;
-  for (let i = 0; i < unlocking.length; i++) {
-    unlocking[i] = planckToUnit(unlocking[i].toNumber(), units);
-    totalUnlocking += unlocking[i];
-  }
+  let totalUnlocking = getTotalUnlocking(unlocking, units)
 
   const remaining = total.sub(active).toNumber() - totalUnlocking;
 

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -24,7 +24,7 @@ export const ManageBond = () => {
   const { active, total } = ledger;
 
   let { unlocking } = ledger;
-  let totalUnlocking = getTotalUnlocking(unlocking, units)
+  let totalUnlocking = getTotalUnlocking(unlocking, units);
 
   const remaining = total.sub(active).toNumber() - totalUnlocking;
 

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -60,7 +60,7 @@ export const Active = (props: any) => {
   }, [nominationStatuses]);
 
   let { unlocking } = ledger;
-  let totalUnlocking = getTotalUnlocking(unlocking, units)
+  let totalUnlocking = getTotalUnlocking(unlocking, units);
 
   const items = [
     {

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -10,7 +10,7 @@ import { useApi } from '../../../contexts/Api';
 import { useStaking } from '../../../contexts/Staking';
 import { useNetworkMetrics } from '../../../contexts/Network';
 import { useBalances } from '../../../contexts/Balances';
-import { planckToUnit } from '../../../Utils';
+import { getTotalUnlocking } from '../../../Utils';
 import { useConnect } from '../../../contexts/Connect';
 import { Nominations } from './Nominations';
 import { ManageBond } from './ManageBond';
@@ -60,11 +60,7 @@ export const Active = (props: any) => {
   }, [nominationStatuses]);
 
   let { unlocking } = ledger;
-  let totalUnlocking = 0;
-  for (let i = 0; i < unlocking.length; i++) {
-    unlocking[i] = planckToUnit(unlocking[i].toNumber(), units);
-    totalUnlocking += unlocking[i];
-  }
+  let totalUnlocking = getTotalUnlocking(unlocking, units)
 
   const items = [
     {

--- a/src/pages/Stake/Setup/index.tsx
+++ b/src/pages/Stake/Setup/index.tsx
@@ -28,7 +28,7 @@ export const Setup = (props: any) => {
   const ledger = getAccountLedger(controller);
 
   let { unlocking } = ledger;
-  let totalUnlocking = getTotalUnlocking(unlocking, units)
+  let totalUnlocking = getTotalUnlocking(unlocking, units);
 
   return (
     <>

--- a/src/pages/Stake/Setup/index.tsx
+++ b/src/pages/Stake/Setup/index.tsx
@@ -4,7 +4,7 @@
 import { PageRowWrapper } from '../../../Wrappers';
 import { SectionWrapper } from '../../../library/Graphs/Wrappers';
 import { useBalances } from '../../../contexts/Balances';
-import { planckToUnit } from '../../../Utils';
+import { getTotalUnlocking } from '../../../Utils';
 import { useApi } from '../../../contexts/Api';
 import { useConnect } from '../../../contexts/Connect';
 import { useStaking } from '../../../contexts/Staking';
@@ -28,11 +28,7 @@ export const Setup = (props: any) => {
   const ledger = getAccountLedger(controller);
 
   let { unlocking } = ledger;
-  let totalUnlocking = 0;
-  for (let i = 0; i < unlocking.length; i++) {
-    unlocking[i] = planckToUnit(unlocking[i].toNumber(), units);
-    totalUnlocking += unlocking[i];
-  }
+  let totalUnlocking = getTotalUnlocking(unlocking, units)
 
   return (
     <>

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -4,7 +4,7 @@
 import { PageProps } from '../types';
 import { Wrapper } from './Wrappers';
 import { useBalances } from '../../contexts/Balances';
-import { planckToUnit } from '../../Utils';
+import { getTotalUnlocking } from '../../Utils';
 import { useApi } from '../../contexts/Api';
 import { useConnect } from '../../contexts/Connect';
 import { useUi } from '../../contexts/UI';
@@ -29,11 +29,7 @@ export const Stake = (props: PageProps) => {
   const ledger = getAccountLedger(controller);
 
   let { unlocking } = ledger;
-  let totalUnlocking = 0;
-  for (let i = 0; i < unlocking.length; i++) {
-    unlocking[i] = planckToUnit(unlocking[i].toNumber(), units);
-    totalUnlocking += unlocking[i];
-  }
+  let totalUnlocking = getTotalUnlocking(unlocking, units);
 
   let _inSetup: boolean = inSetup();
   let _isSyncing = isSyncing();


### PR DESCRIPTION
Currently the totalUnlocking calculation calls the toNumber() on the unlocking object instead of unlocking.val which throws errors if the account has any unlocking values.
To reproduce, 
1- connect a stash account with some unbonded value. 
2- go to sraking tab
```
web3Enable: Enabled 2 extensions: talisman/1.4.3, polkadot-js/0.42.2
logger.js:62 2022-05-12 09:48:20        API/INIT: RPC methods not decorated: state_trieMigrationStatus
ly @ logger.js:62
react-dom.production.min.js:186 TypeError: d[g].toNumber is not a function
    at Y5 (index.tsx:34:46)
    at yn (react-dom.production.min.js:166:137)
    at wi (react-dom.production.min.js:289:386)
    at bu (react-dom.production.min.js:279:389)
    at mu (react-dom.production.min.js:279:320)
    at gu (react-dom.production.min.js:279:180)
    at lu (react-dom.production.min.js:270:88)
    at ou (react-dom.production.min.js:272:300)
    at Wl (react-dom.production.min.js:127:105)
    at react-dom.production.min.js:266:269
```
