### PR TITLE
Introduce Types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { NodeEndpoints } from './types';
 /*
  * SVGs
  */
@@ -19,7 +20,7 @@ export const WESTEND_ENDPOINT = 'wss://westend-rpc.polkadot.io';
 export const DEFAULT_NETWORK = 'polkadot';
 export const ACTIVE_NETWORK = 'polkadot';
 
-export const NODE_ENDPOINTS: any = {
+export const NODE_ENDPOINTS: NodeEndpoints = {
   polkadot: {
     name: 'Polkadot',
     endpoint: 'wss://rpc.polkadot.io',
@@ -55,8 +56,6 @@ export const NODE_ENDPOINTS: any = {
 };
 
 export const POLKADOT_URL = 'https://polkadot.network';
-
-export const CONNECTION_STATUS = ['disconnected', 'connecting', 'connected'];
 
 export const CONNECTION_SYMBOL_COLORS: any = {
   disconnected: 'red',

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -1,7 +1,9 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export const consts = {
+import { APIConstants } from '../../types/api';
+
+export const consts: APIConstants = {
   bondDuration: 0,
   maxNominations: 0,
   sessionsPerEra: 0,

--- a/src/library/NetworkBar/Status.tsx
+++ b/src/library/NetworkBar/Status.tsx
@@ -3,10 +3,10 @@
 
 import { motion } from 'framer-motion';
 import { useApi } from '../../contexts/Api';
-import { ConnectionStatus } from '../../types/api';
+import { ConnectionStatus, APIContextInterface } from '../../types/api';
 
 export const Status = () => {
-  const { status }: any = useApi();
+  const { status } = useApi() as APIContextInterface;
 
   return (
     <>

--- a/src/library/NetworkBar/Status.tsx
+++ b/src/library/NetworkBar/Status.tsx
@@ -3,24 +3,24 @@
 
 import { motion } from 'framer-motion';
 import { useApi } from '../../contexts/Api';
-import { CONNECTION_STATUS } from '../../constants';
+import { ConnectionStatus } from '../../types/api';
 
-export const ConnectionStatus = () => {
+export const Status = () => {
   const { status }: any = useApi();
 
   return (
     <>
-      {status === CONNECTION_STATUS[0] && (
+      {status === ConnectionStatus.Disconnected && (
         <motion.p animate={{ opacity: [0, 1] }} transition={{ duration: 0.3 }}>
           Disconnected
         </motion.p>
       )}
-      {status === CONNECTION_STATUS[1] && (
+      {status === ConnectionStatus.Connecting && (
         <motion.p animate={{ opacity: [0, 1] }} transition={{ duration: 0.3 }}>
           Connecting...
         </motion.p>
       )}
-      {status === CONNECTION_STATUS[2] && (
+      {status === ConnectionStatus.Connected && (
         <motion.p animate={{ opacity: [0, 1] }} transition={{ duration: 0.3 }}>
           Connected to Network
         </motion.p>
@@ -29,4 +29,4 @@ export const ConnectionStatus = () => {
   );
 };
 
-export default ConnectionStatus;
+export default Status;

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -12,14 +12,11 @@ import {
 import { useApi } from '../../contexts/Api';
 import { useUi } from '../../contexts/UI';
 import { BlockNumber } from './BlockNumber';
-import { ConnectionStatus } from './ConnectionStatus';
+import { Status } from './Status';
 import { usePrices } from '../Hooks/usePrices';
 import { useOutsideAlerter } from '../Hooks';
-import {
-  CONNECTION_SYMBOL_COLORS,
-  CONNECTION_STATUS,
-  NODE_ENDPOINTS,
-} from '../../constants';
+import { CONNECTION_SYMBOL_COLORS, NODE_ENDPOINTS } from '../../constants';
+import { ConnectionStatus } from '../../types/api';
 
 export const NetworkBar = () => {
   const { services } = useUi();
@@ -30,9 +27,9 @@ export const NetworkBar = () => {
 
   // handle connection symbol
   const symbolColor =
-    status === CONNECTION_STATUS[1]
+    status === ConnectionStatus.Connecting
       ? CONNECTION_SYMBOL_COLORS.connecting
-      : status === CONNECTION_STATUS[2]
+      : status === ConnectionStatus.Connected
       ? CONNECTION_SYMBOL_COLORS.connected
       : CONNECTION_SYMBOL_COLORS.disconnected;
 
@@ -76,7 +73,7 @@ export const NetworkBar = () => {
           <div className="hide-small">
             <p>{network.name}</p>
             <Separator />
-            <ConnectionStatus />
+            <Status />
           </div>
         </section>
         <section>
@@ -90,7 +87,7 @@ export const NetworkBar = () => {
             {open ? 'Collapse' : 'Network'}
           </button>
           <div className="stat" style={{ marginRight: 0 }}>
-            {status === CONNECTION_STATUS[2] && <BlockNumber />}
+            {status === ConnectionStatus.Connected && <BlockNumber />}
             <ConnectionSymbol color={symbolColor} />
           </div>
           {services.includes('binance_spot') && (

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,36 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ApiPromise } from '@polkadot/api';
+import { NodeEndpoint, NetworkName } from '.';
+
+export enum ConnectionStatus {
+  Connecting = 'connecting',
+  Connected = 'connected',
+  Disconnected = 'disconnected',
+}
+
+export interface NetworkState {
+  name: NetworkName;
+  meta: NodeEndpoint;
+}
+export interface APIConstants {
+  bondDuration: number;
+  maxNominations: number;
+  sessionsPerEra: number;
+  maxNominatorRewardedPerValidator: number;
+  maxElectingVoters: number;
+  expectedBlockTime: number;
+  poolsPalletId: number;
+}
+
+export interface APIContextInterface {
+  connect: (_network: NetworkName) => Promise<void>;
+  fetchDotPrice: () => void;
+  switchNetwork: (_network: NetworkName) => Promise<void>;
+  api: ApiPromise | null;
+  consts: APIConstants;
+  isReady: boolean;
+  status: ConnectionStatus;
+  network: NodeEndpoint;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { FunctionComponent, SVGProps } from 'react';
+
+export enum NetworkName {
+  Polkadot = 'polkadot',
+  Westend = 'westend',
+}
+
+export interface NodeEndpoint {
+  name: string;
+  endpoint: string;
+  subscanEndpoint: string;
+  unit: string;
+  units: number;
+  ss58: number;
+  icon: FunctionComponent<
+    SVGProps<SVGSVGElement> & { title?: string | undefined }
+  >;
+  api: {
+    unit: string;
+    priceTicker: string;
+  };
+  features: {
+    pools: boolean;
+  };
+}
+
+export interface NodeEndpoints {
+  [key: string]: NodeEndpoint;
+}


### PR DESCRIPTION
I've began introducing types to the project to cut down on the `any` usage. 

The convention i've opted for is to default contexts as null. E.g:

```
export const APIContext = React.createContext<APIContextInterface | null>(null);
```

I have used typecasting when consuming contexts as to prevent the compiler flagging `null` warnings. E.g:

```
const { status } = useApi() as APIContextInterface;
```

I wanted to run this past @hamidra before continuing. The other option is to have default functions in the context, but this introduces other issues like unused variables and inconsistencies in function logic between the context definition and injected provider functions. I think this approach is good enough at least for the initial type support we need to introduce.