### PR TITLE
Dropdown Enhancements + Overflow Fixes

### DIFF
--- a/src/library/Account/Wrapper.ts
+++ b/src/library/Account/Wrapper.ts
@@ -17,6 +17,7 @@ export const Wrapper = styled(motion.button)<any>`
   background: ${(props) => props.fill};
   font-size: ${(props) => props.fontSize};
   padding: 0 1rem;
+  max-width: 275px;
   flex: 1;
 
   .identicon {
@@ -24,29 +25,32 @@ export const Wrapper = styled(motion.button)<any>`
   }
 
   .account-label {
+    border-right: 1px solid ${borderSecondary};
     color: ${textSecondary};
     font-size: 0.8em;
     font-variation-settings: 'wght' 535;
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     align-items: center;
     justify-content: flex-end;
     margin-right: 0.5rem;
     padding-right: 0.5rem;
-    border-right: 1px solid ${borderSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    flex-shrink: 1;
   }
 
   .title {
+    color: ${textPrimary};
     margin-left: 0.25rem;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
     line-height: 2.2rem;
     flex: 1;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    color: ${textPrimary};
+    /* flex-grow: 1; */
+    /* flex-shrink: 1; */
 
     &.unassigned {
       color: ${textSecondary};

--- a/src/library/Form/AccountDropdown/Wrappers.ts
+++ b/src/library/Form/AccountDropdown/Wrappers.ts
@@ -2,31 +2,53 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';
-import { borderPrimary, textPrimary, backgroundDropdown } from '../../../theme';
+import {
+  borderPrimary,
+  textPrimary,
+  backgroundDropdown,
+  textSecondary,
+} from '../../../theme';
 
-export const StyledDownshift = styled.div<any>`
+export const StyledDownshift = styled.div`
   box-sizing: border-box;
   position: relative;
   width: 100%;
-  height: ${(props) => (props.height ? props.height : 'auto')};
+  height: auto;
   overflow: hidden;
 
-  /* title of dropdown */
   .label {
-    margin: 1rem 0;
-    display: block;
+    margin: 0.25rem 0 0.75rem 0;
+  }
+  .current {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+
+    > span {
+      margin: 0 0.75rem;
+      color: ${textSecondary};
+      opacity: 0.5;
+    }
   }
 
   /* input element of dropdown */
   .input-wrap {
-    border: 1px solid ${borderPrimary};
+    border-bottom: 1px solid ${borderPrimary};
     display: flex;
     flex-flow: row wrap;
     align-items: center;
     box-sizing: border-box;
-    border-radius: 1rem;
-    padding: 0.1rem 0.75rem;
-    margin: 0.25rem 0;
+    padding: 0.25rem 0 0 0;
+    margin: 0.25rem 0.7rem 0 0.7rem;
+    flex: 1;
+
+    &.selected {
+      border: 1px solid ${borderPrimary};
+      border-radius: 1rem;
+      margin: 0;
+      padding: 0.1rem 0.75rem;
+    }
   }
 
   /* input element of dropdown */
@@ -35,6 +57,9 @@ export const StyledDownshift = styled.div<any>`
     box-sizing: border-box;
     padding-left: 0.75rem;
     flex: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 `;
 
@@ -55,39 +80,43 @@ export const StyledController = styled.button<any>`
 `;
 
 /* dropdown box for vertical scroll */
-export const StyledDropdown = styled.div`
+export const StyledDropdown = styled.div<any>`
   background: ${backgroundDropdown};
   position: relative;
   box-sizing: border-box;
   margin: 0.5rem 0 0;
   border-bottom: none;
-  width: auto;
-  height: 14rem;
   border-radius: 0.75rem;
-  overflow: auto;
   z-index: 1;
 
-  .item {
+  .items {
     box-sizing: border-box;
-    padding: 0.5rem;
-    cursor: pointer;
-    margin: 0.25rem;
-    border-radius: 0.75rem;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    align-items: center;
+    width: auto;
+    height: ${(props) => (props.height ? props.height : 'auto')};
+    overflow: auto;
 
-    .icon {
-      margin-right: 0.5rem;
-    }
-    p {
-      font-size: 1rem;
-      color: ${textPrimary};
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      flex: 1;
+    .item {
+      box-sizing: border-box;
+      padding: 0.5rem;
+      cursor: pointer;
+      margin: 0.25rem;
+      border-radius: 0.75rem;
+      display: flex;
+      flex-flow: row wrap;
+      justify-content: flex-start;
+      align-items: center;
+
+      .icon {
+        margin-right: 0.5rem;
+      }
+      p {
+        font-size: 1rem;
+        color: ${textPrimary};
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        flex: 1;
+      }
     }
   }
 `;

--- a/src/library/Form/AccountDropdown/index.tsx
+++ b/src/library/Form/AccountDropdown/index.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faAnglesRight } from '@fortawesome/free-solid-svg-icons';
 import { useCombobox } from 'downshift';
 import { StyledDownshift, StyledDropdown, StyledController } from './Wrappers';
 import Identicon from '../../Identicon';
@@ -12,10 +12,11 @@ import { defaultThemes } from '../../../theme/default';
 import { convertRemToPixels } from '../../../Utils';
 
 export const AccountDropdown = (props: any) => {
-  const { items, onChange, label, placeholder, value }: any = props;
+  const { items, onChange, placeholder, value, current, height }: any = props;
 
   const itemToString = (item: any) => (item ? item.meta.name : '');
 
+  // store input items
   const [inputItems, setInputItems] = useState(items);
 
   const c: any = useCombobox({
@@ -35,39 +36,66 @@ export const AccountDropdown = (props: any) => {
   return (
     <StyledDownshift>
       <div>
-        {label && (
-          <div className="label" {...c.getLabelProps()}>
-            {label}
-          </div>
-        )}
-        <div style={{ position: 'relative' }}>
-          <div className="input-wrap" {...c.getComboboxProps()}>
-            {value !== null && (
-              <Identicon
-                value={value?.address ?? ''}
-                size={convertRemToPixels('2rem')}
+        <div className="label" {...c.getLabelProps()}>
+          Currently Selected:
+        </div>
+        <div>
+          <div className="current">
+            <div className="input-wrap selected">
+              {current !== null && (
+                <Identicon
+                  value={current?.address ?? ''}
+                  size={convertRemToPixels('2rem')}
+                />
+              )}
+              <input
+                className="input"
+                disabled
+                value={current?.meta?.name ?? ''}
               />
-            )}
-            <input {...c.getInputProps({ placeholder })} className="input" />
+            </div>
+            <span>
+              <FontAwesomeIcon icon={faAnglesRight} />
+            </span>
+            <div className="input-wrap selected">
+              {value !== null && (
+                <Identicon
+                  value={value?.address ?? ''}
+                  size={convertRemToPixels('2rem')}
+                />
+              )}
+              <input
+                className="input"
+                disabled
+                value={value?.meta?.name ?? '...'}
+              />
+            </div>
           </div>
 
-          {c.selectedItem && (
-            <StyledController
-              onClick={() => c.selectItem(null)}
-              aria-label="clear selection"
-            >
-              <FontAwesomeIcon transform="grow-2" icon={faTimes} />
-            </StyledController>
-          )}
-          <StyledDropdown {...c.getMenuProps()}>
-            {inputItems.map((item: any, index: number) => (
-              <DropdownItem
-                key={`controller_acc_${index}`}
-                c={c}
-                item={item}
-                index={index}
-              />
-            ))}
+          <StyledDropdown {...c.getMenuProps()} height={height}>
+            <div className="input-wrap" {...c.getComboboxProps()}>
+              <input {...c.getInputProps({ placeholder })} className="input" />
+            </div>
+
+            <div className="items">
+              {c.selectedItem && (
+                <StyledController
+                  onClick={() => c.selectItem(null)}
+                  aria-label="clear selection"
+                >
+                  <FontAwesomeIcon transform="grow-2" icon={faTimes} />
+                </StyledController>
+              )}
+
+              {inputItems.map((item: any, index: number) => (
+                <DropdownItem
+                  key={`controller_acc_${index}`}
+                  c={c}
+                  item={item}
+                  index={index}
+                />
+              ))}
+            </div>
           </StyledDropdown>
         </div>
       </div>
@@ -77,23 +105,23 @@ export const AccountDropdown = (props: any) => {
 
 const DropdownItem = ({ c, item, index }: any) => {
   const { mode } = useTheme();
-  const color =
-    c.selectedItem === item
-      ? defaultThemes.primary[mode]
-      : defaultThemes.text.primary[mode];
-  const border =
-    c.selectedItem === item
-      ? `2px solid ${defaultThemes.primary[mode]}`
-      : `2px solid ${defaultThemes.transparent[mode]}`;
+
+  let color;
+  let border;
+
+  if (c.selectedItem === item) {
+    color = defaultThemes.primary[mode];
+    border = `2px solid ${defaultThemes.primary[mode]}`;
+  } else {
+    color = defaultThemes.text.primary[mode];
+    border = `2px solid ${defaultThemes.transparent[mode]}`;
+  }
 
   return (
     <div
       className="item"
       {...c.getItemProps({ key: item.meta.name, index, item })}
-      style={{
-        color,
-        border,
-      }}
+      style={{ color, border }}
     >
       <div className="icon">
         <Identicon value={item.address} size={26} />

--- a/src/library/Form/AccountSelect/Wrappers.ts
+++ b/src/library/Form/AccountSelect/Wrappers.ts
@@ -53,6 +53,7 @@ export const StyledController = styled.button<any>`
 
 /* dropdown box for horizontal scroll */
 export const StyledSelect = styled.div`
+  border: 1px solid ${borderPrimary};
   position: relative;
   box-sizing: border-box;
   margin: 0.75rem 0 0;
@@ -65,7 +66,6 @@ export const StyledSelect = styled.div`
   display: flex;
   flex-flow: row wrap;
   flex: 1;
-  border: 1px solid ${borderPrimary};
   border-radius: 1rem;
 
   .wrapper {

--- a/src/library/Form/BondStatusBar/index.tsx
+++ b/src/library/Form/BondStatusBar/index.tsx
@@ -9,12 +9,14 @@ import { Wrapper } from './Wrapper';
 import { useApi } from '../../../contexts/Api';
 import { useStaking } from '../../../contexts/Staking';
 import { OpenAssistantIcon } from '../../OpenAssistantIcon';
+import { useUi } from '../../../contexts/UI';
 
 export const BondStatusBar = (props: any) => {
   const { value } = props;
 
   const { network }: any = useApi();
   const { staking, eraStakers } = useStaking();
+  const { isSyncing } = useUi();
   const { unit, units } = network;
   const { minNominatorBond } = staking;
   const { minActiveBond } = eraStakers;
@@ -29,13 +31,13 @@ export const BondStatusBar = (props: any) => {
   return (
     <Wrapper>
       <div className="bars">
-        <section className={gtMinNominatorBond ? 'invert' : ''}>
+        <section className={gtMinNominatorBond && !isSyncing ? 'invert' : ''}>
           <h4>&nbsp;</h4>
           <div className="bar">
             <h5>Inactive</h5>
           </div>
         </section>
-        <section className={gtMinNominatorBond ? 'invert' : ''}>
+        <section className={gtMinNominatorBond && !isSyncing ? 'invert' : ''}>
           <h4>
             <FontAwesomeIcon icon={faFlag as IconProp} transform="shrink-4" />
             &nbsp; Nominate
@@ -47,16 +49,14 @@ export const BondStatusBar = (props: any) => {
             </h5>
           </div>
         </section>
-        <section className={gtMinActiveBond ? 'invert' : ''}>
+        <section className={gtMinActiveBond && !isSyncing ? 'invert' : ''}>
           <h4>
             <FontAwesomeIcon icon={faFlag as IconProp} transform="shrink-4" />
             &nbsp; Active
             <OpenAssistantIcon page="stake" title="Active Bond Threshold" />
           </h4>
           <div className="bar">
-            <h5>
-              {minActiveBond} {unit}
-            </h5>
+            <h5>{isSyncing ? '...' : `${minActiveBond} ${unit}`}</h5>
           </div>
         </section>
       </div>

--- a/src/library/Form/Dropdown/index.tsx
+++ b/src/library/Form/Dropdown/index.tsx
@@ -3,12 +3,14 @@
 
 import { useState } from 'react';
 import { useCombobox } from 'downshift';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAnglesRight } from '@fortawesome/free-solid-svg-icons';
 import { StyledDownshift, StyledDropdown } from '../AccountDropdown/Wrappers';
 import { useTheme } from '../../../contexts/Themes';
 import { defaultThemes } from '../../../theme/default';
 
 export const Dropdown = (props: any) => {
-  const { items, onChange, label, placeholder, value }: any = props;
+  const { items, onChange, label, placeholder, value, current }: any = props;
 
   const [inputItems, setInputItems] = useState(items);
 
@@ -33,22 +35,34 @@ export const Dropdown = (props: any) => {
           </div>
         )}
         <div style={{ position: 'relative' }}>
-          <div className="input-wrap" {...c.getComboboxProps()}>
-            <input
-              {...c.getInputProps({ placeholder })}
-              className="input"
-              disabled
-            />
-          </div>
-          <StyledDropdown {...c.getMenuProps()}>
-            {inputItems.map((item: any, index: number) => (
-              <DropdownItem
-                key={`controller_acc_${index}`}
-                c={c}
-                item={item}
-                index={index}
+          <div className="current">
+            <div className="input-wrap selected">
+              <input className="input" disabled value={current?.name ?? ''} />
+            </div>
+            <span>
+              <FontAwesomeIcon icon={faAnglesRight} />
+            </span>
+            <div className="input-wrap selected" {...c.getComboboxProps()}>
+              <input
+                className="input"
+                disabled
+                {...c.getInputProps({ placeholder })}
+                value={value?.name ?? '...'}
               />
-            ))}
+            </div>
+          </div>
+
+          <StyledDropdown {...c.getMenuProps()}>
+            <div className="items">
+              {inputItems.map((item: any, index: number) => (
+                <DropdownItem
+                  key={`controller_acc_${index}`}
+                  c={c}
+                  item={item}
+                  index={index}
+                />
+              ))}
+            </div>
           </StyledDropdown>
         </div>
       </div>

--- a/src/library/Graphs/Wrappers.ts
+++ b/src/library/Graphs/Wrappers.ts
@@ -45,6 +45,14 @@ export const SectionWrapper = styled.div<any>`
     }
   }
 
+  h2 {
+    .amount {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+  }
+
   h4 {
     margin: 0.75rem 0;
     display: flex;
@@ -112,6 +120,15 @@ export const GraphWrapper = styled.div<any>`
   }
   .head {
     padding: 0.75rem 1.2rem 0.5rem 1.2rem;
+  }
+
+  h2 {
+    .amount {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      flex: 1;
+    }
   }
 
   h2,

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -46,7 +46,7 @@ export const Connected = () => {
               canClick={hasController()}
               onClick={() => {
                 if (hasController()) {
-                  openModalWith('UpdateController', {}, 'small');
+                  openModalWith('UpdateController', {}, 'large');
                 }
               }}
               filled

--- a/src/modals/ConnectAccounts/Accounts.tsx
+++ b/src/modals/ConnectAccounts/Accounts.tsx
@@ -48,7 +48,7 @@ export const Accounts = (props: any) => {
         >
           <div>
             <Identicon value={activeAccountMeta?.address} size={26} />
-            &nbsp; {activeAccountMeta?.meta?.name}
+            <span className="name">&nbsp; {activeAccountMeta?.meta?.name}</span>
           </div>
           <div className="danger">Disconnect </div>
         </button>
@@ -76,7 +76,7 @@ export const Accounts = (props: any) => {
           >
             <div>
               <Identicon value={address} size={26} />
-              &nbsp; {name}
+              <span className="name">&nbsp; {name}</span>
             </div>
             <div />
           </button>

--- a/src/modals/ConnectAccounts/Wrapper.ts
+++ b/src/modals/ConnectAccounts/Wrapper.ts
@@ -31,65 +31,72 @@ export const Wrapper = styled.div`
     margin-bottom: 1rem;
   }
 
-  button {
+  .item {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0.4rem 0;
+    padding: 0 0.75rem;
+    border-radius: 1rem;
+    font-size: 1rem;
+    background: ${buttonPrimaryBackground};
+    transition: background 0.15s;
+    color: ${textPrimary};
     display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
+    flex-flow: row nowrap;
     align-items: center;
-    font-size: 1.1rem;
+    min-height: 3.5rem;
 
     &:disabled {
       cursor: default;
       opacity: 0.5;
     }
+    &:hover {
+      background: ${backgroundToggle};
+    }
 
-    &.item {
+    > div {
       box-sizing: border-box;
-      width: 100%;
-      min-height: 3.5rem;
-      margin: 0.4rem 0;
-      padding: 0.75rem 0.25rem;
-      border-radius: 1rem;
-      font-size: 1rem;
-      background: ${buttonPrimaryBackground};
-      transition: background 0.15s;
-      color: ${textPrimary};
+      display: flex;
+      flex-flow: row nowrap;
+      justify-content: flex-start;
+      align-items: center;
+      padding: 0 1rem;
 
-      &:hover {
-        background: ${backgroundToggle};
+      &:first-child {
+        flex-shrink: 1;
+        overflow: hidden;
+
+        .name {
+          max-width: 100%;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+        }
       }
 
-      > div {
-        display: flex;
-        align-items: center;
-        justify-content: flex-start;
-        flex: 1;
-        padding: 0 1rem;
+      &:last-child {
+        flex-grow: 1;
+        justify-content: flex-end;
 
-        &:last-child {
-          justify-content: flex-end;
-
-          &.neutral {
-            color: ${textSecondary};
-            opacity: 0.75;
-          }
-          &.danger {
-            color: ${textDanger};
-          }
-
-          .icon {
-            margin-left: 1rem;
-          }
+        &.neutral {
+          color: ${textSecondary};
+          opacity: 0.75;
         }
+        &.danger {
+          color: ${textDanger};
+        }
+        .icon {
+          margin-left: 1rem;
+        }
+      }
 
-        /* svg theming */
-        svg {
-          .light {
-            fill: ${textInvert};
-          }
-          .dark {
-            fill: ${textSecondary};
-          }
+      /* svg theming */
+      svg {
+        .light {
+          fill: ${textInvert};
+        }
+        .dark {
+          fill: ${textSecondary};
         }
       }
     }

--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -23,14 +23,15 @@ export const UpdateController = () => {
   const controller = getBondedAccount(activeAccount);
   const account = getAccount(controller);
 
-  const [selected, setSelected] = useState(account);
+  // the selected value in the form
+  const [selected, setSelected]: any = useState(null);
 
-  isController(activeAccount);
-
+  // reset selected value on account change
   useEffect(() => {
-    setSelected(account);
+    setSelected(null);
   }, [activeAccount]);
 
+  // handle account selection change
   const handleOnChange = ({ selectedItem }: any) => {
     setSelected(selectedItem);
   };
@@ -42,12 +43,13 @@ export const UpdateController = () => {
       return _tx;
     }
     const controllerToSubmit = {
-      Id: selected.address,
+      Id: selected?.address ?? '',
     };
     _tx = api.tx.staking.setController(controllerToSubmit);
     return _tx;
   };
 
+  // handle extrinsic
   const { submitTx, estimatedFee, submitting }: any = useSubmitExtrinsic({
     tx: tx(),
     from: activeAccount,
@@ -58,6 +60,7 @@ export const UpdateController = () => {
     callbackInBlock: () => {},
   });
 
+  // remove active controller from selectable items
   const accountsList = accounts.filter((acc: any) => {
     return acc.address !== activeAccount && !isController(acc.address);
   });
@@ -76,7 +79,8 @@ export const UpdateController = () => {
             (acc: any) => acc.address !== activeAccount
           )}
           onChange={handleOnChange}
-          placeholder="Select Account"
+          placeholder="Search Account"
+          current={account}
           value={selected}
           height="17rem"
         />

--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -28,7 +28,12 @@ export const UpdatePayee = () => {
   const { payee } = staking;
 
   const _selected: any = PAYEE_STATUS.find((item: any) => item.key === payee);
-  const [selected, setSelected] = useState(_selected ?? null);
+  const [selected, setSelected]: any = useState(null);
+
+  // reset selected value on account change
+  useEffect(() => {
+    setSelected(null);
+  }, [activeAccount]);
 
   // ensure selected key is valid
   useEffect(() => {
@@ -66,6 +71,11 @@ export const UpdatePayee = () => {
     callbackInBlock: () => {},
   });
 
+  // remove active payee option from selectable items
+  const payeeItems = PAYEE_STATUS.filter((item: any) => {
+    return item.key !== _selected.key;
+  });
+
   return (
     <Wrapper>
       <HeadingWrapper>
@@ -83,16 +93,13 @@ export const UpdatePayee = () => {
           {getControllerNotImported(controller) && (
             <Warning text="You must have your controller account imported to update your reward destination" />
           )}
-          <h4>
-            Currently Selected:
-            {_selected?.name ?? 'None'}
-          </h4>
         </div>
         <Dropdown
-          items={PAYEE_STATUS}
+          items={payeeItems}
           onChange={handleOnChange}
           placeholder="Reward Destination"
           value={selected}
+          current={_selected}
           height="17rem"
         />
         <div>

--- a/src/pages/Overview/ActiveAccount.tsx
+++ b/src/pages/Overview/ActiveAccount.tsx
@@ -34,11 +34,13 @@ export const ActiveAccount = () => {
             <div className="icon">
               <Identicon value={accountData.address} size="1.6rem" />
             </div>
-            <h4>
-              {clipAddress(accountData.address)}
-              <div className="sep" />{' '}
-              <span className="addr">{accountData.meta.name}</span>
-            </h4>
+            <div className="title">
+              <h4>
+                {clipAddress(accountData.address)}
+                <div className="sep" />{' '}
+                <span className="addr">{accountData.meta.name}</span>
+              </h4>
+            </div>
             <div>
               <motion.div
                 className="copy"
@@ -52,7 +54,7 @@ export const ActiveAccount = () => {
                   <CopyToClipboard text={accountData.address}>
                     <FontAwesomeIcon
                       icon={faCopy as IconProp}
-                      transform="grow-1"
+                      transform="grow-3"
                     />
                   </CopyToClipboard>
                 </button>

--- a/src/pages/Overview/BalanceGraph.tsx
+++ b/src/pages/Overview/BalanceGraph.tsx
@@ -113,7 +113,7 @@ export const BalanceGraph = () => {
       <div className="head" style={{ paddingTop: '0.5rem' }}>
         <h4>Balance</h4>
         <h2>
-          {freeBase} {network.unit}
+          <span className="amount">{freeBase}</span>&nbsp;{network.unit}
           {services.includes('binance_spot') && (
             <>
               &nbsp;

--- a/src/pages/Overview/Wrappers.ts
+++ b/src/pages/Overview/Wrappers.ts
@@ -12,10 +12,11 @@ export const AccountWrapper = styled.div`
   flex-flow: column wrap;
 
   .account {
+    box-sizing: border-box;
     width: 100%;
     height: 27px;
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     align-items: center;
     padding: 0;
     margin-top: 1.25rem;
@@ -28,10 +29,15 @@ export const AccountWrapper = styled.div`
       position: relative;
       top: 0.1rem;
     }
+    .title {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0 0.5rem;
+      flex-grow: 1;
+      overflow: hidden;
+    }
     h4 {
-      margin: 0rem 0.5rem;
-      padding: 0;
-
+      margin: 0;
       > .sep {
         border-right: 1px solid ${borderPrimary};
         margin: 0 0.7rem;
@@ -39,6 +45,10 @@ export const AccountWrapper = styled.div`
         height: 1.25rem;
       }
       > .addr {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        flex: 1;
         opacity: 0.75;
       }
     }

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -68,9 +68,10 @@ export const Overview = () => {
             <div className="head">
               <h4>Recent Payouts</h4>
               <h2>
-                {lastPayout === null ? 0 : lastPayout.amount}
-                &nbsp;
-                {network.unit}
+                <span className="amount">
+                  {lastPayout === null ? 0 : lastPayout.amount}
+                </span>
+                &nbsp;{network.unit}
                 &nbsp;
                 <span className="fiat">
                   {lastPayout === null

--- a/src/pages/Stake/Active/ControllerNotImported.tsx
+++ b/src/pages/Stake/Active/ControllerNotImported.tsx
@@ -36,7 +36,7 @@ export const ControllerNotImported = () => {
               primary
               inline
               title="Set New Controller"
-              onClick={() => openModalWith('UpdateController', {}, 'small')}
+              onClick={() => openModalWith('UpdateController', {}, 'large')}
             />
           </SectionWrapper>
         </PageRowWrapper>

--- a/src/pages/Stake/Active/ManageBond.tsx
+++ b/src/pages/Stake/Active/ManageBond.tsx
@@ -37,7 +37,8 @@ export const ManageBond = () => {
           <OpenAssistantIcon page="stake" title="Bonding" />
         </h4>
         <h2>
-          {planckBnToUnit(active, units)} {network.unit} &nbsp;
+          <span className="amount">{planckBnToUnit(active, units)}</span>&nbsp;
+          {network.unit} &nbsp;
         </h2>
         <ButtonRow>
           <Button


### PR DESCRIPTION
Polishing up the interface in various ways ensuring there are no edge case UX bugs.

The  dropdown for selecting controller accounts and payee options have been updated, showing the currently active item alongside the new item. The search box has been separated from the currently-selected item:

<img width="1146" alt="Screenshot 2022-05-23 at 10 44 03" src="https://user-images.githubusercontent.com/13929023/169801377-932db8d9-bfda-4a45-b27c-122950b01507.png">

Account boxes have a max width and handle account name overflow:

<img width="622" alt="Screenshot 2022-05-23 at 10 59 55" src="https://user-images.githubusercontent.com/13929023/169801429-a2ebca89-d4da-4f9e-ae30-c06a56380984.png">

Active account on Overview has an overflow fix:

<img width="598" alt="Screenshot 2022-05-23 at 11 24 48" src="https://user-images.githubusercontent.com/13929023/169801475-00583430-6ad3-4145-9399-ffceada94b82.png">

In addition to the account selection boxes:

<img width="657" alt="Screenshot 2022-05-23 at 11 37 20" src="https://user-images.githubusercontent.com/13929023/169801564-b59c0bae-0f66-45de-a040-6c5497875eba.png">

And long balance values alongside graphs are also allowed to be overflowed:

<img width="966" alt="Screenshot 2022-05-23 at 11 33 21" src="https://user-images.githubusercontent.com/13929023/169801661-28ebd549-2f09-4aa2-b5b0-7eb196b1e3e5.png">