### PR TITLE
Controller Not Imported Support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,13 +88,6 @@ export const GRAPH_HEIGHT = 430;
 export const SERVICES = ['subscan', 'binance_spot'];
 
 /*
- * Global messages for app components
- */
-export const GLOBAL_MESSGE_KEYS = {
-  CONTROLLER_NOT_IMPORTED: 'controller_not_imported',
-};
-
-/*
  * Fallback config values
  */
 export const MAX_NOMINATIONS = 16;

--- a/src/contexts/Messages.tsx
+++ b/src/contexts/Messages.tsx
@@ -1,10 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useEffect } from 'react';
-import { useConnect } from './Connect';
-import { useBalances } from './Balances';
-import { GLOBAL_MESSGE_KEYS } from '../constants';
+import React, { useState } from 'react';
 
 export interface MessagesContextState {
   messages: any;
@@ -26,32 +23,7 @@ export const MessagesContext: React.Context<MessagesContextState> =
 export const useMessages = () => React.useContext(MessagesContext);
 
 export const MessagesProvider = (props: any) => {
-  const {
-    activeAccount,
-    status: connectStatus,
-    accountExists,
-  }: any = useConnect();
-  const { accounts: balanceAccounts, getBondedAccount }: any = useBalances();
-
   const [messages, _setMessages]: any = useState([]);
-
-  useEffect(() => {
-    const _messages = [];
-
-    // is controller missing from imported accounts? (check once balanceAccounts are fetched)
-    if (balanceAccounts.length) {
-      const controller = getBondedAccount(activeAccount);
-      if (controller !== null) {
-        if (!accountExists(controller)) {
-          _messages.push({
-            key: GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED,
-            msg: true,
-          });
-        }
-      }
-    }
-    setMessages(_messages);
-  }, [activeAccount, connectStatus, balanceAccounts]);
 
   const setMessage = (key: string, msg: any) => {
     const filtered = messages.filter((message: any) => message.key !== key);

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -18,6 +18,7 @@ export interface StakingContextState {
   getNominationsStatus: () => any;
   setTargets: (t: any) => any;
   hasController: () => any;
+  isControllerImported: (a: string) => any;
   isBonding: () => any;
   isNominating: () => any;
   inSetup: () => any;
@@ -31,6 +32,7 @@ export const StakingContext: React.Context<StakingContextState> =
     getNominationsStatus: () => true,
     setTargets: (t: any) => false,
     hasController: () => false,
+    isControllerImported: (a: string) => false,
     isBonding: () => false,
     isNominating: () => false,
     inSetup: () => false,
@@ -42,7 +44,7 @@ export const StakingContext: React.Context<StakingContextState> =
 export const useStaking = () => React.useContext(StakingContext);
 
 export const StakingProvider = ({ children }: any) => {
-  const { activeAccount } = useConnect();
+  const { activeAccount, accounts: connectAccounts } = useConnect();
   const { isReady, api, consts, status, network }: any = useApi();
   const { metrics }: any = useNetworkMetrics();
   const {
@@ -286,6 +288,14 @@ export const StakingProvider = ({ children }: any) => {
   };
 
   /*
+   * Helper function to determine whether the controller account
+   * has been imported.
+   */
+  const isControllerImported = (address: string) => {
+    return connectAccounts.find((acc: any) => acc.address === address) ?? false;
+  };
+
+  /*
    * Helper function to determine whether the active account
    * is bonding, or is yet to start.
    */
@@ -334,6 +344,7 @@ export const StakingProvider = ({ children }: any) => {
         getNominationsStatus,
         setTargets,
         hasController,
+        isControllerImported,
         isBonding,
         isNominating,
         inSetup,

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -18,7 +18,7 @@ export interface StakingContextState {
   getNominationsStatus: () => any;
   setTargets: (t: any) => any;
   hasController: () => any;
-  isControllerImported: (a: string) => any;
+  getControllerNotImported: (a: string) => any;
   isBonding: () => any;
   isNominating: () => any;
   inSetup: () => any;
@@ -32,7 +32,7 @@ export const StakingContext: React.Context<StakingContextState> =
     getNominationsStatus: () => true,
     setTargets: (t: any) => false,
     hasController: () => false,
-    isControllerImported: (a: string) => false,
+    getControllerNotImported: (a: string) => false,
     isBonding: () => false,
     isNominating: () => false,
     inSetup: () => false,
@@ -291,8 +291,13 @@ export const StakingProvider = ({ children }: any) => {
    * Helper function to determine whether the controller account
    * has been imported.
    */
-  const isControllerImported = (address: string) => {
-    return connectAccounts.find((acc: any) => acc.address === address) ?? false;
+  const getControllerNotImported = (address: string) => {
+    if (address === null) {
+      return false;
+    }
+    // check if controller is imported
+    const exists = connectAccounts.find((acc: any) => acc.address === address);
+    return !exists;
   };
 
   /*
@@ -344,7 +349,7 @@ export const StakingProvider = ({ children }: any) => {
         getNominationsStatus,
         setTargets,
         hasController,
-        isControllerImported,
+        getControllerNotImported,
         isBonding,
         isNominating,
         inSetup,

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -324,7 +324,7 @@ export const StakingProvider = ({ children }: any) => {
    */
   const inSetup = () => {
     return (
-      !hasController() || (!isBonding() && !isNominating() && !isUnlocking())
+      !hasController() && !isBonding() && !isNominating() && !isUnlocking()
     );
   };
 

--- a/src/library/Account/Wrapper.ts
+++ b/src/library/Account/Wrapper.ts
@@ -50,6 +50,7 @@ export const Wrapper = styled(motion.button)<any>`
 
     &.unassigned {
       color: ${textSecondary};
+      opacity: 0.45;
     }
   }
 

--- a/src/library/Account/index.tsx
+++ b/src/library/Account/index.tsx
@@ -59,7 +59,7 @@ export const Account = (props: any) => {
       {label !== undefined && <div className="account-label">{label}</div>}
 
       {unassigned ? (
-        <span className="title unassigned">Not Set</span>
+        <span className="title unassigned">Not Staking</span>
       ) : (
         <>
           <span className="identicon">

--- a/src/library/Account/index.tsx
+++ b/src/library/Account/index.tsx
@@ -43,6 +43,11 @@ export const Account = (props: any) => {
       }
   }
 
+  // if title prop is provided, override `displayValue`
+  if (props.title !== undefined) {
+    displayValue = props.title;
+  }
+
   return (
     <Wrapper
       whileHover={{ scale: 1.01 }}

--- a/src/library/Form/BondInput/index.tsx
+++ b/src/library/Form/BondInput/index.tsx
@@ -32,8 +32,10 @@ export const BondInput = (props: any) => {
   const { freeToBond, freeToUnbond } = getBondOptions(activeAccount);
 
   // unbond amount to `minNominatorBond` threshold
-  const freeToUnbondToMinNominatorBond =
-    freeToUnbond - planckBnToUnit(minNominatorBond, units);
+  const freeToUnbondToMinNominatorBond = Math.max(
+    freeToUnbond - planckBnToUnit(minNominatorBond, units),
+    0
+  );
 
   // the current local bond value
   const [bond, setBond] = useState(_value);

--- a/src/library/Form/BondInputWithFeedback/index.tsx
+++ b/src/library/Form/BondInputWithFeedback/index.tsx
@@ -22,7 +22,7 @@ export const BondInputWithFeedback = (props: any) => {
 
   const { network }: any = useApi();
   const { activeAccount } = useConnect();
-  const { staking } = useStaking();
+  const { staking, getControllerNotImported } = useStaking();
   const { getAccountLedger, getBondedAccount, getBondOptions }: any =
     useBalances();
   const { freeToBond, freeToUnbond } = getBondOptions(activeAccount);
@@ -104,6 +104,11 @@ export const BondInputWithFeedback = (props: any) => {
 
     // unbond errors
     if (unbond) {
+      if (getControllerNotImported(controller)) {
+        _errors.push(
+          'You must have your controller account imported to unbond.'
+        );
+      }
       if (bond.bond !== '' && bond.bond > activeBase) {
         _errors.push('Unbond amount is more than your bonded balance.');
       } else if (

--- a/src/library/Form/BondInputWithFeedback/index.tsx
+++ b/src/library/Form/BondInputWithFeedback/index.tsx
@@ -7,7 +7,7 @@ import { useConnect } from '../../../contexts/Connect';
 import { useBalances } from '../../../contexts/Balances';
 import { useStaking } from '../../../contexts/Staking';
 import { BondInput } from '../BondInput';
-import { planckToUnit, humanNumber, planckBnToUnit } from '../../../Utils';
+import { humanNumber, planckBnToUnit } from '../../../Utils';
 import { Spacer } from '../Wrappers';
 import { Warning } from '../Warning';
 
@@ -36,8 +36,10 @@ export const BondInputWithFeedback = (props: any) => {
   const minNominatorBondBase = planckBnToUnit(minNominatorBond, units);
 
   // unbond amount to `minNominatorBond` threshold
-  const freeToUnbondToMinNominatorBond =
-    freeToUnbond - planckBnToUnit(minNominatorBond, units);
+  const freeToUnbondToMinNominatorBond = Math.max(
+    freeToUnbond - planckBnToUnit(minNominatorBond, units),
+    0
+  );
 
   // store errors
   const [errors, setErrors]: any = useState([]);

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -8,12 +8,13 @@ import { Account } from '../Account';
 import { useStaking } from '../../contexts/Staking';
 import { useBalances } from '../../contexts/Balances';
 
-export const Connected = (props: any) => {
+export const Connected = () => {
   const { activeAccount }: any = useConnect();
   const { openModalWith } = useModal();
-  const { isNominating, hasController } = useStaking();
+  const { isNominating, hasController, isControllerImported } = useStaking();
   const { getBondedAccount }: any = useBalances();
   const controller = getBondedAccount(activeAccount);
+  const controllerImported = isControllerImported(controller);
 
   return (
     <>
@@ -35,6 +36,7 @@ export const Connected = (props: any) => {
           <HeadingWrapper>
             <Account
               value={controller}
+              title={controllerImported ? undefined : 'Not Imported'}
               format="name"
               label="Controller"
               canClick={hasController()}

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -11,10 +11,10 @@ import { useBalances } from '../../contexts/Balances';
 export const Connected = () => {
   const { activeAccount }: any = useConnect();
   const { openModalWith } = useModal();
-  const { isNominating, hasController, isControllerImported } = useStaking();
+  const { isNominating, hasController, getControllerNotImported } =
+    useStaking();
   const { getBondedAccount }: any = useBalances();
   const controller = getBondedAccount(activeAccount);
-  const controllerImported = isControllerImported(controller);
 
   return (
     <>
@@ -36,7 +36,11 @@ export const Connected = () => {
           <HeadingWrapper>
             <Account
               value={controller}
-              title={controllerImported ? undefined : 'Not Imported'}
+              title={
+                getControllerNotImported(controller)
+                  ? 'Not Imported'
+                  : undefined
+              }
               format="name"
               label="Controller"
               canClick={hasController()}

--- a/src/library/SideMenu/Item.tsx
+++ b/src/library/SideMenu/Item.tsx
@@ -4,6 +4,10 @@
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import {
+  faExclamationTriangle,
+  faCircle,
+} from '@fortawesome/free-solid-svg-icons';
 import { useUi } from '../../contexts/UI';
 import { ItemWrapper, MinimisedItemWrapper } from './Wrapper';
 
@@ -25,19 +29,16 @@ export const Item = (props: any) => {
         }}
       >
         <div className="icon">{icon}</div>
-        {!minimised && (
-          <>
-            <h3 className="name">{name}</h3>
+        {!minimised && <h3 className="name">{name}</h3>}
 
-            {action && (
-              <div className="action">
-                <FontAwesomeIcon
-                  icon={action as IconProp}
-                  color="rgba(242, 185, 27,0.5)"
-                />
-              </div>
-            )}
-          </>
+        {action && (
+          <div className={`action${minimised ? ` minimised` : ``}`}>
+            <FontAwesomeIcon
+              icon={(minimised ? faCircle : faExclamationTriangle) as IconProp}
+              color="rgba(242, 185, 27,0.75)"
+              transform={minimised ? 'shrink-2' : ''}
+            />
+          </div>
         )}
       </StyledWrapper>
     </Link>

--- a/src/library/SideMenu/Wrapper.ts
+++ b/src/library/SideMenu/Wrapper.ts
@@ -81,6 +81,21 @@ export const LogoWrapper = styled(motion.button)<any>`
   }
 `;
 
+export const HeadingWrapper = styled.div<any>`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: ${(props) => (props.minimised ? 'center' : 'flex-start')};
+  opacity: ${(props) => (props.minimised ? 0.5 : 1)};
+  align-items: center;
+
+  h5 {
+    color: ${textSecondary};
+    margin: 1.1rem 0 0.2rem 0;
+    padding: 0 0.5rem;
+    opacity: 0.7;
+  }
+`;
+
 export const ItemWrapper = styled(motion.div)<any>`
   border-radius: 0.5rem;
   display: flex;
@@ -90,6 +105,7 @@ export const ItemWrapper = styled(motion.div)<any>`
   padding: 0.9rem 0.5rem;
   margin: 0.3rem 0;
   font-size: 1.04rem;
+  position: relative;
 
   .icon {
     margin-left: ${(props) => (props.minimised ? 0 : '0.25rem')};
@@ -114,21 +130,6 @@ export const ItemWrapper = styled(motion.div)<any>`
   }
 `;
 
-export const HeadingWrapper = styled.div<any>`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: ${(props) => (props.minimised ? 'center' : 'flex-start')};
-  opacity: ${(props) => (props.minimised ? 0.5 : 1)};
-  align-items: center;
-
-  h5 {
-    color: ${textSecondary};
-    margin: 1.1rem 0 0.2rem 0;
-    padding: 0 0.5rem;
-    opacity: 0.7;
-  }
-`;
-
 export const MinimisedItemWrapper = styled(motion.div)`
   border-radius: 0.5rem;
   display: flex;
@@ -138,6 +139,7 @@ export const MinimisedItemWrapper = styled(motion.div)`
   padding: 0.9rem 0rem;
   margin: 0.3rem 0;
   font-size: 1.04rem;
+  position: relative;
 
   &.active {
     background: ${highlightPrimary};
@@ -147,6 +149,16 @@ export const MinimisedItemWrapper = styled(motion.div)`
   }
   .icon {
     margin: 0;
+  }
+  .action {
+    &.minimised {
+      > svg {
+        flex: 0;
+        position: absolute;
+        top: -4px;
+        right: -4px;
+      }
+    }
   }
 `;
 

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -34,7 +34,7 @@ export const SideMenu = () => {
   const { activeAccount, accounts }: any = useConnect();
   const { pathname }: any = useLocation();
   const { getBondedAccount }: any = useBalances();
-  const { isControllerImported } = useStaking();
+  const { getControllerNotImported } = useStaking();
   const controller = getBondedAccount(activeAccount);
   const {
     setSideMenu,
@@ -43,6 +43,7 @@ export const SideMenu = () => {
     userSideMenuMinimised,
     setUserSideMenuMinimised,
   }: any = useUi();
+  const controllerNotImported = getControllerNotImported(controller);
 
   const [pageConfig, setPageConfig]: any = useState({
     categories: Object.assign(PAGE_CATEGORIES),
@@ -76,7 +77,7 @@ export const SideMenu = () => {
 
         // on stake menu item, add warning for controller not imported
         if (uri === `${URI_PREFIX}/stake`) {
-          _pageConfigWithMessages[i].action = !isControllerImported(controller);
+          _pageConfigWithMessages[i].action = controllerNotImported;
         }
       }
       setPageConfig({
@@ -84,7 +85,7 @@ export const SideMenu = () => {
         pages: _pageConfigWithMessages,
       });
     }
-  }, [network, activeAccount, accounts, isControllerImported(controller)]);
+  }, [network, activeAccount, accounts, controllerNotImported]);
 
   const ref = useRef(null);
   useOutsideAlerter(ref, () => {

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -12,13 +12,11 @@ import Heading from './Heading';
 import Item from './Item';
 import { PAGE_CATEGORIES, PAGES_CONFIG } from '../../pages';
 import { useConnect } from '../../contexts/Connect';
-import { useMessages } from '../../contexts/Messages';
 import { ReactComponent as PolkadotLogoSVG } from '../../img/polkadot_logo.svg';
 import { ReactComponent as PolkadotIconSVG } from '../../img/polkadot_icon.svg';
 import {
   URI_PREFIX,
   POLKADOT_URL,
-  GLOBAL_MESSGE_KEYS,
   SIDE_MENU_STICKY_THRESHOLD,
 } from '../../constants';
 import { useUi } from '../../contexts/UI';
@@ -26,14 +24,18 @@ import { useOutsideAlerter } from '../Hooks';
 import { useTheme } from '../../contexts/Themes';
 import { useModal } from '../../contexts/Modal';
 import { useApi } from '../../contexts/Api';
+import { useBalances } from '../../contexts/Balances';
+import { useStaking } from '../../contexts/Staking';
 
 export const SideMenu = () => {
   const { network }: any = useApi();
   const { openModalWith } = useModal();
   const { mode, toggleTheme } = useTheme();
   const { activeAccount, accounts }: any = useConnect();
-  const { getMessage }: any = useMessages();
   const { pathname }: any = useLocation();
+  const { getBondedAccount }: any = useBalances();
+  const { isControllerImported } = useStaking();
+  const controller = getBondedAccount(activeAccount);
   const {
     setSideMenu,
     sideMenuOpen,
@@ -74,9 +76,7 @@ export const SideMenu = () => {
 
         // on stake menu item, add warning for controller not imported
         if (uri === `${URI_PREFIX}/stake`) {
-          _pageConfigWithMessages[i].action = getMessage(
-            GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED
-          );
+          _pageConfigWithMessages[i].action = !isControllerImported(controller);
         }
       }
       setPageConfig({
@@ -84,12 +84,7 @@ export const SideMenu = () => {
         pages: _pageConfigWithMessages,
       });
     }
-  }, [
-    network,
-    activeAccount,
-    accounts,
-    getMessage(GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED),
-  ]);
+  }, [network, activeAccount, accounts, isControllerImported(controller)]);
 
   const ref = useRef(null);
   useOutsideAlerter(ref, () => {

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -4,11 +4,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faExclamationTriangle,
-  faExpandAlt,
-  faCompressAlt,
-} from '@fortawesome/free-solid-svg-icons';
+import { faExpandAlt, faCompressAlt } from '@fortawesome/free-solid-svg-icons';
 import { SunnyOutline, Moon, LogoGithub, Cog } from 'react-ionicons';
 import throttle from 'lodash.throttle';
 import { Wrapper, LogoWrapper } from './Wrapper';
@@ -20,6 +16,7 @@ import { useMessages } from '../../contexts/Messages';
 import { ReactComponent as PolkadotLogoSVG } from '../../img/polkadot_logo.svg';
 import { ReactComponent as PolkadotIconSVG } from '../../img/polkadot_icon.svg';
 import {
+  URI_PREFIX,
   POLKADOT_URL,
   GLOBAL_MESSGE_KEYS,
   SIDE_MENU_STICKY_THRESHOLD,
@@ -28,8 +25,10 @@ import { useUi } from '../../contexts/UI';
 import { useOutsideAlerter } from '../Hooks';
 import { useTheme } from '../../contexts/Themes';
 import { useModal } from '../../contexts/Modal';
+import { useApi } from '../../contexts/Api';
 
 export const SideMenu = () => {
+  const { network }: any = useApi();
   const { openModalWith } = useModal();
   const { mode, toggleTheme } = useTheme();
   const { activeAccount, accounts }: any = useConnect();
@@ -70,28 +69,23 @@ export const SideMenu = () => {
     // only process account messages and warnings once accounts are connected
     if (accounts.length) {
       const _pageConfigWithMessages: any = Object.assign(pageConfig.pages);
-
       for (let i = 0; i < _pageConfigWithMessages.length; i++) {
         const { uri } = _pageConfigWithMessages[i];
 
-        if (uri === '/stake') {
-          const notImported = getMessage(
+        // on stake menu item, add warning for controller not imported
+        if (uri === `${URI_PREFIX}/stake`) {
+          _pageConfigWithMessages[i].action = getMessage(
             GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED
           );
-          if (notImported === true) {
-            _pageConfigWithMessages[i].action = faExclamationTriangle;
-          } else {
-            _pageConfigWithMessages[i].action = null;
-          }
         }
       }
-
       setPageConfig({
         categories: pageConfig.categories,
         pages: _pageConfigWithMessages,
       });
     }
   }, [
+    network,
     activeAccount,
     accounts,
     getMessage(GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED),

--- a/src/modals/Nominate/index.tsx
+++ b/src/modals/Nominate/index.tsx
@@ -20,7 +20,7 @@ import { planckBnToUnit } from '../../Utils';
 export const Nominate = () => {
   const { api, network }: any = useApi();
   const { activeAccount } = useConnect();
-  const { targets, staking } = useStaking();
+  const { targets, staking, getControllerNotImported } = useStaking();
   const { getBondedAccount, getAccountLedger }: any = useBalances();
   const { setStatus: setModalStatus }: any = useModal();
   const { units } = network;
@@ -68,6 +68,11 @@ export const Nominate = () => {
 
   // warnings
   const warnings = [];
+  if (getControllerNotImported(controller)) {
+    warnings.push(
+      'You must have your controller account imported to start nominating'
+    );
+  }
   if (!nominations.length) {
     warnings.push('You have no nominations set.');
   }
@@ -110,7 +115,7 @@ export const Nominate = () => {
               type="button"
               className="submit"
               onClick={() => submitTx()}
-              disabled={!valid || submitting}
+              disabled={!valid || submitting || warnings.length}
             >
               <FontAwesomeIcon
                 transform="grow-2"

--- a/src/modals/StopNominating/index.tsx
+++ b/src/modals/StopNominating/index.tsx
@@ -11,12 +11,14 @@ import { Wrapper } from './Wrapper';
 import { useBalances } from '../../contexts/Balances';
 import { useApi } from '../../contexts/Api';
 import { useModal } from '../../contexts/Modal';
+import { useStaking } from '../../contexts/Staking';
 import { useSubmitExtrinsic } from '../../library/Hooks/useSubmitExtrinsic';
 import { useConnect } from '../../contexts/Connect';
 import { Warning } from '../../library/Form/Warning';
 
 export const StopNominating = () => {
   const { api }: any = useApi();
+  const { getControllerNotImported } = useStaking();
   const { activeAccount } = useConnect();
   const { getBondedAccount, getAccountNominations }: any = useBalances();
   const { setStatus: setModalStatus }: any = useModal();
@@ -65,6 +67,10 @@ export const StopNominating = () => {
         }}
       >
         {!nominations.length && <Warning text="You have no nominations set." />}
+        {getControllerNotImported(controller) && (
+          <Warning text="You must have your controller account imported to stop nominating." />
+        )}
+
         <h2>
           You Have {nominations.length} Nomination
           {nominations.length === 1 ? '' : 's'}
@@ -86,7 +92,9 @@ export const StopNominating = () => {
               type="button"
               className="submit"
               onClick={() => submitTx()}
-              disabled={!valid || submitting}
+              disabled={
+                !valid || submitting || getControllerNotImported(controller)
+              }
             >
               <FontAwesomeIcon
                 transform="grow-2"

--- a/src/modals/UpdateBond/Forms.tsx
+++ b/src/modals/UpdateBond/Forms.tsx
@@ -35,8 +35,10 @@ export const Forms = (props: any) => {
   const nominations = getAccountNominations(activeAccount);
 
   // unbond amount to `minNominatorBond` threshold
-  const freeToUnbondToMinNominatorBond =
-    freeToUnbond - planckBnToUnit(minNominatorBond, units);
+  const freeToUnbondToMinNominatorBond = Math.max(
+    freeToUnbond - planckBnToUnit(minNominatorBond, units),
+    0
+  );
 
   // local bond value
   const [bond, setBond] = useState(freeToBond);

--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -44,8 +44,6 @@ export const UpdateController = () => {
     const controllerToSubmit = {
       Id: selected.address,
     };
-
-    // console.log(controllerToSubmit);
     _tx = api.tx.staking.setController(controllerToSubmit);
     return _tx;
   };

--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -16,6 +16,7 @@ import { useModal } from '../../contexts/Modal';
 import { useSubmitExtrinsic } from '../../library/Hooks/useSubmitExtrinsic';
 import { useConnect } from '../../contexts/Connect';
 import { PAYEE_STATUS } from '../../constants';
+import { Warning } from '../../library/Form/Warning';
 
 export const UpdatePayee = () => {
   const { api }: any = useApi();
@@ -23,7 +24,7 @@ export const UpdatePayee = () => {
   const { getBondedAccount }: any = useBalances();
   const { setStatus: setModalStatus }: any = useModal();
   const controller = getBondedAccount(activeAccount);
-  const { staking } = useStaking();
+  const { staking, getControllerNotImported } = useStaking();
   const { payee } = staking;
 
   const _selected: any = PAYEE_STATUS.find((item: any) => item.key === payee);
@@ -79,6 +80,9 @@ export const UpdatePayee = () => {
         }}
       >
         <div className="head">
+          {getControllerNotImported(controller) && (
+            <Warning text="You must have your controller account imported to update your reward destination" />
+          )}
           <h4>
             Currently Selected:
             {_selected?.name ?? 'None'}
@@ -103,7 +107,9 @@ export const UpdatePayee = () => {
               type="button"
               className="submit"
               onClick={() => submitTx()}
-              disabled={!valid || submitting}
+              disabled={
+                !valid || submitting || getControllerNotImported(controller)
+              }
             >
               <FontAwesomeIcon
                 transform="grow-2"

--- a/src/pages/Stake/Active/ControllerNotImported.tsx
+++ b/src/pages/Stake/Active/ControllerNotImported.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { SectionWrapper } from '../../../library/Graphs/Wrappers';
+import { Button } from '../../../library/Button';
+import { useBalances } from '../../../contexts/Balances';
+import { useConnect } from '../../../contexts/Connect';
+import { useStaking } from '../../../contexts/Staking';
+import { PageRowWrapper } from '../../../Wrappers';
+import { useModal } from '../../../contexts/Modal';
+
+export const ControllerNotImported = () => {
+  const { openModalWith } = useModal();
+  const { isControllerImported } = useStaking();
+  const { activeAccount } = useConnect();
+  const { getBondedAccount }: any = useBalances();
+  const controller = getBondedAccount(activeAccount);
+  const controllerImported = isControllerImported(controller);
+
+  return (
+    <>
+      {!controllerImported && (
+        <PageRowWrapper noVerticalSpacer>
+          <SectionWrapper
+            style={{ border: '2px solid rgba(242, 185, 27,0.25)' }}
+          >
+            <div className="head">
+              <h4>
+                You have not imported your Controller account. If you have lost
+                access to your Controller account, set a new one now.
+              </h4>
+            </div>
+            <Button
+              small
+              primary
+              inline
+              title="Set New Controller"
+              onClick={() => openModalWith('UpdateController', {}, 'small')}
+            />
+          </SectionWrapper>
+        </PageRowWrapper>
+      )}
+    </>
+  );
+};

--- a/src/pages/Stake/Active/ControllerNotImported.tsx
+++ b/src/pages/Stake/Active/ControllerNotImported.tsx
@@ -11,15 +11,14 @@ import { useModal } from '../../../contexts/Modal';
 
 export const ControllerNotImported = () => {
   const { openModalWith } = useModal();
-  const { isControllerImported } = useStaking();
+  const { getControllerNotImported } = useStaking();
   const { activeAccount } = useConnect();
   const { getBondedAccount }: any = useBalances();
   const controller = getBondedAccount(activeAccount);
-  const controllerImported = isControllerImported(controller);
 
   return (
     <>
-      {!controllerImported && (
+      {getControllerNotImported(controller) && (
         <PageRowWrapper noVerticalSpacer>
           <SectionWrapper
             style={{ border: '2px solid rgba(242, 185, 27,0.25)' }}

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -26,13 +26,13 @@ import { PAYEE_STATUS } from '../../../constants';
 import ActiveNominationsStatBox from './Stats/ActiveNominations';
 import MinimumActiveBondStatBox from './Stats/MinimumActiveBond';
 import ActiveEraStatBox from './Stats/ActiveEra';
+import { ControllerNotImported } from './ControllerNotImported';
 
 export const Active = (props: any) => {
   const { openModalWith } = useModal();
   const { activeAccount } = useConnect();
   const { getNominationsStatus, staking, targets, setTargets } = useStaking();
   const { getAccountNominations }: any = useBalances();
-
   const { payee } = staking;
   const nominations = getAccountNominations(activeAccount);
   const payeeStatus: any = PAYEE_STATUS.find((item: any) => item.key === payee);
@@ -71,6 +71,7 @@ export const Active = (props: any) => {
         <MinimumActiveBondStatBox />
         <ActiveEraStatBox />
       </StatBoxList>
+      <ControllerNotImported />
       <PageRowWrapper noVerticalSpacer>
         <MainWrapper paddingLeft>
           <SectionWrapper style={{ height: 260 }}>

--- a/src/pages/Stake/Setup/SetController.tsx
+++ b/src/pages/Stake/Setup/SetController.tsx
@@ -3,13 +3,10 @@
 
 import { useState, useEffect } from 'react';
 import { SectionWrapper } from '../../../library/Graphs/Wrappers';
-import { Button, ButtonRow } from '../../../library/Button';
 import { useApi } from '../../../contexts/Api';
 import { useBalances } from '../../../contexts/Balances';
 import { useConnect } from '../../../contexts/Connect';
-import { useMessages } from '../../../contexts/Messages';
 import { useUi } from '../../../contexts/UI';
-import { GLOBAL_MESSGE_KEYS } from '../../../constants';
 import { AccountSelect } from '../../../library/Form/AccountSelect';
 import { Header } from './Header';
 import { Footer } from './Footer';
@@ -25,20 +22,14 @@ export const SetController = (props: any) => {
   const { activeAccount, accounts, getAccount } = useConnect();
   const { getBondedAccount, getAccountBalance, minReserve, isController }: any =
     useBalances();
-  const { getMessage }: any = useMessages();
   const { getSetupProgress, setActiveAccountSetup } = useUi();
-
   const controller = getBondedAccount(activeAccount);
   const setup = getSetupProgress(activeAccount);
-
   const initialValue =
     setup.controller !== null ? setup.controller : controller;
-
   const initialAccount = getAccount(initialValue);
 
-  const [controllerNotImported, setControllerNotImported] = useState(
-    getMessage(GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED)
-  );
+  // store the currently selected controller account
   const [selected, setSelected] = useState(initialAccount);
 
   // update selected value on account switch
@@ -47,12 +38,6 @@ export const SetController = (props: any) => {
     const _initial = getAccount(_selected);
     setSelected(_initial);
   }, [activeAccount]);
-
-  useEffect(() => {
-    setControllerNotImported(
-      getMessage(GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED)
-    );
-  }, [getMessage(GLOBAL_MESSGE_KEYS.CONTROLLER_NOT_IMPORTED)]);
 
   const handleOnChange = ({ selectedItem }: any) => {
     setSelected(selectedItem);
@@ -67,7 +52,7 @@ export const SetController = (props: any) => {
     return !isController(acc.address);
   });
 
-  // inject balances and wheteher account can be an active item
+  // inject balances and whether account can be an active item
   items = items.filter((acc: any) => acc.address !== activeAccount);
   items = items.map((acc: any) => {
     const balance = getAccountBalance(acc.address);
@@ -89,47 +74,25 @@ export const SetController = (props: any) => {
 
   return (
     <>
-      {/* TODO: integrate this into the below section.
-      warning: controller account not present. unable to stake */}
-      {controllerNotImported !== null && (
-        <SectionWrapper
-          transparent
-          style={{ border: '2px solid rgba(242, 185, 27,0.25)' }}
-        >
-          <h3>Import Your Controller Account</h3>
-          <p>
-            You have not imported your Controller account. If you have lost
-            access to your Controller account, set a new Controller now.
-          </p>
-
-          <ButtonRow style={{ width: '100%', padding: 0, marginTop: '1rem' }}>
-            <Button inline title="Set New Controller" />
-          </ButtonRow>
-        </SectionWrapper>
-      )}
-
-      {/* controller management */}
-      {controllerNotImported === null && (
-        <SectionWrapper transparent>
-          <Header
-            thisSection={section}
-            title="Set Controller Account"
-            assistantPage="stake"
-            assistantKey="Stash and Controller Accounts"
-            complete={setup.controller !== null}
+      <SectionWrapper transparent>
+        <Header
+          thisSection={section}
+          title="Set Controller Account"
+          assistantPage="stake"
+          assistantKey="Stash and Controller Accounts"
+          complete={setup.controller !== null}
+        />
+        <MotionContainer thisSection={section} activeSection={setup.section}>
+          <Spacer />
+          <AccountSelect
+            items={items}
+            onChange={handleOnChange}
+            placeholder="Search Account"
+            value={selected}
           />
-          <MotionContainer thisSection={section} activeSection={setup.section}>
-            <Spacer />
-            <AccountSelect
-              items={items}
-              onChange={handleOnChange}
-              placeholder="Search Account"
-              value={selected}
-            />
-            <Footer complete={setup.controller !== null} />
-          </MotionContainer>
-        </SectionWrapper>
-      )}
+          <Footer complete={setup.controller !== null} />
+        </MotionContainer>
+      </SectionWrapper>
     </>
   );
 };


### PR DESCRIPTION
This PR revamps the support for when a controller account is set but not imported.

We have a warning symbol in the side menu, along with a new module on the Stake page to notify the user of the issue:

<img width="1198" alt="Screenshot 2022-05-19 at 15 14 14" src="https://user-images.githubusercontent.com/13929023/169315463-ae983b2b-162d-4415-85b7-2fcd13f8d6b2.png">

The warning icon in the minimised side menu is a yellow circle:

<img width="1203" alt="Screenshot 2022-05-19 at 15 14 07" src="https://user-images.githubusercontent.com/13929023/169315540-a4358d2b-dc9a-41b3-b0d0-ae1255adb30e.png">

Extrinsics that require the controller account have been disabled and accompanied with a warning in the event it is missing:

<img width="676" alt="Screenshot 2022-05-19 at 15 14 33" src="https://user-images.githubusercontent.com/13929023/169315657-0a547b36-cb27-41df-92a1-18a3e09c8f2a.png">

Extrinsics affected:

- update payee
- unbond some
- unbond all
- start nominating (from active stage)
- stop nominating
