### PR TITLE
Chronological payout graphs

### DIFF
--- a/src/contexts/Subscan.tsx
+++ b/src/contexts/Subscan.tsx
@@ -76,7 +76,7 @@ export const SubscanProvider = ({
     if (res.message === 'Success') {
       if (getServices().includes('subscan')) {
         if (res.data.list !== null) {
-          setPayouts(res.data.list.reverse());
+          setPayouts(res.data.list);
         } else {
           setPayouts([]);
         }

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -14,7 +14,6 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { planckToUnit } from 'Utils';
 import { useApi } from 'contexts/Api';
 import { defaultThemes } from 'theme/default';
 import { useTheme } from 'contexts/Themes';
@@ -47,7 +46,7 @@ export const PayoutBar = (props: any) => {
         label: 'Price',
         // data: empty_data,
         data: payouts.map((item: any, index: number) => {
-          return planckToUnit(item.amount, units);
+          return item.amount;
         }),
         borderColor: defaultThemes.graphs.colors[0][mode],
         backgroundColor: (context: any) => {
@@ -59,7 +58,7 @@ export const PayoutBar = (props: any) => {
           return getGradient(ctx, chartArea);
         },
         pointRadius: 0,
-        borderRadius: 5,
+        borderRadius: 3,
       },
     ],
   };
@@ -67,7 +66,7 @@ export const PayoutBar = (props: any) => {
   const options = {
     responsive: true,
     maintainAspectRatio: false,
-    barPercentage: 0.28,
+    barPercentage: 0.4,
     maxBarThickness: 11,
     scales: {
       x: {

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -12,7 +12,6 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { planckToUnit } from 'Utils';
 import { useApi } from 'contexts/Api';
 import { defaultThemes } from 'theme/default';
 import { useTheme } from 'contexts/Themes';
@@ -32,7 +31,6 @@ ChartJS.register(
 export const PayoutLine = (props: any) => {
   const { mode } = useTheme();
   const { network } = useApi() as APIContextInterface;
-  const { units } = network;
   const { payouts, height, background } = props;
 
   const options = {
@@ -99,7 +97,7 @@ export const PayoutLine = (props: any) => {
         label: 'Price',
         // data: empty_data,
         data: payouts.map((item: any, index: number) => {
-          return planckToUnit(item.amount, units);
+          return item.amount;
         }),
         borderColor: (context: any) => {
           const { chart } = context;

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -1,8 +1,11 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import BN from 'bn.js';
+import moment from 'moment';
 import React from 'react';
 import throttle from 'lodash.throttle';
+import { planckBnToUnit } from 'Utils';
 
 export const getSize = (element: any) => {
   const width = element?.offsetWidth;
@@ -82,4 +85,160 @@ export const prefillPayoutGraph = (list: any, maxLength: number) => {
   }
   // move most recent last
   return list.reverse();
+};
+
+// given payouts, calculate daily icome and fill missing days with zero amounts.
+export const calculatePayoutsByDay = (
+  payouts: any,
+  maxDays: number,
+  units: number
+) => {
+  if (!payouts.length) {
+    return payouts;
+  }
+
+  const payoutsByDay: any = [];
+  let curDay = 367;
+  let curYear = 3000;
+  let curPayout = {
+    amount: new BN(0),
+    event_id: '',
+  };
+
+  // determine inactive days since last payout
+  const lastTs = moment.unix(payouts[0].block_timestamp);
+
+  // test from start of day as to not duplicate today's payout entry
+  let daysSinceLast = moment().startOf('day').diff(lastTs, 'days');
+
+  // add inactive days
+  if (daysSinceLast > 0) {
+    daysSinceLast = daysSinceLast > maxDays ? maxDays : daysSinceLast;
+    let timestamp = moment().endOf('day');
+    for (let i = 1; i < daysSinceLast; i++) {
+      timestamp = timestamp.subtract(1, 'days');
+      payoutsByDay.push({
+        amount: 0,
+        event_id: 'Reward',
+        block_timestamp: timestamp.unix(),
+      });
+    }
+  }
+
+  if (payouts.length > 0) {
+    let p = 0; // payouts passed
+    let i = 0; // days passed
+
+    for (const payout of payouts) {
+      // break if graph limit reached
+      if (payoutsByDay.length >= maxDays) {
+        break;
+      }
+      // increment payout
+      p++;
+
+      // extract day and year from payout timestamp
+      const date = moment.unix(payout.block_timestamp);
+      const _day = date.dayOfYear();
+      const _year = date.year();
+
+      // starting a new day
+      if (_day < curDay || _year < curYear) {
+        // check current day with previous, determine missing days
+        const prevTs = moment(`${curDay}/${curYear}`, 'DDD/YYYY').unix();
+        const thisTs = moment(`${_day}/${_year}`, 'DDD/YYYY').unix();
+        const gapDays = moment.unix(prevTs).diff(moment.unix(thisTs), 'days');
+
+        // increment by `gap `days
+        if (i !== 0) {
+          i += gapDays;
+        } else {
+          // increment 1st day
+          i++;
+        }
+
+        // get timestamp of end of day
+        const dayTs = moment(`${curDay}/${curYear}`, 'DDD/YYYY')
+          .endOf('day')
+          .unix();
+
+        // commit previous day payout
+        if (i > 1) {
+          payoutsByDay.push({
+            amount: planckBnToUnit(curPayout.amount, units),
+            event_id: curPayout.amount.lt(new BN(0)) ? 'Slash' : 'Reward',
+            block_timestamp: dayTs,
+          });
+        }
+
+        // commit gap day payouts
+        if (i !== 0) {
+          // fill missing days
+          let gapDayTs = moment.unix(prevTs);
+          if (gapDays > 1) {
+            for (let j = 1; j < gapDays; j++) {
+              gapDayTs = gapDayTs.subtract(1, 'days');
+              payoutsByDay.push({
+                amount: 0,
+                event_id: 'Reward',
+                block_timestamp: gapDayTs.unix(),
+              });
+            }
+          }
+        }
+
+        // overwrite curPayout for this day
+        const amount = new BN(payout.amount);
+        curPayout = {
+          amount,
+          event_id: amount.lt(new BN(0)) ? 'Slash' : 'Reward',
+        };
+
+        // update day and year cursors
+        if (_day < curDay) curDay = _day;
+        if (_year < curYear) curYear = _year;
+      } else {
+        // same day: add to curPayout
+        curPayout.amount = curPayout.amount.add(new BN(payout.amount));
+      }
+
+      // commit last payout
+      if (p === payouts.length) {
+        payoutsByDay.push({
+          amount: planckBnToUnit(curPayout.amount, units),
+          event_id: curPayout.amount.lt(new BN(0)) ? 'Slash' : 'Reward',
+          block_timestamp: payout.block_timestamp,
+        });
+      }
+    }
+  }
+  return payoutsByDay;
+};
+
+// fill in the backlog of days up to `maxDays`
+export const prefillToMaxDays = (payoutsByDay: any, maxDays: number) => {
+  if (payoutsByDay.length < maxDays) {
+    const remainingDays = maxDays - payoutsByDay.length;
+
+    // get earliest timestamp
+    let timestamp;
+    if (!payoutsByDay.length) {
+      timestamp = moment().endOf('day');
+    } else {
+      timestamp = moment.unix(
+        payoutsByDay[payoutsByDay.length - 1].block_timestamp
+      );
+    }
+
+    // fill in remaining days
+    for (let i = 0; i < remainingDays; i++) {
+      timestamp = timestamp.subtract(1, 'days');
+      payoutsByDay.push({
+        amount: 0,
+        event_id: 'Reward',
+        block_timestamp: timestamp.unix(),
+      });
+    }
+  }
+  return payoutsByDay;
 };

--- a/src/pages/Overview/Payouts.tsx
+++ b/src/pages/Overview/Payouts.tsx
@@ -5,20 +5,16 @@ import React from 'react';
 import { useUi } from 'contexts/UI';
 import { PayoutLine } from 'library/Graphs/PayoutLine';
 import { PayoutBar } from 'library/Graphs/PayoutBar';
-import { useSize, formatSize, prefillPayoutGraph } from 'library/Graphs/Utils';
+import { useSize, formatSize } from 'library/Graphs/Utils';
 import { StatusLabel } from 'library/StatusLabel';
 
 export const PayoutsInner = (props: any) => {
   const { payouts } = props;
-
   const { services } = useUi();
 
   const ref: any = React.useRef();
   const size = useSize(ref.current);
   const { width, height, minHeight } = formatSize(size, 306);
-
-  // pre-fill missing items if payouts < 60
-  const payoutsGraph = prefillPayoutGraph([...payouts], 10);
 
   return (
     <div className="inner" ref={ref} style={{ minHeight }}>
@@ -40,9 +36,9 @@ export const PayoutsInner = (props: any) => {
           position: 'absolute',
         }}
       >
-        <PayoutBar payouts={payoutsGraph} height="170px" />
+        <PayoutBar payouts={payouts} height="170px" />
         <div style={{ marginTop: '1rem' }}>
-          <PayoutLine payouts={payoutsGraph} height="70px" />
+          <PayoutLine payouts={payouts} height="70px" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR introduces an algorithm that takes payouts and formats them in daily order for the payout graphs. When the pools API is ready we can look into further formatting options like stacking a bar with payouts (both staking and pool rewards) to represent individual payments on that day.

For now, the following improvements were made:
   - Where multiple payouts are received on the same day, they are added together and represented as daily income.
   - Days where no payouts were made are represented as a zero-payout day.
   - Where there has been inactivity for a number of days since the last payout, zero-payout days are added from the last payout day to the current day.
   
#### Before: simply displaying payouts on a per-record basis
(Notice duplicate day records / missing days issues)

<img width="969" alt="Screenshot 2022-06-13 at 18 45 51" src="https://user-images.githubusercontent.com/13929023/173413384-054e5999-0b8f-4b64-b437-d0a77c985c00.png">

#### After: grouping payouts into daily amounts, periods of inactivity represented chronologically

<img width="971" alt="Screenshot 2022-06-13 at 18 45 59" src="https://user-images.githubusercontent.com/13929023/173413443-9092d5f3-c3af-4c3e-a221-d59bc48ee3cc.png">
