### PR TITLE
Remove Stake Preloading: Active Page By Default

### DIFF
--- a/src/Wrappers.tsx
+++ b/src/Wrappers.tsx
@@ -64,8 +64,8 @@ export const EntryWrapper = styled.div`
     }
   }
   .page-padding {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
 
     @media (min-width: ${SHOW_SIDE_BAR_WIDTH_THRESHOLD + 1}px) {
       padding-left: 1.5rem;

--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -13,6 +13,7 @@ export const stakingMetrics = {
   maxValidatorsCount: new BN(0),
   minNominatorBond: new BN(0),
   historyDepth: new BN(0),
+  payee: null,
   unsub: null,
 };
 
@@ -27,3 +28,5 @@ export const eraStakers = {
 export const targets = {
   nominations: [],
 };
+
+export const nominationStatus = {};

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -165,6 +165,9 @@ export const StakingProvider = ({ children }: any) => {
    * Possible statuses: waiting, inactive, active.
    */
   const getNominationsStatus = () => {
+    if (inSetup()) {
+      return defaults.nominationStatus;
+    }
     const nominations = getAccountNominations(activeAccount);
     const statuses: any = {};
 

--- a/src/contexts/UI.tsx
+++ b/src/contexts/UI.tsx
@@ -26,6 +26,7 @@ export interface UIContextState {
   setActiveAccountSetup: (p: any) => any;
   setActiveAccountSetupSection: (s: number) => void;
   getServices: () => void;
+  setOnSetup: (v: any) => void;
   sideMenuOpen: number;
   userSideMenuMinimised: number;
   sideMenuMinimised: number;
@@ -33,6 +34,7 @@ export interface UIContextState {
   services: any;
   validatorFilters: any;
   validatorOrder: string;
+  onSetup: number;
 }
 
 export const UIContext: React.Context<UIContextState> = React.createContext({
@@ -49,6 +51,7 @@ export const UIContext: React.Context<UIContextState> = React.createContext({
   setActiveAccountSetup: (p: any) => {},
   setActiveAccountSetupSection: (s: number) => {},
   getServices: () => {},
+  setOnSetup: (v: any) => {},
   sideMenuOpen: 0,
   userSideMenuMinimised: 0,
   sideMenuMinimised: 0,
@@ -56,6 +59,7 @@ export const UIContext: React.Context<UIContextState> = React.createContext({
   services: SERVICES,
   validatorFilters: [],
   validatorOrder: 'default',
+  onSetup: 0,
 });
 
 export const useUi = () => React.useContext(UIContext);
@@ -63,7 +67,7 @@ export const useUi = () => React.useContext(UIContext);
 export const UIProvider = (props: any) => {
   const { isReady, consts, network }: any = useApi();
   const { accounts: connectAccounts, activeAccount } = useConnect();
-  const { staking, eraStakers }: any = useStaking();
+  const { staking, eraStakers, inSetup }: any = useStaking();
   const { meta, session } = useValidators();
   const { maxNominatorRewardedPerValidator } = consts;
   const { metrics }: any = useNetworkMetrics();
@@ -101,6 +105,9 @@ export const UIProvider = (props: any) => {
   // global list format
   const [listFormat, _setListFormat] = useState('col');
 
+  // is the user actively on the setup page
+  const [onSetup, setOnSetup] = useState(0);
+
   // services
   const [services, _setServices] = useState(servicesLocal);
   const servicesRef = useRef(services);
@@ -126,6 +133,13 @@ export const UIProvider = (props: any) => {
       setSideMenuMinimised(userSideMenuMinimisedRef.current);
     }
   };
+
+  // go to active page once staking setup completes / network change
+  useEffect(() => {
+    if (!inSetup()) {
+      setOnSetup(0);
+    }
+  }, [inSetup(), network]);
 
   // resize event listener
   useEffect(() => {
@@ -480,6 +494,7 @@ export const UIProvider = (props: any) => {
         setActiveAccountSetup,
         setActiveAccountSetupSection,
         getServices,
+        setOnSetup,
         sideMenuOpen,
         userSideMenuMinimised: userSideMenuMinimisedRef.current,
         sideMenuMinimised,
@@ -487,6 +502,7 @@ export const UIProvider = (props: any) => {
         validatorFilters,
         validatorOrder,
         services: servicesRef.current,
+        onSetup,
       }}
     >
       {props.children}

--- a/src/library/Button/index.tsx
+++ b/src/library/Button/index.tsx
@@ -7,43 +7,44 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { textSecondary, buttonSecondaryBackground } from '../../theme';
 
 export const ButtonRow = styled.div`
-  flex: 1;
   display: flex;
-  flex-flow: row wrap;
-  justify-content: flex-end;
-  align-items: flex-end;
-  align-content: flex-end;
-
-  > button {
-    margin-top: 0.5rem;
-  }
+  align-items: center;
+  justify-content: flex-start;
 `;
 
-export const Wrapper = styled(motion.button)<any>`
-  background: ${(props) =>
-    props.type === 'default'
-      ? buttonSecondaryBackground
-      : 'rgba(211, 48, 121, 0.9)'};
-  color: ${(props) => (props.type === 'default' ? textSecondary : 'white')};
+export const Wrapper = styled(motion.div)<any>`
+  display: inline-block;
   margin: ${(props) => props.margin};
-  flex-grow: 1;
-  padding: ${(props) => props.padding};
-  border-radius: 0.75rem;
-  font-size: ${(props) => (props.fontSize ? props.fontSize : '0.95rem')};
-  font-variation-settings: 'wght' 560;
 
-  .space {
-    margin-right: 0.5rem;
-  }
+  > button {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    background: ${(props) =>
+      props.type === 'default'
+        ? buttonSecondaryBackground
+        : 'rgba(211, 48, 121, 0.9)'};
+    color: ${(props) => (props.type === 'default' ? textSecondary : 'white')};
 
-  &:disabled {
-    cursor: default;
-    opacity: 0.5;
+    padding: ${(props) => props.padding};
+    border-radius: 0.75rem;
+    font-size: ${(props) => props.fontSize};
+    font-variation-settings: 'wght' 560;
+    transition: opacity 0.2s;
+
+    .space {
+      margin-right: 0.6rem;
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.25;
+    }
   }
 `;
 
 export const Button = (props: any) => {
-  let { primary, inline, small, disabled, icon, title } = props;
+  let { primary, inline, small, disabled, icon, transform, title } = props;
   const { onClick } = props;
   title = title ?? false;
   primary = primary ?? false;
@@ -51,25 +52,27 @@ export const Button = (props: any) => {
   small = small ?? false;
   disabled = disabled ?? false;
   icon = icon ?? false;
+  transform = transform ?? 'shrink-1';
 
   return (
     <Wrapper
-      disabled={disabled}
       whileHover={{ scale: !disabled ? 1.02 : 1 }}
       whileTap={{ scale: !disabled ? 0.98 : 1 }}
       type={primary === true ? 'invert' : 'default'}
       margin={inline ? '0' : '0 0.5rem'}
-      padding={small ? '0.3rem 0.75rem' : '0.5rem 1.2rem'}
-      onClick={() => onClick()}
+      padding={small ? '0.3rem 0.75rem' : '0.45rem 1.2rem'}
+      fontSize={small ? '0.95rem' : '1.05rem'}
     >
-      {icon && (
-        <FontAwesomeIcon
-          icon={icon}
-          className={title ? 'space' : undefined}
-          transform="shrink-1"
-        />
-      )}
-      {title && title}
+      <button type="button" disabled={disabled} onClick={() => onClick()}>
+        {icon && (
+          <FontAwesomeIcon
+            icon={icon}
+            className={title ? 'space' : undefined}
+            transform={transform}
+          />
+        )}
+        {title && title}
+      </button>
     </Wrapper>
   );
 };

--- a/src/library/Headers/index.tsx
+++ b/src/library/Headers/index.tsx
@@ -24,7 +24,7 @@ export const Headers = () => {
   const { pending } = useExtrinsics();
   const { isSyncing }: any = useUi();
 
-  let syncing = isSyncing();
+  let syncing = isSyncing;
 
   // keep syncing if on validators page and still fetching
   if (pageFromUri(pathname) === 'validators') {

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -79,7 +79,7 @@ export const SideMenu = () => {
         // on stake menu item, add warning for controller not imported
         if (uri === `${URI_PREFIX}/stake`) {
           _pageConfigWithMessages[i].action =
-            !isSyncing() && controllerNotImported;
+            !isSyncing && controllerNotImported;
         }
       }
       setPageConfig({
@@ -87,7 +87,7 @@ export const SideMenu = () => {
         pages: _pageConfigWithMessages,
       });
     }
-  }, [network, activeAccount, accounts, controllerNotImported, isSyncing()]);
+  }, [network, activeAccount, accounts, controllerNotImported, isSyncing]);
 
   const ref = useRef(null);
   useOutsideAlerter(ref, () => {

--- a/src/library/StatusLabel/index.tsx
+++ b/src/library/StatusLabel/index.tsx
@@ -15,7 +15,7 @@ export const StatusLabel = (props: any) => {
   const { inSetup } = useStaking();
 
   if (status === 'sync_or_setup') {
-    if (isSyncing() || !inSetup()) {
+    if (isSyncing || !inSetup()) {
       return <></>;
     }
   }

--- a/src/pages/Favourites/index.tsx
+++ b/src/pages/Favourites/index.tsx
@@ -23,7 +23,7 @@ export const Favourites = (props: PageProps) => {
       <PageRowWrapper className="page-padding" noVerticalSpacer>
         <SectionWrapper>
           {favouritesList === null ? (
-            <h4>Fetching favourite validators...</h4>
+            <h3>Fetching favourite validators...</h3>
           ) : (
             <>
               {isReady && (

--- a/src/pages/Overview/Announcements/index.tsx
+++ b/src/pages/Overview/Announcements/index.tsx
@@ -109,7 +109,7 @@ export const Announcements = () => {
           animate="show"
           style={{ width: '100%' }}
         >
-          {isSyncing() ? (
+          {isSyncing ? (
             <AnnouncementLoader />
           ) : (
             announcements.map((item, index) => (

--- a/src/pages/Stake/Active/BondedGraph.tsx
+++ b/src/pages/Stake/Active/BondedGraph.tsx
@@ -13,12 +13,12 @@ export const BondedGraph = (props: any) => {
   const { mode } = useTheme();
   const { network }: any = useApi();
 
-  const { active, unlocking, total } = props;
-  let { remaining } = props;
+  const { active, unlocking, total, inactive } = props;
+  let { free } = props;
 
   let zeroBalance = false;
   if (total === 0 || total === undefined) {
-    remaining = -1;
+    free = -1;
     zeroBalance = true;
   }
 
@@ -49,6 +49,9 @@ export const BondedGraph = (props: any) => {
         bodyColor: defaultThemes.text.invert[mode],
         callbacks: {
           label: (context: any) => {
+            if (inactive) {
+              return 'Inactive';
+            }
             return `${context.label}: ${
               context.parsed === -1 ? 0 : context.parsed
             } ${network.unit}`;
@@ -64,7 +67,7 @@ export const BondedGraph = (props: any) => {
     datasets: [
       {
         label: network.unit,
-        data: [active, unlocking, remaining],
+        data: [active, unlocking, free],
         backgroundColor: [
           defaultThemes.graphs.colors[0][mode],
           defaultThemes.graphs.colors[1][mode],

--- a/src/pages/Stake/Active/ControllerNotImported.tsx
+++ b/src/pages/Stake/Active/ControllerNotImported.tsx
@@ -20,7 +20,7 @@ export const ControllerNotImported = () => {
 
   return (
     <>
-      {getControllerNotImported(controller) && !isSyncing() && (
+      {getControllerNotImported(controller) && !isSyncing && (
         <PageRowWrapper className="page-padding" noVerticalSpacer>
           <SectionWrapper
             style={{ border: '2px solid rgba(242, 185, 27,0.25)' }}

--- a/src/pages/Stake/Active/ControllerNotImported.tsx
+++ b/src/pages/Stake/Active/ControllerNotImported.tsx
@@ -8,9 +8,11 @@ import { useConnect } from '../../../contexts/Connect';
 import { useStaking } from '../../../contexts/Staking';
 import { PageRowWrapper } from '../../../Wrappers';
 import { useModal } from '../../../contexts/Modal';
+import { useUi } from '../../../contexts/UI';
 
 export const ControllerNotImported = () => {
   const { openModalWith } = useModal();
+  const { isSyncing } = useUi();
   const { getControllerNotImported } = useStaking();
   const { activeAccount } = useConnect();
   const { getBondedAccount }: any = useBalances();
@@ -18,7 +20,7 @@ export const ControllerNotImported = () => {
 
   return (
     <>
-      {getControllerNotImported(controller) && (
+      {getControllerNotImported(controller) && !isSyncing() && (
         <PageRowWrapper className="page-padding" noVerticalSpacer>
           <SectionWrapper
             style={{ border: '2px solid rgba(242, 185, 27,0.25)' }}

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -45,14 +45,14 @@ export const ManageBond = () => {
             primary
             inline
             title="+"
-            disabled={inSetup() || isSyncing()}
+            disabled={inSetup() || isSyncing}
             onClick={() => openModalWith('UpdateBond', { fn: 'add' }, 'small')}
           />
           <Button
             small
             primary
             title="-"
-            disabled={inSetup() || isSyncing()}
+            disabled={inSetup() || isSyncing}
             onClick={() =>
               openModalWith('UpdateBond', { fn: 'remove' }, 'small')
             }
@@ -63,7 +63,7 @@ export const ManageBond = () => {
             primary
             icon={faLockOpen}
             title={String(totalUnlockChuncks ?? 0)}
-            disabled={inSetup() || isSyncing()}
+            disabled={inSetup() || isSyncing}
             onClick={() => openModalWith('UnlockChunks', {}, 'small')}
           />
         </ButtonRow>

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -7,10 +7,12 @@ import BondedGraph from './BondedGraph';
 import { useApi } from '../../../contexts/Api';
 import { useConnect } from '../../../contexts/Connect';
 import { useBalances } from '../../../contexts/Balances';
-import { Button } from '../../../library/Button';
+import { useStaking } from '../../../contexts/Staking';
+import { Button, ButtonRow } from '../../../library/Button';
 import { GraphWrapper } from '../../../library/Graphs/Wrappers';
 import { OpenAssistantIcon } from '../../../library/OpenAssistantIcon';
 import { useModal } from '../../../contexts/Modal';
+import { useUi } from '../../../contexts/UI';
 
 export const ManageBond = () => {
   const { network }: any = useApi();
@@ -19,6 +21,8 @@ export const ManageBond = () => {
   const { activeAccount } = useConnect();
   const { getAccountLedger, getBondedAccount, getBondOptions }: any =
     useBalances();
+  const { inSetup } = useStaking();
+  const { isSyncing } = useUi();
   const controller = getBondedAccount(activeAccount);
   const ledger = getAccountLedger(controller);
   const { active, total } = ledger;
@@ -35,18 +39,20 @@ export const ManageBond = () => {
         <h2>
           {planckBnToUnit(active, units)} {network.unit} &nbsp;
         </h2>
-        <div>
+        <ButtonRow>
           <Button
             small
             primary
             inline
             title="+"
+            disabled={inSetup() || isSyncing()}
             onClick={() => openModalWith('UpdateBond', { fn: 'add' }, 'small')}
           />
           <Button
             small
             primary
             title="-"
+            disabled={inSetup() || isSyncing()}
             onClick={() =>
               openModalWith('UpdateBond', { fn: 'remove' }, 'small')
             }
@@ -57,9 +63,10 @@ export const ManageBond = () => {
             primary
             icon={faLockOpen}
             title={String(totalUnlockChuncks)}
+            disabled={inSetup() || isSyncing()}
             onClick={() => openModalWith('UnlockChunks', {}, 'small')}
           />
-        </div>
+        </ButtonRow>
       </div>
 
       <GraphWrapper transparent noMargin>
@@ -70,8 +77,9 @@ export const ManageBond = () => {
           <BondedGraph
             active={planckBnToUnit(active, units)}
             unlocking={totalUnlocking}
-            remaining={freeToBond}
+            free={freeToBond}
             total={total.toNumber()}
+            inactive={inSetup()}
           />
         </div>
       </GraphWrapper>

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -62,7 +62,7 @@ export const ManageBond = () => {
             inline
             primary
             icon={faLockOpen}
-            title={String(totalUnlockChuncks)}
+            title={String(totalUnlockChuncks ?? 0)}
             disabled={inSetup() || isSyncing()}
             onClick={() => openModalWith('UnlockChunks', {}, 'small')}
           />

--- a/src/pages/Stake/Active/Nominations/index.tsx
+++ b/src/pages/Stake/Active/Nominations/index.tsx
@@ -40,7 +40,7 @@ export const Nominations = () => {
                 inline
                 primary
                 title="Stop"
-                disabled={inSetup() || isSyncing()}
+                disabled={inSetup() || isSyncing}
                 onClick={() => openModalWith('StopNominating', {}, 'small')}
               />
             </div>
@@ -49,7 +49,7 @@ export const Nominations = () => {
           )}
         </div>
       </div>
-      {nominated === null || isSyncing() ? (
+      {nominated === null || isSyncing ? (
         <div className="head">
           <h3>Syncing nominations...</h3>
         </div>

--- a/src/pages/Stake/Active/Nominations/index.tsx
+++ b/src/pages/Stake/Active/Nominations/index.tsx
@@ -48,7 +48,7 @@ export const Nominations = () => {
       </div>
       {nominated === null || isSyncing() ? (
         <div className="head">
-          <h3>Fetching your nominations...</h3>
+          <h3>Syncing nominations...</h3>
         </div>
       ) : (
         <>

--- a/src/pages/Stake/Active/Nominations/index.tsx
+++ b/src/pages/Stake/Active/Nominations/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '../../../../library/Button';
 import { useModal } from '../../../../contexts/Modal';
 import { useBalances } from '../../../../contexts/Balances';
 import { useConnect } from '../../../../contexts/Connect';
+import { useUi } from '../../../../contexts/UI';
 
 export const Nominations = () => {
   const { openModalWith } = useModal();
@@ -17,6 +18,7 @@ export const Nominations = () => {
   const { activeAccount } = useConnect();
   const { nominated }: any = useValidators();
   const { getAccountNominations }: any = useBalances();
+  const { isSyncing } = useUi();
   const nominations = getAccountNominations(activeAccount);
 
   const batchKey = 'stake_nominations';
@@ -44,9 +46,9 @@ export const Nominations = () => {
           )}
         </div>
       </div>
-      {nominated === null ? (
-        <div style={{ marginTop: '1rem' }}>
-          <p>Fetching your nominations...</p>
+      {nominated === null || isSyncing() ? (
+        <div className="head">
+          <h3>Fetching your nominations...</h3>
         </div>
       ) : (
         <>
@@ -64,7 +66,9 @@ export const Nominations = () => {
                   />
                 </div>
               ) : (
-                <h3>Not Nominating.</h3>
+                <div className="head">
+                  <h3>Not Nominating.</h3>
+                </div>
               )}
             </>
           )}

--- a/src/pages/Stake/Active/Nominations/index.tsx
+++ b/src/pages/Stake/Active/Nominations/index.tsx
@@ -11,12 +11,14 @@ import { useModal } from '../../../../contexts/Modal';
 import { useBalances } from '../../../../contexts/Balances';
 import { useConnect } from '../../../../contexts/Connect';
 import { useUi } from '../../../../contexts/UI';
+import { useStaking } from '../../../../contexts/Staking';
 
 export const Nominations = () => {
   const { openModalWith } = useModal();
   const { isReady }: any = useApi();
   const { activeAccount } = useConnect();
   const { nominated }: any = useValidators();
+  const { inSetup } = useStaking();
   const { getAccountNominations }: any = useBalances();
   const { isSyncing } = useUi();
   const nominations = getAccountNominations(activeAccount);
@@ -38,6 +40,7 @@ export const Nominations = () => {
                 inline
                 primary
                 title="Stop"
+                disabled={inSetup() || isSyncing()}
                 onClick={() => openModalWith('StopNominating', {}, 'small')}
               />
             </div>

--- a/src/pages/Stake/Active/Stats/ActiveNominations.tsx
+++ b/src/pages/Stake/Active/Stats/ActiveNominations.tsx
@@ -1,56 +1,29 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useEffect, useMemo } from 'react';
 import { useStaking } from '../../../../contexts/Staking';
-import { useBalances } from '../../../../contexts/Balances';
-import { useConnect } from '../../../../contexts/Connect';
 import { Pie } from '../../../../library/StatBoxList/Pie';
 
 export const ActiveNominationsStatBox = () => {
-  const { activeAccount } = useConnect();
   const { getNominationsStatus } = useStaking();
-  const { getAccountNominations }: any = useBalances();
-  const nominations = getAccountNominations(activeAccount);
+  const statuses = getNominationsStatus();
 
-  // handle nomination statuses
-  const [nominationsStatus, setNominationsStatus]: any = useState({
-    total: 0,
-    inactive: 0,
-    active: 0,
-  });
-
-  const nominationStatuses = useMemo(
-    () => getNominationsStatus(),
-    [nominations]
-  );
-
-  useEffect(() => {
-    const statuses = nominationStatuses;
-    const total = Object.values(statuses).length;
-    const _active: any = Object.values(statuses).filter(
-      (_v: any) => _v === 'active'
-    ).length;
-
-    setNominationsStatus({
-      total,
-      inactive: total - _active,
-      active: _active,
-    });
-  }, [nominationStatuses]);
+  const total = Object.values(statuses).length;
+  const active =
+    Object.values(statuses).filter((_v: any) => _v === 'active').length ?? 0;
 
   const params = {
     label: 'Active Nominations',
     stat: {
-      value: nominationsStatus.active,
-      total: nominationsStatus.total,
+      value: active,
+      total,
       unit: '',
     },
     graph: {
-      value1: nominationsStatus.active,
-      value2: nominationsStatus.active ? 0 : 1,
+      value1: active,
+      value2: active ? 0 : 1,
     },
-    tooltip: `${nominationsStatus.active ? 'Active' : 'Inactive'}`,
+    tooltip: `${active ? 'Active' : 'Inactive'}`,
     assistant: {
       page: 'stake',
       key: 'Nominations',

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -6,9 +6,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faRedoAlt,
   faWallet,
-  faCircle,
   faChevronCircleRight,
 } from '@fortawesome/free-solid-svg-icons';
+import { faCircle } from '@fortawesome/free-regular-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import {
   PageRowWrapper,
   Separator,
@@ -126,11 +127,13 @@ export const Active = ({ title }: any) => {
               <h2>
                 <FontAwesomeIcon
                   icon={
-                    payee === 'Staked'
+                    (payee === null
+                      ? faCircle
+                      : payee === 'Staked'
                       ? faRedoAlt
                       : payee === 'None'
                       ? faCircle
-                      : faWallet
+                      : faWallet) as IconProp
                   }
                   transform="shrink-4"
                 />

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -109,7 +109,7 @@ export const Active = ({ title }: any) => {
                     <Button
                       primary
                       inline
-                      title="Setup Staking"
+                      title="Start Staking"
                       icon={faChevronCircleRight}
                       transform="grow-1"
                       disabled={!isReady}

--- a/src/pages/Stake/Active/index.tsx
+++ b/src/pages/Stake/Active/index.tsx
@@ -96,7 +96,7 @@ export const Active = ({ title }: any) => {
                 <OpenAssistantIcon page="stake" title="Staking Status" />
               </h4>
               <h2>
-                {inSetup() || isSyncing()
+                {inSetup() || isSyncing
                   ? 'Not Staking'
                   : !nominations.length
                   ? 'Inactive: Not Nominating'
@@ -144,7 +144,7 @@ export const Active = ({ title }: any) => {
                     small
                     inline
                     primary
-                    disabled={inSetup() || isSyncing()}
+                    disabled={inSetup() || isSyncing}
                     title="Update"
                     onClick={() => openModalWith('UpdatePayee', {}, 'small')}
                   />
@@ -161,7 +161,7 @@ export const Active = ({ title }: any) => {
       </PageRowWrapper>
       <PageRowWrapper className="page-padding" noVerticalSpacer>
         <SectionWrapper>
-          {nominations.length || inSetup() || isSyncing() ? (
+          {nominations.length || inSetup() || isSyncing ? (
             <Nominations />
           ) : (
             <>
@@ -176,7 +176,7 @@ export const Active = ({ title }: any) => {
                     inline
                     primary
                     title="Nominate"
-                    disabled={targets.length === 0 || inSetup() || isSyncing()}
+                    disabled={targets.length === 0 || inSetup() || isSyncing}
                     onClick={() => openModalWith('Nominate', {}, 'small')}
                   />
                 </div>

--- a/src/pages/Stake/Setup/index.tsx
+++ b/src/pages/Stake/Setup/index.tsx
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Element } from 'react-scroll';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { PageRowWrapper } from '../../../Wrappers';
+import { GoBackWrapper } from '../Wrappers';
 import { SectionWrapper } from '../../../library/Graphs/Wrappers';
 import { PageTitle } from '../../../library/PageTitle';
 import { ChooseNominators } from './ChooseNominators';
@@ -10,11 +12,26 @@ import { SetController } from './SetController';
 import { Bond } from './Bond';
 import { Payee } from './Payee';
 import { Summary } from './Summary';
+import { Button } from '../../../library/Button';
+import { useUi } from '../../../contexts/UI';
 
-export const Setup = (props: any) => {
+export const Setup = ({ title }: any) => {
+  const { setOnSetup }: any = useUi();
+
   return (
     <>
-      <PageTitle title={`${props.title} Setup`} />
+      <PageTitle title={`${title} Setup`} />
+      <PageRowWrapper className="page-padding" noVerticalSpacer>
+        <GoBackWrapper>
+          <Button
+            inline
+            title="Go Back"
+            icon={faChevronLeft}
+            transform="shrink-3"
+            onClick={() => setOnSetup(0)}
+          />
+        </GoBackWrapper>
+      </PageRowWrapper>
       <PageRowWrapper className="page-padding" noVerticalSpacer>
         <SectionWrapper>
           <Element name="controller" style={{ position: 'absolute' }} />

--- a/src/pages/Stake/Wrappers.tsx
+++ b/src/pages/Stake/Wrappers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';
-import { textSecondary, primary } from '../../theme';
+import { textSecondary, primary, borderPrimary } from '../../theme';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -12,6 +12,13 @@ export const Wrapper = styled.div`
   h3 {
     margin-bottom: 0;
   }
+`;
+
+export const GoBackWrapper = styled.div`
+  border-bottom: 1px solid ${borderPrimary};
+  padding-bottom: 1rem;
+  width: 100%;
+  margin-top: 1rem;
 `;
 
 export const StakingAccount = styled.div<any>`

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -3,32 +3,21 @@
 
 import { PageProps } from '../types';
 import { Wrapper } from './Wrappers';
-import { useUi } from '../../contexts/UI';
-import { useStaking } from '../../contexts/Staking';
 import { Active } from './Active';
 import { Setup } from './Setup';
-import { Stake as Loader } from '../../library/Loaders/Stake';
-import { PageTitle } from '../../library/PageTitle';
+import { useUi } from '../../contexts/UI';
 
 export const Stake = (props: PageProps) => {
-  const { inSetup } = useStaking();
-  const { isSyncing } = useUi();
-
   const { page } = props;
   const { title } = page;
-
-  const _inSetup: boolean = inSetup();
-  const _isSyncing = isSyncing();
+  const { onSetup, setOnSetup } = useUi();
 
   return (
     <Wrapper>
-      {_isSyncing ? (
-        <>
-          <PageTitle title={`${title}`} />
-          <Loader />
-        </>
+      {onSetup ? (
+        <Setup title={title} setOnSetup={setOnSetup} />
       ) : (
-        <>{_inSetup ? <Setup title={title} /> : <Active title={title} />}</>
+        <Active title={title} setOnSetup={setOnSetup} />
       )}
     </Wrapper>
   );

--- a/src/pages/Validators/index.tsx
+++ b/src/pages/Validators/index.tsx
@@ -30,11 +30,15 @@ export const Validators = (props: PageProps) => {
       </StatBoxList>
       <PageRowWrapper className="page-padding" noVerticalSpacer>
         <SectionWrapper>
-          {isReady && (
+          {!isReady ? (
+            <div className="item">
+              <h3>Connecting...</h3>
+            </div>
+          ) : (
             <>
               {validators.length === 0 && (
                 <div className="item">
-                  <h4>Fetching validators...</h4>
+                  <h3>Fetching validators...</h3>
                 </div>
               )}
 


### PR DESCRIPTION
This PR tackles #32 by removing the Stake page preloader completely and defaulting to the Active page.

The bulk of the changes pertain to:
    - Ensuring the correct default values are displayed as the network syncs and realises the active account is not staking.
    - Disabling buttons when not staking / network is syncing.
    -  A "Start Staking" button that navigates the user to the Setup form. An `onSetup` context variable is introduced to keep the user on the Setup page if they want to navigate through the app while setting up their positions.

The page also gracefully falls back to default values and re-populates on network change. 

Not staking / default display:

<img width="1758" alt="Screenshot 2022-05-21 at 21 52 23" src="https://user-images.githubusercontent.com/13929023/169668604-539cafdc-e067-4501-8e44-2f9e9d9d6046.png">

Setup page with Back button:

<img width="1758" alt="Screenshot 2022-05-21 at 21 52 34" src="https://user-images.githubusercontent.com/13929023/169668607-1c3a83e8-dbe0-4da8-8a5d-432629593e18.png">

