### PR TITLE
Add Pooling to Balances Graph

### DIFF
--- a/src/library/Graphs/Wrappers.ts
+++ b/src/library/Graphs/Wrappers.ts
@@ -158,6 +158,7 @@ export const GraphWrapper = styled.div<any>`
     margin: 0.25rem 0 0;
   }
   h4 {
+    align-items: center;
     margin-top: 0.4rem;
 
     .assistant-icon {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -138,7 +138,7 @@ export const ASSISTANT_CONFIG = [
       {
         title: 'Your Balances',
         description: [
-          'Your balance is a total of the total amount you have staked, and the total amount you have bonded in a Pool.',
+          'Your balance represents total amount you have staked in addition to the total amount you have bonded in a Pool.',
           'Unlike your staked balance, your bonded pool balance is held and locked in the pool itself.',
         ],
       },

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -136,7 +136,7 @@ export const ASSISTANT_CONFIG = [
         ],
       },
       {
-        title: 'Your Balances',
+        title: 'Your Balance',
         description: [
           'Your balance represents total amount you have staked in addition to the total amount you have bonded in a Pool.',
           'Unlike your staked balance, your bonded pool balance is held and locked in the pool itself.',

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -136,6 +136,13 @@ export const ASSISTANT_CONFIG = [
         ],
       },
       {
+        title: 'Your Balances',
+        description: [
+          'Your balance is a total of the total amount you have staked, and the total amount you have bonded in a Pool.',
+          'Unlike your staked balance, your bonded pool balance is held and locked in the pool itself.',
+        ],
+      },
+      {
         title: 'Announcements',
         description: [
           'Real time network statistics that may affect your staking positions.',

--- a/src/pages/Overview/BalanceGraph.tsx
+++ b/src/pages/Overview/BalanceGraph.tsx
@@ -89,7 +89,7 @@ export const BalanceGraph = () => {
   };
 
   // determine stats from network features
-  let _labels = ['Available', 'Staking', 'Pooling'];
+  let _labels = ['Available', 'Staking', 'In Pool'];
   let _data = zeroBalance ? [-1, -1, -1] : [graphFreeToStake, graphStaked, 0]; // TODO: inject pooling balance
   let _colors = zeroBalance
     ? [

--- a/src/pages/Overview/BalanceGraph.tsx
+++ b/src/pages/Overview/BalanceGraph.tsx
@@ -14,13 +14,14 @@ import { defaultThemes } from '../../theme/default';
 import { useTheme } from '../../contexts/Themes';
 import { usePrices } from '../../library/Hooks/usePrices';
 import { APIContextInterface } from '../../types/api';
+import { OpenAssistantIcon } from '../../library/OpenAssistantIcon';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 export const BalanceGraph = () => {
   const { mode } = useTheme();
   const { network } = useApi() as APIContextInterface;
-  const { units } = network;
+  const { units, features } = network;
   const { activeAccount }: any = useConnect();
   const { getAccountBalance, getBondOptions }: any = useBalances();
   const balance = getAccountBalance(activeAccount);
@@ -87,31 +88,58 @@ export const BalanceGraph = () => {
     cutout: '75%',
   };
 
+  // determine stats from network features
+  let _labels = ['Available', 'Staking', 'Pooling'];
+  let _data = zeroBalance ? [-1, -1, -1] : [graphFreeToStake, graphStaked, 0]; // TODO: inject pooling balance
+  let _colors = zeroBalance
+    ? [
+        defaultThemes.graphs.colors[2][mode],
+        defaultThemes.graphs.inactive2[mode],
+        defaultThemes.graphs.inactive[mode],
+      ]
+    : [
+        defaultThemes.graphs.colors[2][mode],
+        defaultThemes.graphs.colors[0][mode],
+        defaultThemes.graphs.colors[3][mode],
+      ];
+  _data = features.pools ? _data : _data.slice(0, 2);
+  _colors = features.pools ? _colors : _colors.slice(0, 2);
+  _labels = features.pools ? _labels : _labels.slice(0, 2);
+
+  // default to a greyscale 50/50 donut on zero balance
+  let dataSet;
+  if (zeroBalance) {
+    dataSet = {
+      label: network.unit,
+      data: _data,
+      backgroundColor: _colors,
+      borderWidth: 0,
+    };
+  } else {
+    dataSet = {
+      label: network.unit,
+      data: _data,
+      backgroundColor: _colors,
+      borderWidth: 0,
+    };
+  }
+
   const data = {
-    labels: ['Available', 'Staking'],
-    datasets: [
-      {
-        label: network.unit,
-        data: [graphFreeToStake, graphStaked],
-        backgroundColor: [
-          defaultThemes.graphs.colors[2][mode],
-          zeroBalance
-            ? defaultThemes.graphs.inactive[mode]
-            : defaultThemes.graphs.colors[0][mode],
-        ],
-        borderWidth: 0,
-      },
-    ],
+    labels: _labels,
+    datasets: [dataSet],
   };
 
   const ref: any = React.useRef();
   const size = useSize(ref.current);
-  const { width, height, minHeight } = formatSize(size, 252);
+  const { width, height, minHeight } = formatSize(size, 253);
 
   return (
     <>
       <div className="head" style={{ paddingTop: '0' }}>
-        <h4>Balance</h4>
+        <h4>
+          Balances
+          <OpenAssistantIcon page="overview" title="Your Balances" />
+        </h4>
         <h2>
           <span className="amount">{freeBase}</span>&nbsp;{network.unit}
           <span className="fiat">

--- a/src/pages/Overview/BalanceGraph.tsx
+++ b/src/pages/Overview/BalanceGraph.tsx
@@ -137,8 +137,8 @@ export const BalanceGraph = () => {
     <>
       <div className="head" style={{ paddingTop: '0' }}>
         <h4>
-          Balances
-          <OpenAssistantIcon page="overview" title="Your Balances" />
+          Balance
+          <OpenAssistantIcon page="overview" title="Your Balance" />
         </h4>
         <h2>
           <span className="amount">{freeBase}</span>&nbsp;{network.unit}

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -51,8 +51,14 @@ export const defaultThemes: any = {
     ),
   },
   graphs: {
-    colors: [v('#d33079', '#d33079'), v('#ccc', '#555'), v('#eee', '#222')],
-    inactive: v('#ddd', '#333'),
+    colors: [
+      v('#E6007A', '#d33079'),
+      v('#ccc', '#555'),
+      v('#eee', '#222'),
+      v('#c25bc1', '#c25bc1'),
+    ],
+    inactive: v('#cfcfcf', '#1a1a1a'),
+    inactive2: v('#dadada', '#383838'),
     tooltip: v('#333', '#ddd'),
     grid: v('#eee', '#222'),
   },

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -55,7 +55,7 @@ export const defaultThemes: any = {
       v('#E6007A', '#d33079'),
       v('#ccc', '#555'),
       v('#eee', '#222'),
-      v('#c25bc1', '#c25bc1'),
+      v('#e474bc', '#e474bc'),
     ],
     inactive: v('#cfcfcf', '#1a1a1a'),
     inactive2: v('#dadada', '#383838'),


### PR DESCRIPTION
Note that the pool balance is hard-coded zero until we have memberships fully hooked up.

- Pooling stat added to Balances graph
- New purple color introduced (up for debate)
- Assistant item explaining that pool balance is not held in your account, unlike staked balance.

<img width="597" alt="Screenshot 2022-05-26 at 16 17 32" src="https://user-images.githubusercontent.com/13929023/170518832-075bc2b1-3caa-4511-bd19-4e448e7181dc.png">