### PR TITLE
hide unrelated components from pool page based on pooling state

### DIFF
--- a/src/contexts/Pools/index.tsx
+++ b/src/contexts/Pools/index.tsx
@@ -695,9 +695,7 @@ export const PoolsProvider = ({ children }: { children: React.ReactNode }) => {
     const { nominations } = targets;
     const statuses: any = {};
     for (const nomination of nominations) {
-      const s = eraStakers.current.stakers.find(
-        (_n: any) => _n.address === nomination
-      );
+      const s = eraStakers.stakers.find((_n: any) => _n.address === nomination);
 
       if (s === undefined) {
         statuses[nomination] = 'waiting';

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -31,7 +31,7 @@ export const Pools = (props: PageProps) => {
   const { title } = page;
   const { network } = useApi() as APIContextInterface;
   const navigate = useNavigate();
-  const { bondedPools, isBonding, targets } = usePools();
+  const { bondedPools, isBonding, isNominator, targets } = usePools();
   const { isSyncing } = useUi();
 
   // back to overview if pools are not supported on network
@@ -61,30 +61,32 @@ export const Pools = (props: PageProps) => {
       </PageRowWrapper>
       {isBonding() && (
         <>
-          {targets.nominations.length > 0 && <ManagePool />}
           <PageRowWrapper className="page-padding" noVerticalSpacer>
             <SectionWrapper>
               <Roles />
             </SectionWrapper>
           </PageRowWrapper>
+          {isNominator() && <ManagePool />}
         </>
       )}
-      <PageRowWrapper className="page-padding" noVerticalSpacer>
-        <SectionWrapper>
-          <SectionHeaderWrapper>
-            <h2>
-              {isBonding() || isSyncing ? 'Pools' : 'Join a Pool'}
-              <OpenAssistantIcon page="pools" title="Nomination Pools" />
-            </h2>
-          </SectionHeaderWrapper>
-          <PoolList
-            pools={bondedPools}
-            title="Active Pools"
-            allowMoreCols
-            pagination
-          />
-        </SectionWrapper>
-      </PageRowWrapper>
+      {!isBonding() && !isSyncing && (
+        <PageRowWrapper className="page-padding" noVerticalSpacer>
+          <SectionWrapper>
+            <SectionHeaderWrapper>
+              <h2>
+                Join a Pool
+                <OpenAssistantIcon page="pools" title="Nomination Pools" />
+              </h2>
+            </SectionHeaderWrapper>
+            <PoolList
+              pools={bondedPools}
+              title="Active Pools"
+              allowMoreCols
+              pagination
+            />
+          </SectionWrapper>
+        </PageRowWrapper>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Some improvments Re: #80 
these should make the pool page more context aware. applying the following changes:
- hide pool lists when is in a pool.
- show manage pools when is the pool nominator.