### PR TITLE
pass stat items as StatBoxListItems to StatBoxList

### DIFF
--- a/src/library/Graphs/StatBoxPie.tsx
+++ b/src/library/Graphs/StatBoxPie.tsx
@@ -8,8 +8,7 @@ import { useTheme } from '../../contexts/Themes';
 
 ChartJS.register(ArcElement, Tooltip);
 
-export const StatBoxPie = (props: any) => {
-
+export const StatPie = (props: any) => {
   let { value, value2 } = props;
 
   // format zero value graph
@@ -68,6 +67,6 @@ export const StatBoxPie = (props: any) => {
       />
     </div>
   );
-}
+};
 
-export default StatBoxPie;
+export default StatPie;

--- a/src/library/StatBoxList/Item.tsx
+++ b/src/library/StatBoxList/Item.tsx
@@ -2,135 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { StatBoxWrapper } from './Wrapper';
-import NumberEasing from 'che-react-number-easing';
-import { StatPie } from '../../library/Graphs/StatBoxPie';
-import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
+import { Pie } from './Pie';
+import { Number } from './Number';
+import { Text } from './Text';
 
-const PieStatBox = (props: any) => {
-  const { label, value, value2, total, unit, tooltip, assistant } = props;
-  let assist = assistant !== undefined;
-  let page = assistant?.page ?? '';
-  let key = assistant?.key ?? '';
-
-  let showValue = !(value === 0 && total !== 0);
-  let showTotal = !(total === undefined || !total);
-  return (
-    <StatBox>
-      <div className="content chart">
-        <div className="chart">
-          <StatPie value={value} value2={value2} />
-          {tooltip && (
-            <div className="tooltip">
-              <p>{tooltip}</p>
-            </div>
-          )}
-        </div>
-
-        <div className="labels">
-          <>
-            <h2>
-              {showValue ? (
-                <>
-                  <NumberEasing
-                    ease="quintInOut"
-                    precision={2}
-                    speed={250}
-                    trail={false}
-                    value={value}
-                    useLocaleString={true}
-                  />
-                  {unit && <>&nbsp;{unit}</>}
-
-                  {showTotal && (
-                    <span className="total">
-                      /{' '}
-                      <NumberEasing
-                        ease="quintInOut"
-                        precision={2}
-                        speed={250}
-                        trail={false}
-                        value={total}
-                        useLocaleString={true}
-                      />
-                      {unit && <>&nbsp;{unit}</>}
-                    </span>
-                  )}
-                </>
-              ) : (
-                <>0</>
-              )}
-            </h2>
-            <h4>
-              {label}
-              {assist && <OpenAssistantIcon page={page} title={key} />}
-            </h4>
-          </>
-        </div>
-      </div>
-    </StatBox>
-  );
-};
-
-const TextStatBox = (props: any) => {
-  const { label, value, assistant } = props;
-
-  let assist = assistant !== undefined;
-  let page = assistant?.page ?? '';
-  let key = assistant?.key ?? '';
-  return (
-    <StatBox>
-      <div className="content chart">
-        <div className="labels">
-          <>
-            <h1>{value}</h1>
-            <h4>
-              {label}
-              {assist && <OpenAssistantIcon page={page} title={key} />}
-            </h4>
-          </>
-        </div>
-      </div>
-    </StatBox>
-  );
-};
-
-const NumberStatBox = (props: any) => {
-  const { label, value, unit, assistant } = props;
-
-  let assist = assistant !== undefined;
-  let page = assistant?.page ?? '';
-  let key = assistant?.key ?? '';
-
-  let currency = props.currency ?? '';
-  return (
-    <StatBox>
-      <div className="content chart">
-        <div className="labels">
-          <>
-            <h2>
-              <NumberEasing
-                ease="quintInOut"
-                precision={2}
-                speed={250}
-                trail={false}
-                value={value}
-                useLocaleString={true}
-                currency={currency}
-              />
-              {unit && <>&nbsp;{unit}</>}
-            </h2>
-            <h4>
-              {label}
-              {assist && <OpenAssistantIcon page={page} title={key} />}
-            </h4>
-          </>
-        </div>
-      </div>
-    </StatBox>
-  );
-};
-
-const StatBox = ({ children }: any) => {
+export const StatBox = ({ children }: any) => {
   return (
     <StatBoxWrapper
       whileHover={{ scale: 1.02 }}
@@ -148,11 +24,14 @@ const StatBox = ({ children }: any) => {
 const StatBoxListItem = ({ format, params }: any) => {
   switch (format) {
     case 'chart-pie':
-      return <PieStatBox {...params} />;
+      return <Pie {...params} />;
+
     case 'number':
-      return <NumberStatBox {...params} />;
+      return <Number {...params} />;
+
     case 'text':
-      return <TextStatBox {...params} />;
+      return <Text {...params} />;
+
     default:
       return null;
   }

--- a/src/library/StatBoxList/Item.tsx
+++ b/src/library/StatBoxList/Item.tsx
@@ -3,113 +3,159 @@
 
 import { StatBoxWrapper } from './Wrapper';
 import NumberEasing from 'che-react-number-easing';
-import { StatBoxPie } from '../../library/Graphs/StatBoxPie';
+import { StatPie } from '../../library/Graphs/StatBoxPie';
 import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
 
-export const Item = (props: any) => {
+const PieStatBox = (props: any) => {
+  const { label, value, value2, total, unit, tooltip, assistant } = props;
+  let assist = assistant !== undefined;
+  let page = assistant?.page ?? '';
+  let key = assistant?.key ?? '';
 
-  const { label, value, value2, total, unit, format, tooltip, assistant } = props;
+  let showValue = !(value === 0 && total !== 0);
+  let showTotal = !(total === undefined || !total);
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="chart">
+          <StatPie value={value} value2={value2} />
+          {tooltip && (
+            <div className="tooltip">
+              <p>{tooltip}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="labels">
+          <>
+            <h2>
+              {showValue ? (
+                <>
+                  <NumberEasing
+                    ease="quintInOut"
+                    precision={2}
+                    speed={250}
+                    trail={false}
+                    value={value}
+                    useLocaleString={true}
+                  />
+                  {unit && <>&nbsp;{unit}</>}
+
+                  {showTotal && (
+                    <span className="total">
+                      /{' '}
+                      <NumberEasing
+                        ease="quintInOut"
+                        precision={2}
+                        speed={250}
+                        trail={false}
+                        value={total}
+                        useLocaleString={true}
+                      />
+                      {unit && <>&nbsp;{unit}</>}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <>0</>
+              )}
+            </h2>
+            <h4>
+              {label}
+              {assist && <OpenAssistantIcon page={page} title={key} />}
+            </h4>
+          </>
+        </div>
+      </div>
+    </StatBox>
+  );
+};
+
+const TextStatBox = (props: any) => {
+  const { label, value, assistant } = props;
+
+  let assist = assistant !== undefined;
+  let page = assistant?.page ?? '';
+  let key = assistant?.key ?? '';
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="labels">
+          <>
+            <h1>{value}</h1>
+            <h4>
+              {label}
+              {assist && <OpenAssistantIcon page={page} title={key} />}
+            </h4>
+          </>
+        </div>
+      </div>
+    </StatBox>
+  );
+};
+
+const NumberStatBox = (props: any) => {
+  const { label, value, unit, assistant } = props;
 
   let assist = assistant !== undefined;
   let page = assistant?.page ?? '';
   let key = assistant?.key ?? '';
 
   let currency = props.currency ?? '';
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="labels">
+          <>
+            <h2>
+              <NumberEasing
+                ease="quintInOut"
+                precision={2}
+                speed={250}
+                trail={false}
+                value={value}
+                useLocaleString={true}
+                currency={currency}
+              />
+              {unit && <>&nbsp;{unit}</>}
+            </h2>
+            <h4>
+              {label}
+              {assist && <OpenAssistantIcon page={page} title={key} />}
+            </h4>
+          </>
+        </div>
+      </div>
+    </StatBox>
+  );
+};
 
-  let showValue = !(value === 0 && total !== 0);
-  let showTotal = !(total === undefined || !total);
-
+const StatBox = ({ children }: any) => {
   return (
     <StatBoxWrapper
       whileHover={{ scale: 1.02 }}
       transition={{
         duration: 0.5,
-        type: "spring",
+        type: 'spring',
         bounce: 0.4,
       }}
     >
-      <div className='content chart'>
-        {(format === 'chart-pie' || format === 'chart-bar') &&
-          <div className='chart'>
-            {format === 'chart-pie' && <StatBoxPie value={value} value2={value2} />}
-            {tooltip &&
-              <div className='tooltip'>
-                <p>{tooltip}</p>
-              </div>
-            }
-          </div>
-        }
-        <div className='labels'>
-          {format === 'number' &&
-            <>
-              <h2>
-                <NumberEasing
-                  ease="quintInOut"
-                  precision={2}
-                  speed={250}
-                  trail={false}
-                  value={value}
-                  useLocaleString={true}
-                  currency={currency}
-                />
-                {unit && <>&nbsp;{unit}</>}
-              </h2>
-              <h4>
-                {label}
-                {assist && <OpenAssistantIcon page={page} title={key} />}
-              </h4>
-            </>
-          }
-          {format === 'text' &&
-            <>
-              <h1>{value}</h1>
-              <h4>
-                {label}
-                {assist && <OpenAssistantIcon page={page} title={key} />}
-              </h4>
-            </>
-          }
-          {(format === 'chart-pie' || format === 'chart-bar') &&
-            <>
-              <h2>
-                {showValue
-                  ?
-                  <>
-                    <NumberEasing
-                      ease="quintInOut"
-                      precision={2}
-                      speed={250}
-                      trail={false}
-                      value={value}
-                      useLocaleString={true}
-                    />{unit && <>&nbsp;{unit}</>}
-
-                    {showTotal &&
-                      <span className='total'>
-                        / <NumberEasing
-                          ease="quintInOut"
-                          precision={2}
-                          speed={250}
-                          trail={false}
-                          value={total}
-                          useLocaleString={true}
-                        />{unit && <>&nbsp;{unit}</>}
-                      </span>
-                    }
-                  </>
-                  : <>0</>
-                }
-              </h2>
-              <h4>
-                {label}
-                {assist && <OpenAssistantIcon page={page} title={key} />}
-              </h4>
-            </>
-          }
-        </div>
-      </div>
+      {children}
     </StatBoxWrapper>
-  )
-}
+  );
+};
 
-export default Item;
+const StatBoxListItem = ({ format, params }: any) => {
+  switch (format) {
+    case 'chart-pie':
+      return <PieStatBox {...params} />;
+    case 'number':
+      return <NumberStatBox {...params} />;
+    case 'text':
+      return <TextStatBox {...params} />;
+    default:
+      return null;
+  }
+};
+
+export default StatBoxListItem;

--- a/src/library/StatBoxList/Number.tsx
+++ b/src/library/StatBoxList/Number.tsx
@@ -1,0 +1,41 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatBox } from './Item';
+import NumberEasing from 'che-react-number-easing';
+import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
+
+export const Number = (props: any) => {
+
+  const { label, value, unit, assistant } = props;
+
+  let assist = assistant !== undefined;
+  let page = assistant?.page ?? '';
+  let key = assistant?.key ?? '';
+
+  let currency = props.currency ?? '';
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="labels">
+          <h2>
+            <NumberEasing
+              ease="quintInOut"
+              precision={2}
+              speed={250}
+              trail={false}
+              value={value}
+              useLocaleString={true}
+              currency={currency}
+            />
+            {unit && <>&nbsp;{unit}</>}
+          </h2>
+          <h4>
+            {label}
+            {assist && <OpenAssistantIcon page={page} title={key} />}
+          </h4>
+        </div>
+      </div>
+    </StatBox>
+  );
+};

--- a/src/library/StatBoxList/Pie.tsx
+++ b/src/library/StatBoxList/Pie.tsx
@@ -1,0 +1,71 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatBox } from './Item';
+import NumberEasing from 'che-react-number-easing';
+import { StatPie } from '../../library/Graphs/StatBoxPie';
+import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
+
+export const Pie = (props: any) => {
+
+  const { label, value, value2, total, unit, tooltip, assistant } = props;
+  let assist = assistant !== undefined;
+  let page = assistant?.page ?? '';
+  let key = assistant?.key ?? '';
+
+  let showValue = !(value === 0 && total !== 0);
+  let showTotal = !(total === undefined || !total);
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="chart">
+          <StatPie value={value} value2={value2} />
+          {tooltip && (
+            <div className="tooltip">
+              <p>{tooltip}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="labels">
+          <h2>
+            {showValue ? (
+              <>
+                <NumberEasing
+                  ease="quintInOut"
+                  precision={2}
+                  speed={250}
+                  trail={false}
+                  value={value}
+                  useLocaleString={true}
+                />
+                {unit && <>&nbsp;{unit}</>}
+
+                {showTotal && (
+                  <span className="total">
+                    /{' '}
+                    <NumberEasing
+                      ease="quintInOut"
+                      precision={2}
+                      speed={250}
+                      trail={false}
+                      value={total}
+                      useLocaleString={true}
+                    />
+                    {unit && <>&nbsp;{unit}</>}
+                  </span>
+                )}
+              </>
+            ) : (
+              <>0</>
+            )}
+          </h2>
+          <h4>
+            {label}
+            {assist && <OpenAssistantIcon page={page} title={key} />}
+          </h4>
+        </div>
+      </div>
+    </StatBox>
+  );
+};

--- a/src/library/StatBoxList/Text.tsx
+++ b/src/library/StatBoxList/Text.tsx
@@ -1,0 +1,27 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatBox } from './Item';
+import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
+
+export const Text = (props: any) => {
+
+  const { label, value, assistant } = props;
+
+  let assist = assistant !== undefined;
+  let page = assistant?.page ?? '';
+  let key = assistant?.key ?? '';
+  return (
+    <StatBox>
+      <div className="content chart">
+        <div className="labels">
+          <h1>{value}</h1>
+          <h4>
+            {label}
+            {assist && <OpenAssistantIcon page={page} title={key} />}
+          </h4>
+        </div>
+      </div>
+    </StatBox>
+  );
+};

--- a/src/library/StatBoxList/index.tsx
+++ b/src/library/StatBoxList/index.tsx
@@ -2,21 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Wrapper, ListWrapper } from './Wrapper';
-import Item from './Item';
 
-export const StatBoxList = (props: any) => {
-
-  const { items } = props;
-
+export const StatBoxList = ({ children }: any) => {
   return (
     <Wrapper>
-      <ListWrapper>
-        {items.map((item: any, index: number) =>
-          <Item {...item} key={index} />
-        )}
-      </ListWrapper>
+      <ListWrapper>{children}</ListWrapper>
     </Wrapper>
-  )
-}
+  );
+};
 
 export default StatBoxList;

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -20,9 +20,9 @@ import { planckToUnit, defaultIfNaN } from '../../Utils';
 import moment from 'moment';
 import { GRAPH_HEIGHT } from '../../constants';
 import { ActiveAccount } from './ActiveAccount';
+import StatBoxListItem from '../../library/StatBoxList/Item';
 
 export const Overview = () => {
-
   const { network, consts }: any = useApi();
   const { units } = network;
   const { maxElectingVoters } = consts;
@@ -32,30 +32,31 @@ export const Overview = () => {
   const { staking, eraStakers }: any = useStaking();
   const { payouts }: any = useSubscan();
 
-  const {
-    totalNominators,
-    maxNominatorsCount,
-    lastTotalStake
-  } = staking;
+  const { totalNominators, maxNominatorsCount, lastTotalStake } = staking;
 
   const { activeNominators } = eraStakers;
 
   // total supply as percent
   let supplyAsPercent = 0;
   if (totalIssuance.gt(new BN(0))) {
-    supplyAsPercent = lastTotalStake.div(totalIssuance.div(new BN(100))).toNumber();
+    supplyAsPercent = lastTotalStake
+      .div(totalIssuance.div(new BN(100)))
+      .toNumber();
   }
 
   // total active nominators as percent
   let totalNominatorsAsPercent = 0;
   if (maxNominatorsCount.gt(new BN(0))) {
-    totalNominatorsAsPercent = totalNominators.div(maxNominatorsCount.div(new BN(100))).toNumber();
+    totalNominatorsAsPercent = totalNominators
+      .div(maxNominatorsCount.div(new BN(100)))
+      .toNumber();
   }
 
   // active nominators as percent
   let activeNominatorsAsPercent = 0;
   if (maxElectingVoters > 0) {
-    activeNominatorsAsPercent = activeNominators / (new BN(maxElectingVoters)).div(new BN(100)).toNumber();
+    activeNominatorsAsPercent =
+      activeNominators / new BN(maxElectingVoters).div(new BN(100)).toNumber();
   }
 
   // base values
@@ -65,41 +66,47 @@ export const Overview = () => {
   // stats
   const items = [
     {
-      label: "Supply Staked",
-      value: lastTotalStakeBase.toNumber(),
-      value2: totalIssuanceBase.sub(lastTotalStakeBase).toNumber(),
-      unit: network.unit,
-      tooltip: `${supplyAsPercent.toFixed(2)}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'overview',
-        key: 'Supply Staked',
+      format: 'chart-pie',
+      params: {
+        label: 'Supply Staked',
+        value: lastTotalStakeBase.toNumber(),
+        value2: totalIssuanceBase.sub(lastTotalStakeBase).toNumber(),
+        unit: network.unit,
+        tooltip: `${supplyAsPercent.toFixed(2)}%`,
+        assistant: {
+          page: 'overview',
+          key: 'Supply Staked',
+        },
       },
     },
     {
-      label: "Total Nominators",
-      value: totalNominators.toNumber(),
-      value2: maxNominatorsCount.sub(totalNominators).toNumber(),
-      total: maxNominatorsCount,
-      unit: "",
-      tooltip: `${totalNominatorsAsPercent.toFixed(2)}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'overview',
-        key: 'Nominators',
+      format: 'chart-pie',
+      params: {
+        label: 'Total Nominators',
+        value: totalNominators.toNumber(),
+        value2: maxNominatorsCount.sub(totalNominators).toNumber(),
+        total: maxNominatorsCount,
+        unit: '',
+        tooltip: `${totalNominatorsAsPercent.toFixed(2)}%`,
+        assistant: {
+          page: 'overview',
+          key: 'Nominators',
+        },
       },
     },
     {
-      label: "Active Nominators",
-      value: activeNominators,
-      value2: maxElectingVoters - activeNominators,
-      total: maxElectingVoters,
-      unit: "",
-      tooltip: `${activeNominatorsAsPercent.toFixed(2)}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'overview',
-        key: 'Active Nominators',
+      format: 'chart-pie',
+      params: {
+        label: 'Active Nominators',
+        value: activeNominators,
+        value2: maxElectingVoters - activeNominators,
+        total: maxElectingVoters,
+        unit: '',
+        tooltip: `${activeNominatorsAsPercent.toFixed(2)}%`,
+        assistant: {
+          page: 'overview',
+          key: 'Active Nominators',
+        },
       },
     },
   ];
@@ -109,14 +116,18 @@ export const Overview = () => {
     let _last = payouts[payouts.length - 1];
     lastPayout = {
       amount: planckToUnit(_last['amount'], units),
-      block_timestamp: _last['block_timestamp'] + "",
+      block_timestamp: _last['block_timestamp'] + '',
     };
   }
 
   return (
     <>
       <PageTitle title="What's Happening" />
-      <StatBoxList items={items} />
+      <StatBoxList>
+        {items.map((item: any, index: number) => (
+          <StatBoxListItem {...item} key={index} />
+        ))}
+      </StatBoxList>
       <PageRowWrapper noVerticalSpacer>
         <SecondaryWrapper style={{ flexBasis: '40%', maxWidth: '40%' }}>
           <GraphWrapper flex>
@@ -127,10 +138,16 @@ export const Overview = () => {
         <MainWrapper paddingLeft>
           <GraphWrapper style={{ minHeight: GRAPH_HEIGHT }} flex>
             <SubscanButton />
-            <div className='head'>
+            <div className="head">
               <h4>Recent Payouts</h4>
               <h2>
-                {lastPayout === null ? 0 : lastPayout.amount} {network.unit}&nbsp;<span className='fiat'>{lastPayout === null ? `` : moment.unix(lastPayout['block_timestamp']).fromNow()}</span>
+                {lastPayout === null ? 0 : lastPayout.amount} {network.unit}
+                &nbsp;
+                <span className="fiat">
+                  {lastPayout === null
+                    ? ``
+                    : moment.unix(lastPayout['block_timestamp']).fromNow()}
+                </span>
               </h2>
             </div>
             <Payouts
@@ -145,6 +162,6 @@ export const Overview = () => {
       </PageRowWrapper>
     </>
   );
-}
+};
 
 export default Overview;

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -9,6 +9,7 @@ import { StatBoxList } from '../../library/StatBoxList';
 import { useSubscan } from '../../contexts/Subscan';
 import { useStaking } from '../../contexts/Staking';
 import { useApi } from '../../contexts/Api';
+import { useUi } from '../../contexts/UI';
 import { GraphWrapper } from '../../library/Graphs/Wrappers';
 import { PageRowWrapper } from '../../Wrappers';
 import { SubscanButton } from '../../library/SubscanButton';
@@ -26,6 +27,7 @@ export const Payouts = (props: PageProps) => {
   const { network }: any = useApi();
   const { staking }: any = useStaking();
   const { payouts }: any = useSubscan();
+  const { services }: any = useUi();
   const { unit, units } = network;
   const { lastReward } = staking;
 
@@ -85,7 +87,10 @@ export const Payouts = (props: PageProps) => {
             </h2>
           </div>
           <div className="inner" ref={ref} style={{ minHeight: minHeight }}>
-            <StatusLabel topOffset="30%" title="Not Yet Staking" />
+            {!services.includes('subscan')
+              ? <StatusLabel status="active_service" statusFor='subscan' title="Subscan Disabled" />
+              : <StatusLabel status="sync_or_setup" title="Not Yet Staking" />
+            }
             <div
               className="graph"
               style={{

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -20,9 +20,9 @@ import { StatusLabel } from '../../library/StatusLabel';
 import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
 import { PayoutList } from './PayoutList';
 import { SectionWrapper } from '../../library/Graphs/Wrappers';
+import StatBoxListItem from '../../library/StatBoxList/Item';
 
 export const Payouts = (props: PageProps) => {
-
   const { network }: any = useApi();
   const { staking }: any = useStaking();
   const { payouts }: any = useSubscan();
@@ -40,14 +40,16 @@ export const Payouts = (props: PageProps) => {
 
   let items = [
     {
-      label: "Last Era Payout",
-      value: lastRewardBase,
-      unit: unit,
-      format: "number",
-      assistant: {
-        page: 'payouts',
-        key: 'Last Era Payout'
-      }
+      format: 'number',
+      params: {
+        label: 'Last Era Payout',
+        value: lastRewardBase,
+        unit: unit,
+        assistant: {
+          page: 'payouts',
+          key: 'Last Era Payout',
+        },
+      },
     },
   ];
 
@@ -56,40 +58,51 @@ export const Payouts = (props: PageProps) => {
   return (
     <>
       <PageTitle title={title} />
-      <StatBoxList items={items} />
+      <StatBoxList>
+        {items.map((item: any, index: number) => (
+          <StatBoxListItem {...item} key={index} />
+        ))}
+      </StatBoxList>
       <PageRowWrapper>
         <GraphWrapper>
           <SubscanButton />
-          <div className='head'>
+          <div className="head">
             <h4>
               Payout History
-              <OpenAssistantIcon page='payouts' title='Payout History' />
+              <OpenAssistantIcon page="payouts" title="Payout History" />
             </h4>
             <h2>
-              {(payouts.length) ?
+              {payouts.length ? (
                 <>
-                  {moment.unix(payouts[0].block_timestamp).format('Do MMMM')} - {moment.unix(payouts[payouts.length - 1].block_timestamp).format('Do MMMM')}
+                  {moment.unix(payouts[0].block_timestamp).format('Do MMMM')} -{' '}
+                  {moment
+                    .unix(payouts[payouts.length - 1].block_timestamp)
+                    .format('Do MMMM')}
                 </>
-                : <span className='fiat'>None</span>
-              }
+              ) : (
+                <span className="fiat">None</span>
+              )}
             </h2>
           </div>
-          <div className='inner' ref={ref} style={{ minHeight: minHeight }}>
+          <div className="inner" ref={ref} style={{ minHeight: minHeight }}>
             <StatusLabel topOffset="30%" title="Not Yet Staking" />
-            <div className='graph' style={{ height: `${height}px`, width: `${width}px`, position: 'absolute' }}>
-              <PayoutBar
-                payouts={payouts.slice(0, 60)}
-                height='120px'
-              />
-              <PayoutLine
-                payouts={payouts.slice(0, 60)}
-                height='70px'
-              />
+            <div
+              className="graph"
+              style={{
+                height: `${height}px`,
+                width: `${width}px`,
+                position: 'absolute',
+              }}
+            >
+              <PayoutBar payouts={payouts.slice(0, 60)} height="120px" />
+              <PayoutLine payouts={payouts.slice(0, 60)} height="70px" />
             </div>
           </div>
         </GraphWrapper>
       </PageRowWrapper>
-      {!payoutsList.length ? <></> :
+      {!payoutsList.length ? (
+        <></>
+      ) : (
         <PageRowWrapper noVerticalSpacer>
           <SectionWrapper>
             <PayoutList
@@ -99,9 +112,9 @@ export const Payouts = (props: PageProps) => {
             />
           </SectionWrapper>
         </PageRowWrapper>
-      }
+      )}
     </>
   );
-}
+};
 
 export default Payouts;

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -68,46 +68,41 @@ export const Payouts = (props: PageProps) => {
       <PageRowWrapper>
         <GraphWrapper>
           <SubscanButton />
-          <div className="head">
+          <div className='head'>
             <h4>
               Payout History
-              <OpenAssistantIcon page="payouts" title="Payout History" />
+              <OpenAssistantIcon page='payouts' title='Payout History' />
             </h4>
             <h2>
-              {payouts.length ? (
+              {(payouts.length) ?
                 <>
-                  {moment.unix(payouts[0].block_timestamp).format('Do MMMM')} -{' '}
-                  {moment
-                    .unix(payouts[payouts.length - 1].block_timestamp)
-                    .format('Do MMMM')}
+                  {moment.unix(payouts[0].block_timestamp).format('Do MMMM')} - {moment.unix(payouts[payouts.length - 1].block_timestamp).format('Do MMMM')}
                 </>
-              ) : (
-                <span className="fiat">None</span>
-              )}
+                : <span className='fiat'>None</span>
+              }
             </h2>
           </div>
-          <div className="inner" ref={ref} style={{ minHeight: minHeight }}>
+          <div className='inner' ref={ref} style={{ minHeight: minHeight }}>
+
             {!services.includes('subscan')
               ? <StatusLabel status="active_service" statusFor='subscan' title="Subscan Disabled" />
               : <StatusLabel status="sync_or_setup" title="Not Yet Staking" />
             }
-            <div
-              className="graph"
-              style={{
-                height: `${height}px`,
-                width: `${width}px`,
-                position: 'absolute',
-              }}
-            >
-              <PayoutBar payouts={payouts.slice(0, 60)} height="120px" />
-              <PayoutLine payouts={payouts.slice(0, 60)} height="70px" />
+
+            <div className='graph' style={{ height: `${height}px`, width: `${width}px`, position: 'absolute' }}>
+              <PayoutBar
+                payouts={payouts.slice(0, 60)}
+                height='120px'
+              />
+              <PayoutLine
+                payouts={payouts.slice(0, 60)}
+                height='70px'
+              />
             </div>
           </div>
         </GraphWrapper>
       </PageRowWrapper>
-      {!payoutsList.length ? (
-        <></>
-      ) : (
+      {!payoutsList.length ? <></> :
         <PageRowWrapper noVerticalSpacer>
           <SectionWrapper>
             <PayoutList
@@ -117,7 +112,7 @@ export const Payouts = (props: PageProps) => {
             />
           </SectionWrapper>
         </PageRowWrapper>
-      )}
+      }
     </>
   );
 };

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -16,9 +16,9 @@ import { MainWrapper, SecondaryWrapper } from '../../library/Layout';
 import { Button } from '../../library/Button';
 import { PoolList } from '../../library/PoolList';
 import { usePools } from '../../contexts/Pools';
+import StatBoxListItem from '../../library/StatBoxList/Item';
 
 export const Pools = (props: PageProps) => {
-
   const { page } = props;
   const { title } = page;
 
@@ -41,7 +41,7 @@ export const Pools = (props: PageProps) => {
         addresses: {
           stash: '133YZZ6GvY8DGVjH2WExeGkahFQcw68N2MnVRieaURmqD3u3',
           reward: '133YZZ6GvY8DGVjH2WExeGkahFQcw68N2MnVRieaURmqD3u3',
-        }
+        },
       },
       {
         id: 2,
@@ -57,92 +57,128 @@ export const Pools = (props: PageProps) => {
         addresses: {
           stash: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
           reward: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
-        }
-      }
+        },
+      },
     ],
     activePool: 1,
   });
 
   const totalPools = meta.counterForBondedPools + meta.counterForRewardPools;
-  const activePoolsAsPercent = defaultIfNaN(((meta.counterForRewardPools ?? 0) / (totalPools * 0.01)).toFixed(2), 0);
-  const activePool = state.pools.find((item: any) => item.id === meta.counterForRewardPools);
+  const activePoolsAsPercent = defaultIfNaN(
+    ((meta.counterForRewardPools ?? 0) / (totalPools * 0.01)).toFixed(2),
+    0
+  );
+  const activePool = state.pools.find(
+    (item: any) => item.id === meta.counterForRewardPools
+  );
 
   const items: any = [
     {
-      label: "Active Pools",
-      value: meta.counterForRewardPools,
-      value2: totalPools - meta.counterForRewardPools,
-      total: totalPools,
-      unit: "",
-      tooltip: `${activePoolsAsPercent}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'pools',
-        key: 'Active Pools'
-      }
-    }, {
-      label: "Minimum Join Bond",
-      value: meta.minJoinBond,
-      unit: "DOT",
-      format: "number",
-      assistant: {
-        page: 'pools',
-        key: 'Era',
-      }
-    }, {
-      label: "Minimum Create Bond",
-      value: meta.minCreateBond,
-      unit: "DOT",
-      format: "number",
-      assistant: {
-        page: 'pools',
-        key: 'Era',
-      }
-    }
+      format: 'chart-pie',
+      params: {
+        label: 'Active Pools',
+        value: meta.counterForRewardPools,
+        value2: totalPools - meta.counterForRewardPools,
+        total: totalPools,
+        unit: '',
+        tooltip: `${activePoolsAsPercent}%`,
+        assistant: {
+          page: 'pools',
+          key: 'Active Pools',
+        },
+      },
+    },
+    {
+      format: 'number',
+      params: {
+        label: 'Minimum Join Bond',
+        value: meta.minJoinBond,
+        unit: 'DOT',
+        assistant: {
+          page: 'pools',
+          key: 'Era',
+        },
+      },
+    },
+    {
+      format: 'number',
+      params: {
+        label: 'Minimum Create Bond',
+        value: meta.minCreateBond,
+        unit: 'DOT',
+        assistant: {
+          page: 'pools',
+          key: 'Era',
+        },
+      },
+    },
   ];
 
   return (
     <>
       <PageTitle title={title} />
-      <StatBoxList items={items} />
+      <StatBoxList>
+        {items.map((item: any, index: number) => (
+          <StatBoxListItem {...item} key={index} />
+        ))}
+      </StatBoxList>
       <PageRowWrapper noVerticalSpacer>
         <MainWrapper paddingRight style={{ flex: 1 }}>
           <SectionWrapper style={{ height: 360 }}>
-            <div className='head'>
+            <div className="head">
               <h4>
                 Status
-                <OpenAssistantIcon page='pools' title='Pool Status' />
+                <OpenAssistantIcon page="pools" title="Pool Status" />
               </h4>
               <h2>
                 Actively in Pool and Earning Rewards &nbsp;
                 <div>
-                  {activePool === undefined
-                    ? <Button small inline primary title='Create Pool' onClick={() => { }} />
-                    : <Button small inline primary title='Leave' onClick={() => { }} />
-                  }
+                  {activePool === undefined ? (
+                    <Button
+                      small
+                      inline
+                      primary
+                      title="Create Pool"
+                      onClick={() => {}}
+                    />
+                  ) : (
+                    <Button
+                      small
+                      inline
+                      primary
+                      title="Leave"
+                      onClick={() => {}}
+                    />
+                  )}
                 </div>
               </h2>
               <Separator />
               <h4>
                 Bonded in Pool
-                <OpenAssistantIcon page='pools' title='Bonded in Pool' />
+                <OpenAssistantIcon page="pools" title="Bonded in Pool" />
               </h4>
               <h2>
                 32.622931 {network.unit} &nbsp;
                 <div>
-                  <Button small primary inline title='+' onClick={() => { }} />
-                  <Button small primary title='-' onClick={() => { }} />
+                  <Button small primary inline title="+" onClick={() => {}} />
+                  <Button small primary title="-" onClick={() => {}} />
                 </div>
               </h2>
               <Separator />
               <h4>
                 Unclaimed Rewards
-                <OpenAssistantIcon page='pools' title='Pool Rewards' />
+                <OpenAssistantIcon page="pools" title="Pool Rewards" />
               </h4>
               <h2>
                 0.82 {network.unit} &nbsp;
                 <div>
-                  <Button small primary inline title='Claim' onClick={() => { }} />
+                  <Button
+                    small
+                    primary
+                    inline
+                    title="Claim"
+                    onClick={() => {}}
+                  />
                 </div>
               </h2>
             </div>
@@ -150,20 +186,31 @@ export const Pools = (props: PageProps) => {
         </MainWrapper>
         <SecondaryWrapper>
           <SectionWrapper style={{ height: 360 }}>
-
-            <div className='head'>
+            <div className="head">
               <h2>Pool Roles</h2>
-              <h4> Root <OpenAssistantIcon page='pools' title='Joined Pool' /></h4>
+              <h4>
+                Root <OpenAssistantIcon page="pools" title="Joined Pool" />
+              </h4>
               <PoolAccount address={activePool?.roles?.root ?? null} />
 
-              <h4> Depositor <OpenAssistantIcon page='pools' title='Joined Pool' /></h4>
+              <h4>
+                Depositor <OpenAssistantIcon page="pools" title="Joined Pool" />
+              </h4>
               <PoolAccount address={activePool?.roles?.depositor ?? null} />
 
-              <h4> Nominator <OpenAssistantIcon page='pools' title='Joined Pool' /></h4>
+              <h4>
+                Nominator <OpenAssistantIcon page="pools" title="Joined Pool" />
+              </h4>
               <PoolAccount address={activePool?.roles?.nominator ?? null} />
 
-              <h4> State Toggler <OpenAssistantIcon page='pools' title='Joined Pool' /></h4>
-              <PoolAccount address={activePool?.roles?.stateToggler ?? null} last={true} />
+              <h4>
+                State Toggler
+                <OpenAssistantIcon page="pools" title="Joined Pool" />
+              </h4>
+              <PoolAccount
+                address={activePool?.roles?.stateToggler ?? null}
+                last={true}
+              />
             </div>
           </SectionWrapper>
         </SecondaryWrapper>
@@ -176,7 +223,7 @@ export const Pools = (props: PageProps) => {
           </h2>
           <PoolList
             pools={state.pools}
-            title='Active Pools'
+            title="Active Pools"
             allowMoreCols
             pagination
           />
@@ -184,6 +231,6 @@ export const Pools = (props: PageProps) => {
       </PageRowWrapper>
     </>
   );
-}
+};
 
 export default Pools;

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -16,21 +16,26 @@ import { Nominations } from './Nominations';
 import { ManageBond } from './ManageBond';
 import { Button } from '../../../library/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faRedoAlt, faWallet, faCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faRedoAlt,
+  faWallet,
+  faCircle,
+} from '@fortawesome/free-solid-svg-icons';
 import { Separator } from '../../../Wrappers';
 import { PageTitle } from '../../../library/PageTitle';
 import { OpenAssistantIcon } from '../../../library/OpenAssistantIcon';
 import { useModal } from '../../../contexts/Modal';
+import StatBoxListItem from '../../../library/StatBoxList/Item';
 
 export const Active = (props: any) => {
-
   const { network }: any = useApi();
   const { units } = network;
   const { openModalWith } = useModal();
   const { activeAccount } = useConnect();
   const { metrics } = useNetworkMetrics();
   const { getNominationsStatus, eraStakers, staking } = useStaking();
-  const { getAccountLedger, getBondedAccount, getAccountNominations }: any = useBalances();
+  const { getAccountLedger, getBondedAccount, getAccountNominations }: any =
+    useBalances();
   const { payee } = staking;
 
   const { minActiveBond } = eraStakers;
@@ -45,12 +50,17 @@ export const Active = (props: any) => {
     active: 0,
   });
 
-  const nominationStatuses = useMemo(() => getNominationsStatus(), [nominations]);
+  const nominationStatuses = useMemo(
+    () => getNominationsStatus(),
+    [nominations]
+  );
 
   useEffect(() => {
     let statuses = nominationStatuses;
     let total = Object.values(statuses).length;
-    let _active: any = Object.values(statuses).filter((_v: any) => _v === 'active').length;
+    let _active: any = Object.values(statuses).filter(
+      (_v: any) => _v === 'active'
+    ).length;
 
     setNominationsStatus({
       total: total,
@@ -60,66 +70,86 @@ export const Active = (props: any) => {
   }, [nominationStatuses]);
 
   let { unlocking } = ledger;
-  let totalUnlocking = getTotalUnlocking(unlocking, units)
+  let totalUnlocking = getTotalUnlocking(unlocking, units);
 
   const items = [
     {
-      label: "Active Nominations",
-      value: nominationsStatus.active,
-      value2: nominationsStatus.active ? 0 : 1,
-      total: nominationsStatus.total,
-      unit: '',
-      tooltip: `${nominationsStatus.active ? `Active` : `Inactive`}`,
-      format: "chart-pie",
-      assistant: {
-        page: 'stake',
-        key: 'Nominations',
-      }
+      format: 'chart-pie',
+      params: {
+        label: 'Active Nominations',
+        value: nominationsStatus.active,
+        value2: nominationsStatus.active ? 0 : 1,
+        total: nominationsStatus.total,
+        unit: '',
+        tooltip: `${nominationsStatus.active ? `Active` : `Inactive`}`,
+        assistant: {
+          page: 'stake',
+          key: 'Nominations',
+        },
+      },
     },
     {
-      label: "Minimum Active Bond",
-      value: minActiveBond,
-      unit: network.unit,
-      format: "number",
-      assistant: {
-        page: 'stake',
-        key: 'Bonding',
-      }
+      format: 'number',
+      params: {
+        label: 'Minimum Active Bond',
+        value: minActiveBond,
+        unit: network.unit,
+        assistant: {
+          page: 'stake',
+          key: 'Bonding',
+        },
+      },
     },
     {
-      label: "Active Era",
-      value: metrics.activeEra.index,
-      unit: "",
-      format: "number",
-      assistant: {
-        page: 'validators',
-        key: 'Era',
-      }
-    }
+      format: 'number',
+      params: {
+        label: 'Active Era',
+        value: metrics.activeEra.index,
+        unit: '',
+        assistant: {
+          page: 'validators',
+          key: 'Era',
+        },
+      },
+    },
   ];
 
   return (
     <>
       <PageTitle title={props.title} />
-      <StatBoxList items={items} />
+      <StatBoxList>
+        {items.map((item: any, index: number) => (
+          <StatBoxListItem {...item} key={index} />
+        ))}
+      </StatBoxList>
       <PageRowWrapper noVerticalSpacer>
         <MainWrapper paddingRight style={{ flex: 1 }}>
           <SectionWrapper style={{ height: 260 }}>
-            <div className='head'>
+            <div className="head">
               <h4>
                 Status
-                <OpenAssistantIcon page='stake' title='Staking Status' />
+                <OpenAssistantIcon page="stake" title="Staking Status" />
               </h4>
-              <h2>{nominationsStatus.active ? 'Active and Earning Rewards' : 'Waiting for Active Nominations'}</h2>
+              <h2>
+                {nominationsStatus.active
+                  ? 'Active and Earning Rewards'
+                  : 'Waiting for Active Nominations'}
+              </h2>
               <Separator />
               <h4>
                 Reward Destination
-                <OpenAssistantIcon page='stake' title='Reward Destination' />
+                <OpenAssistantIcon page="stake" title="Reward Destination" />
               </h4>
               <h2>
                 <FontAwesomeIcon
-                  icon={payee === 'Staked' ? faRedoAlt : payee === 'None' ? faCircle : faWallet}
-                  transform='shrink-4'
+                  icon={
+                    payee === 'Staked'
+                      ? faRedoAlt
+                      : payee === 'None'
+                      ? faCircle
+                      : faWallet
+                  }
+                  transform="shrink-4"
                 />
                 &nbsp;
                 {payee === 'Staked' && 'Back to Staking'}
@@ -133,7 +163,7 @@ export const Active = (props: any) => {
                     small
                     inline
                     primary
-                    title='Update'
+                    title="Update"
                     onClick={() => openModalWith('UpdatePayee', {}, 'small')}
                   />
                 </div>
@@ -154,6 +184,6 @@ export const Active = (props: any) => {
       </PageRowWrapper>
     </>
   );
-}
+};
 
 export default Active;

--- a/src/pages/validators/Browse.tsx
+++ b/src/pages/validators/Browse.tsx
@@ -12,9 +12,9 @@ import { SectionWrapper } from '../../library/Graphs/Wrappers';
 import { ValidatorList } from '../../library/ValidatorList';
 import { PageTitle } from '../../library/PageTitle';
 import { PageRowWrapper } from '../../Wrappers';
+import StatBoxListItem from '../../library/StatBoxList/Item';
 
 export const Browse = (props: PageProps) => {
-
   const { page } = props;
   const { title } = page;
 
@@ -29,85 +29,98 @@ export const Browse = (props: PageProps) => {
   // total validators as percent
   let totalValidatorsAsPercent = 0;
   if (maxValidatorsCount.gt(new BN(0))) {
-    totalValidatorsAsPercent = totalValidators.div(maxValidatorsCount.div(new BN(100))).toNumber();
+    totalValidatorsAsPercent = totalValidators
+      .div(maxValidatorsCount.div(new BN(100)))
+      .toNumber();
   }
 
   // active validators as percent
   let activeValidatorsAsPercent = 0;
   if (validatorCount.gt(new BN(0))) {
-    activeValidatorsAsPercent = activeValidators / (validatorCount.toNumber() * 0.01);
+    activeValidatorsAsPercent =
+      activeValidators / (validatorCount.toNumber() * 0.01);
   }
 
   const items = [
     {
-      label: "Total Validators",
-      value: totalValidators.toNumber(),
-      value2: maxValidatorsCount.sub(totalValidators).toNumber(),
-      total: maxValidatorsCount.toNumber(),
-      unit: "",
-      tooltip: `${totalValidatorsAsPercent.toFixed(2)}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'validators',
-        key: 'Validator'
-      }
+      format: 'chart-pie',
+      params: {
+        label: 'Total Validators',
+        value: totalValidators.toNumber(),
+        value2: maxValidatorsCount.sub(totalValidators).toNumber(),
+        total: maxValidatorsCount.toNumber(),
+        unit: '',
+        tooltip: `${totalValidatorsAsPercent.toFixed(2)}%`,
+        assistant: {
+          page: 'validators',
+          key: 'Validator',
+        },
+      },
     },
     {
-      label: "Active Validators",
-      value: activeValidators,
-      value2: validatorCount.sub(new BN(activeValidators)).toNumber(),
-      total: validatorCount.toNumber(),
-      unit: "",
-      tooltip: `${activeValidatorsAsPercent.toFixed(2)}%`,
-      format: "chart-pie",
-      assistant: {
-        page: 'validators',
-        key: 'Active Validator'
-      }
+      format: 'chart-pie',
+      params: {
+        label: 'Active Validators',
+        value: activeValidators,
+        value2: validatorCount.sub(new BN(activeValidators)).toNumber(),
+        total: validatorCount.toNumber(),
+        unit: '',
+        tooltip: `${activeValidatorsAsPercent.toFixed(2)}%`,
+        assistant: {
+          page: 'validators',
+          key: 'Active Validator',
+        },
+      },
     },
     {
-      label: "Active Era",
-      value: metrics.activeEra.index,
-      unit: "",
-      format: "number",
-      assistant: {
-        page: 'validators',
-        key: 'Era',
-      }
-    }
+      format: 'number',
+      params: {
+        label: 'Active Era',
+        value: metrics.activeEra.index,
+        unit: '',
+        assistant: {
+          page: 'validators',
+          key: 'Era',
+        },
+      },
+    },
   ];
 
   return (
     <>
       <PageTitle title={title} />
-      <StatBoxList items={items} />
+      <StatBoxList>
+        {items.map((item: any, index: number) => (
+          <StatBoxListItem {...item} key={index} />
+        ))}
+      </StatBoxList>
       <PageRowWrapper noVerticalSpacer>
         <SectionWrapper>
-          {isReady &&
+          {isReady && (
             <>
-              {validators.length === 0 &&
-                <div className='item'>
+              {validators.length === 0 && (
+                <div className="item">
                   <h4>Fetching validators...</h4>
                 </div>
-              }
+              )}
 
-              {validators.length > 0 &&
+              {validators.length > 0 && (
                 <ValidatorList
                   validators={validators}
-                  batchKey='validators_browse'
-                  title='Validators'
+                  batchKey="validators_browse"
+                  title="Validators"
                   allowMoreCols
                   allowFilters
                   pagination
                   toggleFavourites
                 />
-              }
+              )}
             </>
-          }
+          )}
         </SectionWrapper>
       </PageRowWrapper>
     </>
   );
-}
+};
 
 export default Browse;


### PR DESCRIPTION
These will address the #39 to refactor breakdown StatBox Items to separate components. If something like this makes sense we can further customize the chart statboxes to have a new statbox for era with a pie or doughnut timer.
main changes are:
- instead of one Item it will breakdown the stat list items to 3 different components (PieStatBox, TextStatBox, NumberStatBox)
- adds a StatBoxListItem to wrap StatBoxes that are a list item

I use prettier for formatting so some changes are due to fromatter! if there is a formatter/linter that we use for the project I can reformat the changes based on that.