### PR TITLE
reset activeBondedPool when unsubscribe

### DIFF
--- a/src/contexts/Account.tsx
+++ b/src/contexts/Account.tsx
@@ -99,7 +99,11 @@ export const AccountProvider = ({
     const batchesUpdated = Object.assign(accountMetaBatchesRef.current);
     batchesUpdated[key] = {};
     batchesUpdated[key].addresses = addresses;
-    setStateWithRef(batchesUpdated, setAccountMetaBatch, accountMetaBatchesRef);
+    setStateWithRef(
+      { ...batchesUpdated },
+      setAccountMetaBatch,
+      accountMetaBatchesRef
+    );
 
     const subscribeToIdentities = async (addr: any) => {
       const unsub = await api.query.identity.identityOf.multi(
@@ -112,7 +116,7 @@ export const AccountProvider = ({
           const _batchesUpdated = Object.assign(accountMetaBatchesRef.current);
           _batchesUpdated[key].identities = identities;
           setStateWithRef(
-            _batchesUpdated,
+            { ..._batchesUpdated },
             setAccountMetaBatch,
             accountMetaBatchesRef
           );
@@ -157,7 +161,7 @@ export const AccountProvider = ({
           const _batchesUpdated = Object.assign(accountMetaBatchesRef.current);
           _batchesUpdated[key].supers = supers;
           setStateWithRef(
-            _batchesUpdated,
+            { ..._batchesUpdated },
             setAccountMetaBatch,
             accountMetaBatchesRef
           );

--- a/src/contexts/Pools/index.tsx
+++ b/src/contexts/Pools/index.tsx
@@ -611,7 +611,11 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
     const batchesUpdated = Object.assign(poolMetaBatchesRef.current);
     batchesUpdated[key] = {};
     batchesUpdated[key].ids = ids;
-    setStateWithRef(batchesUpdated, setPoolMetaBatch, poolMetaBatchesRef);
+    setStateWithRef(
+      { ...batchesUpdated },
+      setPoolMetaBatch,
+      poolMetaBatchesRef
+    );
 
     const subscribeToMetadata = async (id: any) => {
       const unsub = await api.query.nominationPools.metadata.multi(
@@ -623,8 +627,9 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
           }
           const _batchesUpdated = Object.assign(poolMetaBatchesRef.current);
           _batchesUpdated[key].metadata = metadata;
+
           setStateWithRef(
-            _batchesUpdated,
+            { ..._batchesUpdated },
             setPoolMetaBatch,
             poolMetaBatchesRef
           );

--- a/src/contexts/Pools/index.tsx
+++ b/src/contexts/Pools/index.tsx
@@ -179,6 +179,10 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
     if (activeBondedPool?.unsub) {
       activeBondedPool?.unsub();
     }
+    setActiveBondedPool({
+      membership: undefined,
+      unsub: null,
+    });
   };
 
   // subscribe to pool nominations
@@ -525,7 +529,7 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   const isNominator = () => {
-    const roles = activeBondedPool.pool?.roles;
+    const roles = activeBondedPool?.pool?.roles;
     if (!activeAccount || !roles) {
       return false;
     }

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -350,7 +350,7 @@ export const ValidatorsProvider = ({
     batchesUpdated[key] = {};
     batchesUpdated[key].addresses = addresses;
     setStateWithRef(
-      batchesUpdated,
+      { ...batchesUpdated },
       setValidatorMetaBatch,
       validatorMetaBatchesRef
     );
@@ -368,7 +368,7 @@ export const ValidatorsProvider = ({
           );
           _batchesUpdated[key].identities = identities;
           setStateWithRef(
-            _batchesUpdated,
+            { ..._batchesUpdated },
             setValidatorMetaBatch,
             validatorMetaBatchesRef
           );
@@ -415,7 +415,7 @@ export const ValidatorsProvider = ({
           );
           _batchesUpdated[key].supers = supers;
           setStateWithRef(
-            _batchesUpdated,
+            { ..._batchesUpdated },
             setValidatorMetaBatch,
             validatorMetaBatchesRef
           );
@@ -496,7 +496,7 @@ export const ValidatorsProvider = ({
         _batchesUpdated[key].stake = stake;
 
         setStateWithRef(
-          _batchesUpdated,
+          { ..._batchesUpdated },
           setValidatorMetaBatch,
           validatorMetaBatchesRef
         );

--- a/src/library/PoolAccount/index.tsx
+++ b/src/library/PoolAccount/index.tsx
@@ -46,7 +46,6 @@ export const PoolAccount = (props: any) => {
   // handle pool list bootstrapping
   const getPoolMeta = () => {
     const pools: any = [{ id: props.pool.id }];
-    // console.log('fetching');
     fetchPoolsMetaBatch(batchKey, pools, true);
   };
 

--- a/src/library/PoolAccount/index.tsx
+++ b/src/library/PoolAccount/index.tsx
@@ -9,44 +9,44 @@ import { useTheme } from 'contexts/Themes';
 import { defaultThemes } from 'theme/default';
 import { ReactComponent as WalletSVG } from 'img/wallet.svg';
 import Identicon from 'library/Identicon';
+import { useConnect } from 'contexts/Connect';
+import { ConnectContextInterface } from 'types/connect';
 import Wrapper from './Wrapper';
 import { clipAddress, convertRemToPixels } from '../../Utils';
 
 export const PoolAccount = (props: any) => {
   const { mode } = useTheme();
   const { isReady } = useApi() as APIContextInterface;
+  const { activeAccount } = useConnect() as ConnectContextInterface;
   const { fetchPoolsMetaBatch, meta } = usePools();
 
   const { label }: any = props;
-
-  const [pool, setPool] = useState(props.pool);
 
   // is this the initial fetch
   const [fetched, setFetched] = useState(false);
 
   const batchKey = 'pool_header';
 
-  // refetch list when pool changes
+  // refetch when pool or active account changes
   useEffect(() => {
-    if (props.pool !== pool) {
-      setFetched(false);
-    }
     setFetched(false);
-  }, [props.pool]);
+  }, [activeAccount, props.pool]);
 
   // configure pool list when network is ready to fetch
   useEffect(() => {
-    if (isReady && !fetched) {
-      getPoolMeta();
+    if (isReady) {
+      setFetched(true);
+
+      if (!fetched) {
+        getPoolMeta();
+      }
     }
   }, [isReady, fetched]);
 
   // handle pool list bootstrapping
   const getPoolMeta = () => {
-    setPool(props.pool);
-    setFetched(true);
     const pools: any = [{ id: props.pool.id }];
-
+    // console.log('fetching');
     fetchPoolsMetaBatch(batchKey, pools, true);
   };
 
@@ -57,14 +57,14 @@ export const PoolAccount = (props: any) => {
 
   const metaBatch = meta[batchKey];
   const metaData = metaBatch?.metadata?.[0];
-  const syncing = meta[batchKey]?.metadata === undefined;
+  const syncing = metaData === undefined;
 
   // fallback to address on empty metadata string
-  const display = syncing
+  const display =
     ? 'Syncing...'
     : metaData !== ''
     ? metaData
-    : clipAddress(pool.addresses.stash);
+    : clipAddress(props.pool.addresses.stash);
 
   return (
     <Wrapper
@@ -78,7 +78,7 @@ export const PoolAccount = (props: any) => {
 
       <span className="identicon">
         <Identicon
-          value={pool.addresses.stash}
+          value={props.pool.addresses.stash}
           size={convertRemToPixels(fontSize) * 1.45}
         />
       </span>

--- a/src/library/PoolAccount/index.tsx
+++ b/src/library/PoolAccount/index.tsx
@@ -60,7 +60,7 @@ export const PoolAccount = (props: any) => {
   const syncing = metaData === undefined;
 
   // fallback to address on empty metadata string
-  const display =
+  const display = syncing
     ? 'Syncing...'
     : metaData !== ''
     ? metaData

--- a/src/pages/Pools/Roles.tsx
+++ b/src/pages/Pools/Roles.tsx
@@ -18,7 +18,7 @@ export const Roles = () => {
   const { fetchAccountMetaBatch } = useAccount();
   const { isNominator, activeBondedPool } = usePools();
   const activePool = activeBondedPool;
-  const { roles } = activePool;
+  const { roles } = activePool || {};
 
   const batchKey = 'pool_roles';
 


### PR DESCRIPTION
This should fix bug: #79 in the nomination pool page, where the users who are not in an active pool see the wrong pool context.