### PR TITLE
Add a graph for era progress in the validator page

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -20,11 +20,13 @@ import { AssistantProvider } from './contexts/Assistant';
 import { ModalProvider } from './contexts/Modal';
 import { APIProvider } from './contexts/Api';
 import { useTheme } from './contexts/Themes';
+import { SessionEraProvider } from './contexts/SessionEra';
 
-export const WrappedRouter = () =>
+export const WrappedRouter = () => (
   <Wrapper>
     <Router />
-  </Wrapper>;
+  </Wrapper>
+);
 
 export const ThemedRouter = () => {
   const { mode } = useTheme();
@@ -34,7 +36,7 @@ export const ThemedRouter = () => {
       <WrappedRouter />
     </ThemeProvider>
   );
-}
+};
 
 export const Providers = withProviders(
   APIProvider,
@@ -51,8 +53,7 @@ export const Providers = withProviders(
   SubscanProvider,
   NotificationsProvider,
   ExtrinsicsProvider,
-)(
-  ThemedRouter
-);
+  SessionEraProvider
+)(ThemedRouter);
 
 export default Providers;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,6 +90,7 @@ export const SESSIONS_PER_ERA = 6;
 export const MAX_NOMINATOR_REWARDED_PER_VALIDATOR = 256;
 export const VOTER_SNAPSHOT_PER_BLOCK = 22500;
 export const MAX_ELECTING_VOTERS = 22500;
+export const EXPECTED_BLOCK_TIME = 6000;
 
 /*
  * Misc values 

--- a/src/contexts/Api.tsx
+++ b/src/contexts/Api.tsx
@@ -12,6 +12,7 @@ import {
   API_ENDPOINTS,
   NODE_ENDPOINTS,
   MAX_ELECTING_VOTERS,
+  EXPECTED_BLOCK_TIME,
 } from '../constants';
 
 type NetworkOptions = 'polkadot' | 'westend';
@@ -49,6 +50,7 @@ export const APIProvider = (props: any) => {
     sessionsPerEra: 0,
     maxNominatorRewardedPerValidator: 0,
     maxElectingVoters: 0,
+    expectedBlockTime: 0,
   });
 
   // connection status state
@@ -90,6 +92,7 @@ export const APIProvider = (props: any) => {
       _api.consts.staking.sessionsPerEra,
       _api.consts.staking.maxNominatorRewardedPerValidator,
       _api.consts.electionProviderMultiPhase.maxElectingVoters,
+      _api.consts.babe.expectedBlockTime,
     ]);
 
     setApi(_api);
@@ -99,6 +102,7 @@ export const APIProvider = (props: any) => {
       sessionsPerEra: _metrics[2]?.toNumber() ?? SESSIONS_PER_ERA,
       maxNominatorRewardedPerValidator: _metrics[3]?.toNumber() ?? MAX_NOMINATOR_REWARDED_PER_VALIDATOR,
       maxElectingVoters: _metrics[4]?.toNumber() ?? MAX_ELECTING_VOTERS,
+      expectedBlockTime: _metrics[5]?.toNumber() ?? EXPECTED_BLOCK_TIME,
     });
   }
 

--- a/src/contexts/SessionEra/defaults.ts
+++ b/src/contexts/SessionEra/defaults.ts
@@ -1,0 +1,13 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import BN from 'bn.js';
+
+export const state = {
+  eraLength: 0,
+  eraProgress: 0,
+  sessionLength: 0,
+  sessionProgress: 0,
+  sessionsPerEra: 0,
+  unsub: undefined,
+};

--- a/src/contexts/SessionEra/index.tsx
+++ b/src/contexts/SessionEra/index.tsx
@@ -1,0 +1,75 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState, useEffect } from 'react';
+import { useApi } from '../Api';
+import * as defaults from './defaults';
+
+export interface SessionEraContextState {
+  sessionEra: any;
+}
+
+export const SessionEraContext: React.Context<SessionEraContextState> =
+  React.createContext({
+    sessionEra: {},
+  });
+
+export const useSessionEra = () => React.useContext(SessionEraContext);
+
+export const SessionEraProvider = (props: any) => {
+  const { isReady, api, status }: any = useApi();
+
+  useEffect(() => {
+    if (status === 'connecting') {
+      setState(defaults.state);
+    }
+  }, [status]);
+
+  // store network metrics in state
+  const [state, setState]: any = useState(defaults.state);
+
+  // manage unsubscribe
+  useEffect(() => {
+    subscribeToSessionProgress();
+    return () => {
+      if (state.unsub !== undefined) {
+        state.unsub();
+      }
+    };
+  }, [isReady]);
+
+  // active subscription
+  const subscribeToSessionProgress = async () => {
+    if (isReady) {
+      const unsub = await api.derive.session.progress((session: any) => {
+        let _state = {
+          eraLength: session.eraLength.toNumber(),
+          eraProgress: session.eraProgress.toNumber(),
+          sessionLength: session.sessionLength.toNumber(),
+          sessionProgress: session.sessionProgress.toNumber(),
+          sessionsPerEra: session.sessionsPerEra.toNumber(),
+          unsub,
+        };
+        setState(_state);
+      });
+      return unsub;
+    }
+    return undefined;
+  };
+
+  return (
+    <SessionEraContext.Provider
+      value={{
+        sessionEra: {
+          eraLength: state.eraLength,
+          eraProgress: state.eraProgress,
+          sessionLength: state.sessionLength,
+          sessionProgress: state.sessionProgress,
+          sessionsPerEra: state.sessionsPerEra,
+        },
+      }}
+    >
+      {props.children}
+    </SessionEraContext.Provider>
+  );
+};

--- a/src/library/StatBoxList/Pie.tsx
+++ b/src/library/StatBoxList/Pie.tsx
@@ -8,18 +8,18 @@ import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
 
 export const Pie = (props: any) => {
 
-  const { label, value, value2, total, unit, tooltip, assistant } = props;
+  const { label, stat, graph, tooltip, assistant } = props;
   let assist = assistant !== undefined;
   let page = assistant?.page ?? '';
   let key = assistant?.key ?? '';
 
-  let showValue = !(value === 0 && total !== 0);
-  let showTotal = !(total === undefined || !total);
+  let showValue = stat?.value !== 0 || stat?.total === 0;
+  let showTotal = !!stat?.total;
   return (
     <StatBox>
       <div className="content chart">
         <div className="chart">
-          <StatPie value={value} value2={value2} />
+          <StatPie value={graph?.value1} value2={graph?.value2} />
           {tooltip && (
             <div className="tooltip">
               <p>{tooltip}</p>
@@ -36,10 +36,10 @@ export const Pie = (props: any) => {
                   precision={2}
                   speed={250}
                   trail={false}
-                  value={value}
+                  value={stat?.value}
                   useLocaleString={true}
                 />
-                {unit && <>&nbsp;{unit}</>}
+                {stat?.unit && <>&nbsp;{stat?.unit}</>}
 
                 {showTotal && (
                   <span className="total">
@@ -49,10 +49,10 @@ export const Pie = (props: any) => {
                       precision={2}
                       speed={250}
                       trail={false}
-                      value={total}
+                      value={stat?.total}
                       useLocaleString={true}
                     />
-                    {unit && <>&nbsp;{unit}</>}
+                    {stat?.unit && <>&nbsp;{stat?.unit}</>}
                   </span>
                 )}
               </>

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -69,9 +69,15 @@ export const Overview = () => {
       format: 'chart-pie',
       params: {
         label: 'Supply Staked',
-        value: lastTotalStakeBase.toNumber(),
-        value2: totalIssuanceBase.sub(lastTotalStakeBase).toNumber(),
-        unit: network.unit,
+        stat: {
+          value: lastTotalStakeBase.toNumber(),
+          unit: network.unit,
+        },
+        graph: {
+          value1: lastTotalStakeBase.toNumber(),
+          value2: totalIssuanceBase.sub(lastTotalStakeBase).toNumber(),
+        },
+
         tooltip: `${supplyAsPercent.toFixed(2)}%`,
         assistant: {
           page: 'overview',
@@ -83,10 +89,16 @@ export const Overview = () => {
       format: 'chart-pie',
       params: {
         label: 'Total Nominators',
-        value: totalNominators.toNumber(),
-        value2: maxNominatorsCount.sub(totalNominators).toNumber(),
-        total: maxNominatorsCount,
-        unit: '',
+        stat: {
+          value: totalNominators.toNumber(),
+          total: maxNominatorsCount,
+          unit: '',
+        },
+        graph: {
+          value1: totalNominators.toNumber(),
+          value2: maxNominatorsCount.sub(totalNominators).toNumber(),
+        },
+
         tooltip: `${totalNominatorsAsPercent.toFixed(2)}%`,
         assistant: {
           page: 'overview',
@@ -98,10 +110,15 @@ export const Overview = () => {
       format: 'chart-pie',
       params: {
         label: 'Active Nominators',
-        value: activeNominators,
-        value2: maxElectingVoters - activeNominators,
-        total: maxElectingVoters,
-        unit: '',
+        stat: {
+          value: activeNominators,
+          total: maxElectingVoters,
+          unit: '',
+        },
+        graph: {
+          value1: activeNominators,
+          value2: maxElectingVoters - activeNominators,
+        },
         tooltip: `${activeNominatorsAsPercent.toFixed(2)}%`,
         assistant: {
           page: 'overview',

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -77,10 +77,15 @@ export const Pools = (props: PageProps) => {
       format: 'chart-pie',
       params: {
         label: 'Active Pools',
-        value: meta.counterForRewardPools,
-        value2: totalPools - meta.counterForRewardPools,
-        total: totalPools,
-        unit: '',
+        stat: {
+          value: meta.counterForRewardPools,
+          total: totalPools,
+          unit: '',
+        },
+        graph: {
+          value1: meta.counterForRewardPools,
+          value2: totalPools - meta.counterForRewardPools,
+        },
         tooltip: `${activePoolsAsPercent}%`,
         assistant: {
           page: 'pools',

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -77,10 +77,15 @@ export const Active = (props: any) => {
       format: 'chart-pie',
       params: {
         label: 'Active Nominations',
-        value: nominationsStatus.active,
-        value2: nominationsStatus.active ? 0 : 1,
-        total: nominationsStatus.total,
-        unit: '',
+        stat: {
+          value: nominationsStatus.active,
+          total: nominationsStatus.total,
+          unit: '',
+        },
+        graph: {
+          value1: nominationsStatus.active,
+          value2: nominationsStatus.active ? 0 : 1,
+        },
         tooltip: `${nominationsStatus.active ? `Active` : `Inactive`}`,
         assistant: {
           page: 'stake',

--- a/src/pages/validators/Browse.tsx
+++ b/src/pages/validators/Browse.tsx
@@ -55,6 +55,7 @@ export const Browse = (props: PageProps) => {
     return diffTime;
   }
 
+  // store era time left as state object
   const [eraTimeLeft, _setEraTimeLeft]: any = useState(0);
   const eraTimeLeftRef = useRef(eraTimeLeft);
   const setEraTimeLeft = (_timeleft: number) => {
@@ -62,6 +63,8 @@ export const Browse = (props: PageProps) => {
     eraTimeLeftRef.current = _timeleft;
   }
 
+  // update time left every second
+  // clears and resets interval on `eraProgress` update.
   let timeleftInterval: any;
   useEffect(() => {
     setEraTimeLeft(getEraTimeLeft());
@@ -69,12 +72,12 @@ export const Browse = (props: PageProps) => {
     timeleftInterval = setInterval(() => {
       setEraTimeLeft(eraTimeLeftRef.current - 1);
     }, 1000);
-
     return (() => {
       clearInterval(timeleftInterval);
     })
   }, [sessionEra]);
 
+  // format era time left
   let _timeleft = moment.duration(eraTimeLeftRef.current * 1000, 'milliseconds');
   let timeleft = _timeleft.hours() + ":" + _timeleft.minutes() + ":" + _timeleft.seconds();
 

--- a/src/pages/validators/Browse.tsx
+++ b/src/pages/validators/Browse.tsx
@@ -8,6 +8,7 @@ import { useApi } from '../../contexts/Api';
 import { useStaking } from '../../contexts/Staking';
 import { useValidators } from '../../contexts/Validators/Validators';
 import { useNetworkMetrics } from '../../contexts/Network';
+import { useSessionEra } from '../../contexts/SessionEra';
 import { SectionWrapper } from '../../library/Graphs/Wrappers';
 import { ValidatorList } from '../../library/ValidatorList';
 import { PageTitle } from '../../library/PageTitle';
@@ -22,6 +23,7 @@ export const Browse = (props: PageProps) => {
   const { metrics } = useNetworkMetrics();
   const { staking, eraStakers }: any = useStaking();
   const { validators } = useValidators();
+  const { sessionEra } = useSessionEra();
 
   const { totalValidators, maxValidatorsCount, validatorCount } = staking;
   const { activeValidators } = eraStakers;
@@ -83,11 +85,17 @@ export const Browse = (props: PageProps) => {
       },
     },
     {
-      format: 'number',
+      format: 'chart-pie',
       params: {
         label: 'Active Era',
-        value: metrics.activeEra.index,
-        unit: '',
+        stat: {
+          value: metrics.activeEra.index,
+          unit: '',
+        },
+        graph: {
+          value1: sessionEra.eraProgress,
+          value2: sessionEra.eraLength - sessionEra.eraProgress,
+        },
         assistant: {
           page: 'validators',
           key: 'Era',

--- a/src/pages/validators/Browse.tsx
+++ b/src/pages/validators/Browse.tsx
@@ -46,10 +46,15 @@ export const Browse = (props: PageProps) => {
       format: 'chart-pie',
       params: {
         label: 'Total Validators',
-        value: totalValidators.toNumber(),
-        value2: maxValidatorsCount.sub(totalValidators).toNumber(),
-        total: maxValidatorsCount.toNumber(),
-        unit: '',
+        stat: {
+          value: totalValidators.toNumber(),
+          total: maxValidatorsCount.toNumber(),
+          unit: '',
+        },
+        graph: {
+          value1: totalValidators.toNumber(),
+          value2: maxValidatorsCount.sub(totalValidators).toNumber(),
+        },
         tooltip: `${totalValidatorsAsPercent.toFixed(2)}%`,
         assistant: {
           page: 'validators',
@@ -61,10 +66,15 @@ export const Browse = (props: PageProps) => {
       format: 'chart-pie',
       params: {
         label: 'Active Validators',
-        value: activeValidators,
-        value2: validatorCount.sub(new BN(activeValidators)).toNumber(),
-        total: validatorCount.toNumber(),
-        unit: '',
+        stat: {
+          value: activeValidators,
+          total: validatorCount.toNumber(),
+          unit: '',
+        },
+        graph: {
+          value1: activeValidators,
+          value2: validatorCount.sub(new BN(activeValidators)).toNumber(),
+        },
         tooltip: `${activeValidatorsAsPercent.toFixed(2)}%`,
         assistant: {
           page: 'validators',


### PR DESCRIPTION
These changes should address #33 
-sets the pieStat params to separate groups for stat and graph values, to be able to set independent values for the graph and texts.
- adds a SessionEra context to subscribe to the era and epoch progress.
- Also noticed the unsub is missing in the NetworkMetrics context. I also added the unsub to the state to be called when unmounts.

