### PR TITLE
Theming Palette Intro

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -12,6 +12,7 @@ import { BalancesProvider } from './contexts/Balances';
 import { ConnectProvider } from './contexts/Connect';
 import { ExtrinsicsProvider } from './contexts/Extrinsics';
 import { MenuProvider } from './contexts/Menu';
+import { PaletteProvider } from './contexts/Palette';
 import { MessagesProvider } from './contexts/Messages';
 import { ModalProvider } from './contexts/Modal';
 import { NetworkMetricsProvider } from './contexts/Network';
@@ -63,6 +64,7 @@ export const Providers = withProviders(
   MessagesProvider,
   SubscanProvider,
   MenuProvider,
+  PaletteProvider,
   NotificationsProvider,
   ExtrinsicsProvider,
   SessionEraProvider

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -36,10 +36,10 @@ export const WrappedRouter = () => (
 );
 
 export const ThemedRouter = () => {
-  const { mode } = useTheme();
+  const { mode, card } = useTheme();
 
   return (
-    <ThemeProvider theme={{ mode }}>
+    <ThemeProvider theme={{ mode, card }}>
       <WrappedRouter />
     </ThemeProvider>
   );

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -12,6 +12,7 @@ import {
 import { AnimatePresence } from 'framer-motion';
 import { Helmet } from 'react-helmet';
 import { Menu } from 'library/Menu';
+import { Palette } from 'library/Palette';
 import {
   PageWrapper,
   SideInterfaceWrapper,
@@ -50,6 +51,9 @@ export const RouterInner = () => {
 
         {/* Menu: closed by default */}
         <Menu />
+
+        {/* Palette: closed by default */}
+        <Palette />
 
         {/* Left side menu */}
         <SideInterfaceWrapper open={sideMenuOpen} minimised={sideMenuMinimised}>

--- a/src/Wrappers.tsx
+++ b/src/Wrappers.tsx
@@ -233,7 +233,6 @@ export const PageRowWrapper = styled.div<any>`
 export const RowPrimaryWrapper = styled.div<any>`
   order: ${(props) => props.vOrder};
   box-sizing: border-box;
-  overflow: hidden;
   flex: 1;
   flex-basis: 100%;
   max-width: 100%;
@@ -260,7 +259,6 @@ export const RowPrimaryWrapper = styled.div<any>`
 export const RowSecondaryWrapper = styled.div<any>`
   order: ${(props) => props.vOrder};
   box-sizing: border-box;
-  overflow: hidden;
   flex-basis: 100%;
   width: 100%;
   border-radius: 1rem;

--- a/src/contexts/Palette.tsx
+++ b/src/contexts/Palette.tsx
@@ -1,0 +1,100 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+
+export interface PaletteContextState {
+  openPalette: () => any;
+  closePalette: () => any;
+  setPalettePosition: (ref: any) => void;
+  checkPalettePosition: (ref: any) => void;
+  open: number;
+  show: number;
+  position: [number, number];
+}
+
+export const PaletteContext: React.Context<PaletteContextState> =
+  React.createContext({
+    openPalette: () => {},
+    closePalette: () => {},
+    setPalettePosition: (ref: any) => {},
+    checkPalettePosition: (ref: any) => {},
+    open: 0,
+    show: 0,
+    position: [0, 0],
+  });
+
+export const usePalette = () => React.useContext(PaletteContext);
+
+export const PaletteProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [open, setOpen] = useState(0);
+  const [show, setShow] = useState(0);
+
+  const [position, setPosition] = useState<[number, number]>([0, 0]);
+
+  const openPalette = () => {
+    if (open) return;
+    setOpen(1);
+  };
+
+  const closePalette = () => {
+    setShow(0);
+    setTimeout(() => {
+      setOpen(0);
+    }, 100);
+  };
+
+  const setPalettePosition = (posRef: any) => {
+    if (open) return;
+    const bodyRect = document.body.getBoundingClientRect();
+    const elemRect = posRef.current.getBoundingClientRect();
+
+    const x = elemRect.left - bodyRect.left;
+    const y = elemRect.top - bodyRect.top;
+
+    setPosition([x, y]);
+    openPalette();
+  };
+
+  const checkPalettePosition = (paletteRef: any) => {
+    const bodyRect = document.body.getBoundingClientRect();
+    const paletteRect = paletteRef.current.getBoundingClientRect();
+
+    let x = paletteRect.left - bodyRect.left;
+    let y = paletteRect.top - bodyRect.top;
+    const right = paletteRect.right;
+    const bottom = paletteRect.bottom;
+
+    const documentPadding = 20;
+
+    if (right > bodyRect.right) {
+      x = bodyRect.right - paletteRef.current.offsetWidth - documentPadding;
+    }
+    if (bottom > bodyRect.bottom) {
+      y = bodyRect.bottom - paletteRef.current.offsetHeight - documentPadding;
+    }
+
+    setPosition([x, y]);
+    setShow(1);
+  };
+
+  return (
+    <PaletteContext.Provider
+      value={{
+        openPalette,
+        closePalette,
+        setPalettePosition,
+        checkPalettePosition,
+        open,
+        show,
+        position,
+      }}
+    >
+      {children}
+    </PaletteContext.Provider>
+  );
+};

--- a/src/contexts/Themes.tsx
+++ b/src/contexts/Themes.tsx
@@ -5,7 +5,9 @@ import React from 'react';
 
 export const ThemeContext: React.Context<any> = React.createContext({
   toggleTheme: (str?: string) => {},
+  toggleCard: (c: string) => {},
   mode: 'light',
+  card: 'flat',
 });
 
 export const useTheme = () => React.useContext(ThemeContext);
@@ -13,6 +15,7 @@ export const useTheme = () => React.useContext(ThemeContext);
 export const ThemesProvider = ({ children }: { children: React.ReactNode }) => {
   // get the current theme
   let localTheme = localStorage.getItem('theme');
+  let localCard = localStorage.getItem('card');
 
   // provide default theme if not set
   if (localTheme !== 'light' && localTheme !== 'dark') {
@@ -20,21 +23,34 @@ export const ThemesProvider = ({ children }: { children: React.ReactNode }) => {
     localStorage.setItem('theme', localTheme);
   }
 
+  // provide default card if not set
+  if (!['flat', 'border', 'shadow'].includes(localCard || '')) {
+    localCard = 'flat';
+    localStorage.setItem('card', 'flat');
+  }
+
   // the theme state
   const [state, setState] = React.useState({
     mode: localTheme,
+    card: localCard,
   });
 
   const toggleTheme = (_theme: string | null = null): void => {
     if (_theme === null) {
       _theme = state.mode === 'dark' ? 'light' : 'dark';
     }
-
     localStorage.setItem('theme', _theme);
-
     setState({
       ...state,
       mode: _theme,
+    });
+  };
+
+  const toggleCard = (_card: string): void => {
+    localStorage.setItem('card', _card);
+    setState({
+      ...state,
+      card: _card,
     });
   };
 
@@ -42,7 +58,9 @@ export const ThemesProvider = ({ children }: { children: React.ReactNode }) => {
     <ThemeContext.Provider
       value={{
         toggleTheme,
+        toggleCard,
         mode: state.mode,
+        card: state.card,
       }}
     >
       {children}

--- a/src/library/Graphs/Bonded.tsx
+++ b/src/library/Graphs/Bonded.tsx
@@ -81,7 +81,11 @@ export const Bonded = (props: any) => {
   };
 
   return (
-    <GraphWrapper transparent noMargin>
+    <GraphWrapper
+      transparent
+      noMargin
+      style={{ border: 'none', boxShadow: 'none' }}
+    >
       <div
         className="graph"
         style={{

--- a/src/library/Graphs/Wrappers.ts
+++ b/src/library/Graphs/Wrappers.ts
@@ -3,7 +3,14 @@
 
 import styled from 'styled-components';
 import { SECTION_FULL_WIDTH_THRESHOLD } from 'consts';
-import { textSecondary, backgroundSecondary } from 'theme';
+import {
+  textSecondary,
+  backgroundSecondary,
+  cardBorder,
+  borderPrimary,
+  cardShadow,
+  shadowColor,
+} from 'theme';
 
 /* CardHeaderWrapper
  *
@@ -47,6 +54,8 @@ export const CardHeaderWrapper = styled.div<any>`
  * Used to separate the main modules throughout the app.
  */
 export const CardWrapper = styled.div<any>`
+  border: ${cardBorder} ${borderPrimary};
+  box-shadow: ${cardShadow} ${shadowColor};
   box-sizing: border-box;
   padding: ${(props) =>
     props.noPadding ? '0rem' : props.transparent ? '0rem 0rem' : '1.2rem'};
@@ -98,6 +107,8 @@ export const CardWrapper = styled.div<any>`
  */
 
 export const GraphWrapper = styled.div<any>`
+  border: ${cardBorder} ${borderPrimary};
+  box-shadow: ${cardShadow} ${shadowColor};
   box-sizing: border-box;
   border-radius: 1rem;
   background: ${(props) => (props.transparent ? 'none' : backgroundSecondary)};

--- a/src/library/Menu/Wrappers.ts
+++ b/src/library/Menu/Wrappers.ts
@@ -3,18 +3,17 @@
 
 import styled from 'styled-components';
 import { FLOATING_MENU_WIDTH } from 'consts';
-import { backgroundPrimary, borderPrimary, textSecondary } from 'theme';
+import { modalBackground, borderPrimary, textSecondary } from 'theme';
 
 export const Wrapper = styled.div<any>`
-  background: ${backgroundPrimary};
+  background: ${modalBackground};
   box-sizing: border-box;
-  border-radius: 0.5rem;
   width: ${FLOATING_MENU_WIDTH}px;
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 0.75rem;
   display: flex;
   flex-flow: column wrap;
   transition: opacity 0.1s;
-  box-shadow: 1px 1px 1px ${borderPrimary};
+  border-radius: 1rem;
 
   > button:last-child {
     border: none;

--- a/src/library/Palette/Wrappers.ts
+++ b/src/library/Palette/Wrappers.ts
@@ -1,0 +1,70 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from 'styled-components';
+import { FLOATING_MENU_WIDTH } from 'consts';
+import { backgroundPrimary, borderPrimary, textSecondary } from 'theme';
+
+export const Wrapper = styled.div<any>`
+  background: ${backgroundPrimary};
+  box-sizing: border-box;
+  border-radius: 1rem;
+  width: ${FLOATING_MENU_WIDTH}px;
+  padding: 1rem 0.75rem;
+  display: flex;
+  flex-flow: column wrap;
+  transition: opacity 0.1s;
+  box-shadow: 3px 3px 20px ${borderPrimary};
+
+  h4 {
+    color: ${textSecondary};
+    margin: 0 0 0.5rem 0;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const ItemWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  button {
+    position: relative;
+    color: ${textSecondary};
+    transition: color 0.2s;
+    margin: 0 0.25rem;
+    opacity: 0.75;
+    border: 2px solid ${borderPrimary};
+    background: none;
+    border-radius: 0.75rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
+
+    svg {
+      padding: 0;
+      margin: 0;
+    }
+
+    path {
+      fill: ${textSecondary};
+    }
+    &:hover {
+      opacity: 1;
+    }
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+      background: ${borderPrimary};
+    }
+  }
+`;

--- a/src/library/Palette/Wrappers.ts
+++ b/src/library/Palette/Wrappers.ts
@@ -13,9 +13,9 @@ import {
 export const Wrapper = styled.div<any>`
   background: ${backgroundPrimary};
   box-sizing: border-box;
-  border-radius: 1rem;
+  border-radius: 1.25rem;
   width: ${FLOATING_MENU_WIDTH}px;
-  padding: 1rem 0.75rem;
+  padding: 1rem;
   display: flex;
   flex-flow: column wrap;
   transition: opacity 0.1s;

--- a/src/library/Palette/Wrappers.ts
+++ b/src/library/Palette/Wrappers.ts
@@ -3,7 +3,12 @@
 
 import styled from 'styled-components';
 import { FLOATING_MENU_WIDTH } from 'consts';
-import { backgroundPrimary, borderPrimary, textSecondary } from 'theme';
+import {
+  backgroundPrimary,
+  borderPrimary,
+  textSecondary,
+  shadowColor,
+} from 'theme';
 
 export const Wrapper = styled.div<any>`
   background: ${backgroundPrimary};
@@ -14,7 +19,7 @@ export const Wrapper = styled.div<any>`
   display: flex;
   flex-flow: column wrap;
   transition: opacity 0.1s;
-  box-shadow: 3px 3px 20px ${borderPrimary};
+  box-shadow: 3px 3px 20px ${shadowColor};
 
   h4 {
     color: ${textSecondary};

--- a/src/library/Palette/index.tsx
+++ b/src/library/Palette/index.tsx
@@ -1,0 +1,97 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRef, useEffect } from 'react';
+import { usePalette } from 'contexts/Palette';
+import { useOutsideAlerter } from 'library/Hooks';
+import { useTheme } from 'contexts/Themes';
+import { ReactComponent as MoonOutlineSVG } from 'img/moon-outline.svg';
+import { ReactComponent as SunnyOutlineSVG } from 'img/sunny-outline.svg';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSquare } from '@fortawesome/free-solid-svg-icons';
+import { faSquare as faSquareRegular } from '@fortawesome/free-regular-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { Wrapper, ItemWrapper } from './Wrappers';
+
+export const Palette = () => {
+  const { mode, toggleTheme } = useTheme();
+  const palette = usePalette();
+  const { position } = palette;
+
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (palette.open === 1) {
+      palette.checkPalettePosition(ref);
+      // check position
+    }
+  }, [palette.open]);
+
+  useEffect(() => {
+    window.addEventListener('resize', resizeCallback);
+    return () => {
+      window.removeEventListener('resize', resizeCallback);
+    };
+  }, []);
+
+  const resizeCallback = () => {
+    palette.closePalette();
+  };
+
+  useOutsideAlerter(
+    ref,
+    () => {
+      palette.closePalette();
+    },
+    ['ignore-open-palette-button']
+  );
+
+  return (
+    <>
+      {palette.open === 1 && (
+        <Wrapper
+          ref={ref}
+          style={{
+            position: 'absolute',
+            left: `${position[0]}px`,
+            top: `${position[1]}px`,
+            zIndex: 99,
+            opacity: palette.show === 1 ? 1 : 0,
+          }}
+        >
+          <h4>Theme</h4>
+          <ItemWrapper>
+            <button
+              type="button"
+              onClick={() => toggleTheme()}
+              disabled={mode === 'light'}
+            >
+              <SunnyOutlineSVG width="1.65rem" height="1.65rem" />
+            </button>
+            <button
+              type="button"
+              onClick={() => toggleTheme()}
+              disabled={mode === 'dark'}
+            >
+              <MoonOutlineSVG width="1.25rem" height="1.25rem" />
+            </button>
+          </ItemWrapper>
+          <h4>Card Style</h4>
+          <ItemWrapper>
+            <button type="button" onClick={() => {}}>
+              <FontAwesomeIcon icon={faSquare} />
+            </button>
+            <button type="button" onClick={() => {}}>
+              <FontAwesomeIcon icon={faSquareRegular as IconProp} />
+            </button>
+            <button type="button" onClick={() => {}}>
+              <FontAwesomeIcon icon={faSquare} />
+            </button>
+          </ItemWrapper>
+        </Wrapper>
+      )}
+    </>
+  );
+};
+
+export default Palette;

--- a/src/library/Palette/index.tsx
+++ b/src/library/Palette/index.tsx
@@ -14,7 +14,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { Wrapper, ItemWrapper } from './Wrappers';
 
 export const Palette = () => {
-  const { mode, toggleTheme } = useTheme();
+  const { mode, card, toggleTheme, toggleCard } = useTheme();
   const palette = usePalette();
   const { position } = palette;
 
@@ -78,13 +78,25 @@ export const Palette = () => {
           </ItemWrapper>
           <h4>Card Style</h4>
           <ItemWrapper>
-            <button type="button" onClick={() => {}}>
-              <FontAwesomeIcon icon={faSquare} />
+            <button
+              type="button"
+              onClick={() => toggleCard('flat')}
+              disabled={card === 'flat'}
+            >
+              &nbsp;
             </button>
-            <button type="button" onClick={() => {}}>
+            <button
+              type="button"
+              onClick={() => toggleCard('border')}
+              disabled={card === 'border'}
+            >
               <FontAwesomeIcon icon={faSquareRegular as IconProp} />
             </button>
-            <button type="button" onClick={() => {}}>
+            <button
+              type="button"
+              onClick={() => toggleCard('shadow')}
+              disabled={card === 'shadow'}
+            >
               <FontAwesomeIcon icon={faSquare} />
             </button>
           </ItemWrapper>

--- a/src/library/SideMenu/Wrapper.ts
+++ b/src/library/SideMenu/Wrapper.ts
@@ -50,6 +50,7 @@ export const Wrapper = styled.div<any>`
       padding-top: 0.5rem;
 
       button {
+        position: relative;
         color: ${textSecondary};
         transition: color 0.2s;
         margin-right: ${(props) => (props.minimised ? 0 : '0.1rem')};
@@ -160,6 +161,12 @@ export const MinimisedItemWrapper = styled(motion.div)`
       }
     }
   }
+`;
+
+export const PalettePosition = styled.div`
+  position: absolute;
+  right: 10px;
+  top: -150px;
 `;
 
 export default Wrapper;

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -4,38 +4,38 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExpandAlt, faCompressAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExpandAlt,
+  faCompressAlt,
+  faPalette,
+} from '@fortawesome/free-solid-svg-icons';
 import throttle from 'lodash.throttle';
 import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
-import { useTheme } from 'contexts/Themes';
 import { useModal } from 'contexts/Modal';
 import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
 import { useStaking } from 'contexts/Staking';
-import { ReactComponent as PolkadotLogoSVG } from 'img/polkadot_logo.svg';
-import { ReactComponent as PolkadotIconSVG } from 'img/polkadot_icon.svg';
 import { ReactComponent as CogOutlineSVG } from 'img/cog-outline.svg';
 import { ReactComponent as LogoGithubSVG } from 'img/logo-github.svg';
-import { ReactComponent as MoonOutlineSVG } from 'img/moon-outline.svg';
-import { ReactComponent as SunnyOutlineSVG } from 'img/sunny-outline.svg';
 import { URI_PREFIX, POLKADOT_URL, SIDE_MENU_STICKY_THRESHOLD } from 'consts';
 import { useOutsideAlerter } from 'library/Hooks';
 import { APIContextInterface } from 'types/api';
 import { PAGE_CATEGORIES, PAGES_CONFIG } from 'config/pages';
 import { ConnectContextInterface } from 'types/connect';
+import { usePalette } from 'contexts/Palette';
 import Item from './Item';
 import Heading from './Heading';
-import { Wrapper, LogoWrapper } from './Wrapper';
+import { Wrapper, LogoWrapper, PalettePosition } from './Wrapper';
 
 export const SideMenu = () => {
   const { network } = useApi() as APIContextInterface;
   const { openModalWith } = useModal();
-  const { mode, toggleTheme } = useTheme();
   const { activeAccount, accounts } = useConnect() as ConnectContextInterface;
   const { pathname }: any = useLocation();
   const { getBondedAccount }: any = useBalances();
   const { getControllerNotImported } = useStaking();
+  const { setPalettePosition, open }: any = usePalette();
   const controller = getBondedAccount(activeAccount);
   const {
     isSyncing,
@@ -104,6 +104,14 @@ export const SideMenu = () => {
     );
   }
 
+  // toggle palette
+  const posRef = useRef(null);
+  const togglePalette = () => {
+    if (!open) {
+      setPalettePosition(posRef);
+    }
+  };
+
   return (
     <Wrapper ref={ref} minimised={sideMenuMinimised}>
       <section>
@@ -169,6 +177,17 @@ export const SideMenu = () => {
         <button
           type="button"
           onClick={() =>
+            setUserSideMenuMinimised(userSideMenuMinimised ? 0 : 1)
+          }
+        >
+          <FontAwesomeIcon
+            icon={userSideMenuMinimised ? faExpandAlt : faCompressAlt}
+            transform="grow-3"
+          />
+        </button>
+        <button
+          type="button"
+          onClick={() =>
             window.open(
               'https://github.com/rossbulat/polkadot-staking-experience',
               '_blank'
@@ -183,23 +202,9 @@ export const SideMenu = () => {
         >
           <CogOutlineSVG width="1.65rem" height="1.65rem" />
         </button>
-        <button type="button" onClick={() => toggleTheme()}>
-          {mode === 'light' ? (
-            <SunnyOutlineSVG width="1.65rem" height="1.65rem" />
-          ) : (
-            <MoonOutlineSVG width="1.45rem" height="1.45rem" />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() =>
-            setUserSideMenuMinimised(userSideMenuMinimised ? 0 : 1)
-          }
-        >
-          <FontAwesomeIcon
-            icon={userSideMenuMinimised ? faExpandAlt : faCompressAlt}
-            transform="grow-3"
-          />
+        <button type="button" onClick={() => togglePalette()}>
+          <PalettePosition ref={posRef} />
+          <FontAwesomeIcon icon={faPalette} transform="grow-5" />
         </button>
       </section>
     </Wrapper>

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -45,7 +45,15 @@ export const ValidatorMetrics = () => {
         </h1>
       </div>
       <div className="body">
-        <GraphWrapper style={{ margin: '0 0.5rem', height: 275 }} flex>
+        <GraphWrapper
+          style={{
+            margin: '0 0.5rem',
+            height: 275,
+            border: 'none',
+            boxShadow: 'none',
+          }}
+          flex
+        >
           <h4>Recent Era Points</h4>
           <div className="inner" ref={ref} style={{ minHeight }}>
             <StatusLabel

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -1,6 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// configure theme
 const v = (light: string, dark: string) => ({
   light,
   dark,
@@ -87,6 +88,19 @@ export const defaultThemes: any = {
     foreground: v('#e1e1e1', '#151515'),
     background: v('#dadada', '#101010'),
   },
+  shadow: v('#eaeaea', '#181818'),
 };
 
-export default defaultThemes;
+// configure card style
+const c = (flat: string, border: string, shadow: string) => ({
+  flat,
+  border,
+  shadow,
+});
+
+export const cardThemes: any = {
+  card: {
+    border: c('none', '1px solid', 'none'),
+    shadow: c('none', 'none', '-2px 2px 26px'),
+  },
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import theme from 'styled-theming';
-import { defaultThemes } from './default';
+import { defaultThemes, cardThemes } from './default';
 
 /* Aggregates all theme configurations and serves the currently
  * active mode via the theming context.
@@ -165,3 +165,13 @@ export const assistantLink: theme.ThemeSet = theme(
   v,
   defaultThemes.assistant.link
 );
+
+// shadow
+
+export const shadowColor: theme.ThemeSet = theme(v, defaultThemes.shadow);
+
+const c = 'card';
+
+export const cardBorder: theme.ThemeSet = theme(c, cardThemes.card.border);
+
+export const cardShadow: theme.ThemeSet = theme(c, cardThemes.card.shadow);


### PR DESCRIPTION
This PR adds a palette for theming the dashboard, and introduces multi-dimensional theming in the form of card styles.

Cards have been flat, but users now have the option of either having a bordered or shadowed cards:

<img width="539" alt="Screenshot 2022-06-14 at 12 41 35" src="https://user-images.githubusercontent.com/13929023/173569244-d96a5f13-2991-4958-a90f-308f40078831.png">