### PR TITLE
Nomination Pools metadata subscription

### DIFF
--- a/src/contexts/Pools/index.tsx
+++ b/src/contexts/Pools/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { bnToU8a, stringToU8a, u8aConcat } from '@polkadot/util';
 import * as defaults from './defaults';
 import { useApi } from '../Api';
@@ -15,16 +15,20 @@ const MOD_PREFIX = stringToU8a('modl');
 const U32_OPTS = { bitLength: 32, isLe: true };
 
 export interface PoolsContextState {
+  fetchPoolsMetaBatch: (k: string, v: [], r?: boolean) => void;
   membership: any;
   enabled: number;
+  meta: any;
   stats: any;
   bondedPools: any;
 }
 
 export const PoolsContext: React.Context<PoolsContextState> =
   React.createContext({
+    fetchPoolsMetaBatch: (k: string, v: [], r?: boolean) => {},
     membership: undefined,
     enabled: 0,
+    meta: [],
     stats: defaults.stats,
     bondedPools: [],
   });
@@ -35,7 +39,6 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
   const { api, network, isReady, consts } = useApi() as APIContextInterface;
   const { poolsPalletId } = consts;
   const { features } = network;
-
   const { activeAccount } = useConnect();
 
   // whether pools are enabled
@@ -47,10 +50,27 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
     unsub: null,
   });
 
+  // stores pool membership
   const [poolMembership, setPoolMembership]: any = useState({
     membership: undefined,
     unsub: null,
   });
+
+  // stores the meta data batches for pool lists
+  const [poolMetaBatches, _setPoolMetaBatch]: any = useState({});
+  const poolMetaBatchesRef = useRef(poolMetaBatches);
+  const setPoolMetaBatch = (val: any) => {
+    poolMetaBatchesRef.current = val;
+    _setPoolMetaBatch(val);
+  };
+
+  // stores the meta batch subscriptions for pool lists
+  const [poolSubs, _setPoolSubs]: any = useState({});
+  const poolSubsRef = useRef(poolSubs);
+  const setPoolSubs = (val: any) => {
+    poolSubsRef.current = val;
+    _setPoolSubs(val);
+  };
 
   // store bonded pools
   const [bondedPools, setBondedPools]: any = useState([]);
@@ -83,6 +103,17 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
       unsubscribePoolMembership();
     };
   }, [network, isReady, activeAccount]);
+
+  // unsubscribe from any meta batches upon network change
+  useEffect(() => {
+    return () => {
+      Object.values(poolSubsRef.current).map((batch: any, index: number) => {
+        return Object.entries(batch).map(([k, v]: any) => {
+          return v();
+        });
+      });
+    };
+  }, [isReady, network]);
 
   const unsubscribe = async () => {
     if (poolsConfig.unsub !== null) {
@@ -221,12 +252,98 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
       .toString();
   };
 
+  /*
+    Fetches a new batch of pool metadata.
+    Fetches the metadata of a pool that we assume to be a string.
+    structure:
+    {
+      key: {
+        [
+          {
+          metadata: [],
+        }
+      ]
+    },
+  };
+  */
+  const fetchPoolsMetaBatch = async (key: string, p: any, refetch = false) => {
+    if (!isReady || !api) {
+      return;
+    }
+    if (!p.length) {
+      return;
+    }
+
+    if (!refetch) {
+      // if already exists, do not re-fetch
+      if (poolMetaBatchesRef.current[key] !== undefined) {
+        return;
+      }
+    } else {
+      // tidy up if existing batch exists
+      delete poolMetaBatches[key];
+      delete poolMetaBatchesRef.current[key];
+
+      if (poolSubsRef.current[key] !== undefined) {
+        for (const unsub of poolSubsRef.current[key]) {
+          unsub();
+        }
+      }
+    }
+
+    const ids = [];
+    for (const _p of p) {
+      ids.push(_p.id.toNumber());
+    }
+
+    // store batch ids
+    const batchesUpdated = Object.assign(poolMetaBatchesRef.current);
+    batchesUpdated[key] = {};
+    batchesUpdated[key].ids = ids;
+    setPoolMetaBatch({ ...batchesUpdated });
+
+    const subscribeToMetadata = async (id: any) => {
+      const unsub = await api.query.nominationPools.metadata.multi(
+        id,
+        (_metadata: any) => {
+          const metadata = [];
+          for (let i = 0; i < _metadata.length; i++) {
+            metadata.push(_metadata[i].toHuman());
+          }
+          const _batchesUpdated = Object.assign(poolMetaBatchesRef.current);
+          _batchesUpdated[key].metadata = metadata;
+          setPoolMetaBatch({ ..._batchesUpdated });
+        }
+      );
+      return unsub;
+    };
+
+    // initiate subscriptions
+    await Promise.all([subscribeToMetadata(ids)]).then((unsubs: any) => {
+      addMetaBatchUnsubs(key, unsubs);
+    });
+  };
+
+  /*
+   * Helper function to add mataBatch unsubs by key.
+   */
+  const addMetaBatchUnsubs = (key: string, unsubs: any) => {
+    const _unsubs = poolSubsRef.current;
+    const _keyUnsubs = _unsubs[key] ?? [];
+
+    _keyUnsubs.push(...unsubs);
+    _unsubs[key] = _keyUnsubs;
+    setPoolSubs(_unsubs);
+  };
+
   return (
     <PoolsContext.Provider
       value={{
+        fetchPoolsMetaBatch,
         membership: poolMembership?.membership,
         enabled,
         stats: poolsConfig.stats,
+        meta: poolMetaBatchesRef.current,
         bondedPools,
       }}
     >

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -73,7 +73,6 @@ export const ValidatorsProvider = ({
 
   // stores the meta data batches for validator lists
   const [validatorMetaBatches, _setValidatorMetaBatch]: any = useState({});
-
   const validatorMetaBatchesRef = useRef(validatorMetaBatches);
   const setValidatorMetaBatch = (val: any) => {
     validatorMetaBatchesRef.current = val;
@@ -82,7 +81,6 @@ export const ValidatorsProvider = ({
 
   // stores the meta batch subscriptions for validator lists
   const [validatorSubs, _setValidatorSubs]: any = useState({});
-
   const validatorSubsRef = useRef(validatorSubs);
   const setValidatorSubs = (val: any) => {
     validatorSubsRef.current = val;
@@ -491,19 +489,6 @@ export const ValidatorsProvider = ({
       delete validatorMetaBatches[key];
       delete validatorMetaBatchesRef.current[key];
     }
-  };
-
-  const removeIndexFromBatch = (key: string, index: number) => {
-    const batchesUpdated = Object.assign(validatorMetaBatchesRef.current, {});
-    batchesUpdated[key].addresses.splice(index, 1);
-
-    if (batchesUpdated[key].stake !== undefined) {
-      batchesUpdated[key].identities.splice(index, 1);
-    }
-    if (batchesUpdated[key].stake !== undefined) {
-      batchesUpdated[key].stake.splice(index, 1);
-    }
-    setValidatorMetaBatch({ ...batchesUpdated });
   };
 
   /*

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -16,7 +16,6 @@ export interface ValidatorsContextState {
   fetchValidatorMetaBatch: (k: string, v: [], r?: boolean) => void;
   removeValidatorMetaBatch: (k: string) => void;
   fetchValidatorPrefs: (v: any) => any;
-  removeIndexFromBatch: (k: string, i: number) => void;
   addFavourite: (a: string) => any;
   removeFavourite: (a: string) => any;
   getMinRewardBond: (v: any) => any;
@@ -34,7 +33,6 @@ export const ValidatorsContext: React.Context<ValidatorsContextState> =
     fetchValidatorMetaBatch: (k: string, v: [], r?: boolean) => {},
     removeValidatorMetaBatch: (k: string) => {},
     fetchValidatorPrefs: (v: any) => {},
-    removeIndexFromBatch: (k: string, i: number) => {},
     addFavourite: (a: string) => {},
     removeFavourite: (a: string) => {},
     getMinRewardBond: (v: any) => {},
@@ -546,7 +544,6 @@ export const ValidatorsProvider = ({
         fetchValidatorMetaBatch,
         removeValidatorMetaBatch,
         fetchValidatorPrefs,
-        removeIndexFromBatch,
         addFavourite,
         removeFavourite,
         getMinRewardBond,

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -7,18 +7,33 @@ import { faUsers } from '@fortawesome/free-solid-svg-icons';
 import { Wrapper } from './Wrapper';
 import Identicon from '../Identicon';
 import { clipAddress } from '../../Utils';
+import { usePools } from '../../contexts/Pools';
 
-export const PoolInner = (props: any) => {
-  const { initial, pool } = props;
+export const Pool = (props: any) => {
+  const { pool, batchKey, batchIndex } = props;
   const { memberCounter, addresses, id } = pool;
+  const { meta } = usePools();
+
+  const metadata = meta[batchKey]?.metadata ?? [];
+
+  // aggregate synced status
+  const metadataSynced = metadata.length > 0 ?? false;
+
+  // display value
+  const defaultDisplay = clipAddress(addresses.stash);
+
+  // fallback to address on empty metadata string
+  let display = metadata[batchIndex] ?? defaultDisplay;
+  if (display === '') {
+    display = defaultDisplay;
+  }
 
   return (
     <Wrapper>
       <div>
         <h3>{id.toNumber()}</h3>
         <Identicon value={addresses.stash} size={26} />
-
-        {initial ? (
+        {!metadataSynced ? (
           <motion.div
             className="identity"
             initial={{ opacity: 0 }}
@@ -28,9 +43,14 @@ export const PoolInner = (props: any) => {
             <h4>{clipAddress(addresses.stash)}</h4>
           </motion.div>
         ) : (
-          <div className="identity">
-            <h4>{clipAddress(addresses.stash)}</h4>
-          </div>
+          <motion.div
+            className="identity"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.3 }}
+          >
+            <h4>{display}</h4>
+          </motion.div>
         )}
 
         <div className="labels">
@@ -49,7 +69,5 @@ export const PoolInner = (props: any) => {
     </Wrapper>
   );
 };
-
-export const Pool = (props: any) => <PoolInner {...props} />;
 
 export default Pool;


### PR DESCRIPTION
This PR adds a subscription to a pool list's metadata. We assume that the bytes returned by `nominationPools.metedata` is a string, and fallback to display the pool's address if an empty string is returned.

The mechanism behind this is the same as validator lists, whereby a batch of pool items (every pool in a PoolList) is fetched as one subscription, under a particular "batch key".  This asynchronous batching maintains high responsiveness and overall performance of the app, and could be expanded with additional pool metrics in the future (one batch can handle multiple subscriptions).