### PR TITLE
Rb enhance select controller

### DIFF
--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -13,7 +13,6 @@ import { Option } from '@polkadot/types-codec';
 import { useNetworkMetrics } from 'contexts/Network';
 import { APIContextInterface } from 'types/api';
 import { rmCommas, setStateWithRef } from 'Utils';
-
 import {
   BalanceLedger,
   BalancesAccount,
@@ -482,8 +481,8 @@ export const BalancesProvider = ({
         getAccountNominations,
         getBondOptions,
         isController,
-        accounts: accountsRef.current,
         minReserve,
+        accounts: accountsRef.current,
         ledgers: ledgersRef.current,
       }}
     >

--- a/src/library/Form/AccountDropdown/Wrappers.ts
+++ b/src/library/Form/AccountDropdown/Wrappers.ts
@@ -7,6 +7,7 @@ import {
   textPrimary,
   backgroundDropdown,
   textSecondary,
+  borderSecondary,
 } from 'theme';
 
 export const StyledDownshift = styled.div`
@@ -107,6 +108,14 @@ export const StyledDropdown = styled.div<any>`
       align-items: center;
 
       .icon {
+        margin-right: 0.5rem;
+      }
+      span {
+        color: ${textSecondary};
+        border: 1px solid ${borderSecondary};
+        border-radius: 0.5rem;
+        padding: 0.2rem 0.5rem;
+        font-size: 0.9rem;
         margin-right: 0.5rem;
       }
       p {

--- a/src/library/Form/AccountDropdown/index.tsx
+++ b/src/library/Form/AccountDropdown/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes, faAnglesRight } from '@fortawesome/free-solid-svg-icons';
 import { useCombobox, UseComboboxStateChange } from 'downshift';
@@ -17,6 +17,10 @@ import { AccountDropdownProps, InputItem } from '../types';
 export const AccountDropdown = (props: AccountDropdownProps) => {
   const { items, onChange, placeholder, value, current, height } = props;
 
+  useEffect(() => {
+    setInputItems(items);
+  }, [items]);
+
   const itemToString = (item: InputItem) => {
     const name = item?.name ?? '';
     return name;
@@ -24,7 +28,6 @@ export const AccountDropdown = (props: AccountDropdownProps) => {
 
   // store input items
   const [inputItems, setInputItems] = useState<Array<InputItem>>(items);
-
   const c = useCombobox({
     items: inputItems,
     itemToString,
@@ -118,15 +121,23 @@ const DropdownItem = ({ c, item, index }: any) => {
     border = `2px solid ${defaultThemes.transparent[mode]}`;
   }
 
+  // disable item in list if account doesn't satisfy controller budget.
+  const itemProps = item.active
+    ? c.getItemProps({ key: item.name, index, item })
+    : {};
+  const opacity = item.active ? 1 : 0.5;
+  const cursor = item.active ? 'pointer' : 'default';
+
   return (
     <div
       className="item"
-      {...c.getItemProps({ key: item.name, index, item })}
-      style={{ color, border }}
+      {...itemProps}
+      style={{ color, border, opacity, cursor }}
     >
       <div className="icon">
         <Identicon value={item.address} size={26} />
       </div>
+      {!item.active && <span>Not Enough {network.unit}</span>}
       <p>{item.name}</p>
     </div>
   );

--- a/src/library/Form/Utils/getEligibleControllers.tsx
+++ b/src/library/Form/Utils/getEligibleControllers.tsx
@@ -26,8 +26,12 @@ export const getEligibleControllers = (): Array<InputItem> => {
   }, [activeAccount, connectAccounts]);
 
   const filterAccounts = () => {
-    // filter items that are already controller accounts
+    // remove read only accounts
     let _accounts = connectAccounts.filter((acc: ImportedAccount) => {
+      return acc?.source !== 'external';
+    });
+    // filter items that are already controller accounts
+    _accounts = _accounts.filter((acc: ImportedAccount) => {
       return !isController(acc?.address ?? null);
     });
 

--- a/src/library/Form/Utils/getEligibleControllers.tsx
+++ b/src/library/Form/Utils/getEligibleControllers.tsx
@@ -1,0 +1,62 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import BN from 'bn.js';
+import { useApi } from 'contexts/Api';
+import { useBalances } from 'contexts/Balances';
+import { APIContextInterface } from 'types/api';
+import { BalancesContextInterface } from 'types/balances';
+import { ConnectContextInterface, ImportedAccount } from 'types/connect';
+import { planckBnToUnit } from 'Utils';
+import { useConnect } from 'contexts/Connect';
+
+export const getEligibleControllers = () => {
+  const { network } = useApi() as APIContextInterface;
+  const { activeAccount, accounts: connectAccounts } =
+    useConnect() as ConnectContextInterface;
+  const { isController, getAccountBalance, minReserve } =
+    useBalances() as BalancesContextInterface;
+
+  const [accounts, setAccounts] = useState<any>([]);
+
+  useEffect(() => {
+    setAccounts(filterAccounts());
+  }, [activeAccount, connectAccounts]);
+
+  const filterAccounts = () => {
+    // filter items that are already controller accounts
+    let _accounts = connectAccounts.filter((acc: ImportedAccount) => {
+      return !isController(acc?.address ?? null);
+    });
+
+    // remove active account from eligible accounts
+    _accounts = _accounts.filter(
+      (acc: ImportedAccount) => acc.address !== activeAccount
+    );
+
+    // inject balances and whether account can be an active item
+    let _accountsAsInput = _accounts.map((acc: ImportedAccount) => {
+      const balance = getAccountBalance(acc?.address ?? null);
+      return {
+        ...acc,
+        balance,
+        active:
+          planckBnToUnit(balance.free, network.units) >=
+          planckBnToUnit(minReserve, network.units),
+        alert: `Not Enough ${network.unit}`,
+      };
+    });
+
+    // sort accounts with at least free balance first
+    _accountsAsInput = _accountsAsInput.sort((a: any, b: any) => {
+      const aFree = a?.balance?.free ?? new BN(0);
+      const bFree = b?.balance?.free ?? new BN(0);
+      return bFree.sub(aFree).toNumber();
+    });
+
+    return _accountsAsInput;
+  };
+
+  return accounts;
+};

--- a/src/library/Form/Utils/getEligibleControllers.tsx
+++ b/src/library/Form/Utils/getEligibleControllers.tsx
@@ -10,15 +10,16 @@ import { BalancesContextInterface } from 'types/balances';
 import { ConnectContextInterface, ImportedAccount } from 'types/connect';
 import { planckBnToUnit } from 'Utils';
 import { useConnect } from 'contexts/Connect';
+import { InputItem } from '../types';
 
-export const getEligibleControllers = () => {
+export const getEligibleControllers = (): Array<InputItem> => {
   const { network } = useApi() as APIContextInterface;
   const { activeAccount, accounts: connectAccounts } =
     useConnect() as ConnectContextInterface;
   const { isController, getAccountBalance, minReserve } =
     useBalances() as BalancesContextInterface;
 
-  const [accounts, setAccounts] = useState<any>([]);
+  const [accounts, setAccounts] = useState<Array<InputItem>>([]);
 
   useEffect(() => {
     setAccounts(filterAccounts());
@@ -36,20 +37,22 @@ export const getEligibleControllers = () => {
     );
 
     // inject balances and whether account can be an active item
-    let _accountsAsInput = _accounts.map((acc: ImportedAccount) => {
-      const balance = getAccountBalance(acc?.address ?? null);
-      return {
-        ...acc,
-        balance,
-        active:
-          planckBnToUnit(balance.free, network.units) >=
-          planckBnToUnit(minReserve, network.units),
-        alert: `Not Enough ${network.unit}`,
-      };
-    });
+    let _accountsAsInput: Array<InputItem> = _accounts.map(
+      (acc: ImportedAccount) => {
+        const balance = getAccountBalance(acc?.address ?? null);
+        return {
+          ...acc,
+          balance,
+          active:
+            planckBnToUnit(balance.free, network.units) >=
+            planckBnToUnit(minReserve, network.units),
+          alert: `Not Enough ${network.unit}`,
+        };
+      }
+    );
 
     // sort accounts with at least free balance first
-    _accountsAsInput = _accountsAsInput.sort((a: any, b: any) => {
+    _accountsAsInput = _accountsAsInput.sort((a: InputItem, b: InputItem) => {
       const aFree = a?.balance?.free ?? new BN(0);
       const bFree = b?.balance?.free ?? new BN(0);
       return bFree.sub(aFree).toNumber();

--- a/src/library/Form/types.ts
+++ b/src/library/Form/types.ts
@@ -1,9 +1,23 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ImportedAccount } from 'types/connect';
+import { ExternalAccount } from 'types/connect';
+import { WalletAccount } from '@talisman-connect/wallets';
+import { Balance } from 'types/balances';
 
-export type InputItem = ImportedAccount | null;
+export interface WalletAccountItem extends WalletAccount {
+  active?: boolean;
+  alert?: string;
+  balance?: Balance;
+}
+export interface ExternalAccountItem extends ExternalAccount {
+  active?: boolean;
+  alert?: string;
+  balance?: Balance;
+}
+export type ImportedAccountItem = WalletAccountItem | ExternalAccountItem;
+
+export type InputItem = ImportedAccountItem | null;
 
 export interface DropdownInput {
   key: string;
@@ -20,7 +34,7 @@ export interface AccountDropdownProps {
 }
 
 export interface AccountSelectProps {
-  items: Array<ImportedAccount>;
+  items: Array<InputItem>;
   onChange: (o: any) => void;
   placeholder: string;
   value: InputItem;

--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -14,15 +14,16 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { getEligibleControllers } from 'library/Form/Utils/getEligibleControllers';
 import { useApi } from 'contexts/Api';
 import { APIContextInterface } from 'types/api';
-import { ConnectContextInterface } from 'types/connect';
+import { ConnectContextInterface, ImportedAccount } from 'types/connect';
 import { BalancesContextInterface } from 'types/balances';
 import { Warning } from 'library/Form/Warning';
+import { InputItem } from 'library/Form/types';
 import { HeadingWrapper, FooterWrapper, NotesWrapper } from '../Wrappers';
 import Wrapper from './Wrapper';
 
 export const UpdateController = () => {
   const { api } = useApi() as APIContextInterface;
-  const { setStatus: setModalStatus }: any = useModal();
+  const { setStatus: setModalStatus } = useModal();
   const { activeAccount, getAccount, accountHasSigner } =
     useConnect() as ConnectContextInterface;
   const { getBondedAccount } = useBalances() as BalancesContextInterface;
@@ -30,7 +31,7 @@ export const UpdateController = () => {
   const account = getAccount(controller);
 
   // the selected value in the form
-  const [selected, setSelected]: any = useState(null);
+  const [selected, setSelected] = useState<ImportedAccount | null>(null);
 
   // get eligible controller accounts
   const items = getEligibleControllers();
@@ -41,7 +42,7 @@ export const UpdateController = () => {
   }, [activeAccount, items]);
 
   // handle account selection change
-  const handleOnChange = ({ selectedItem }: any) => {
+  const handleOnChange = ({ selectedItem }: { selectedItem: InputItem }) => {
     setSelected(selectedItem);
   };
 

--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -11,6 +11,7 @@ import { AccountDropdown } from 'library/Form/AccountDropdown';
 import { useBalances } from 'contexts/Balances';
 import { useModal } from 'contexts/Modal';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
+import { getEligibleControllers } from 'library/Form/Utils/getEligibleControllers';
 import { useApi } from 'contexts/Api';
 import { APIContextInterface } from 'types/api';
 import { ConnectContextInterface } from 'types/connect';
@@ -22,20 +23,22 @@ import Wrapper from './Wrapper';
 export const UpdateController = () => {
   const { api } = useApi() as APIContextInterface;
   const { setStatus: setModalStatus }: any = useModal();
-  const { accounts, activeAccount, getAccount, accountHasSigner } =
+  const { activeAccount, getAccount, accountHasSigner } =
     useConnect() as ConnectContextInterface;
-  const { getBondedAccount, isController } =
-    useBalances() as BalancesContextInterface;
+  const { getBondedAccount } = useBalances() as BalancesContextInterface;
   const controller = getBondedAccount(activeAccount);
   const account = getAccount(controller);
 
   // the selected value in the form
   const [selected, setSelected]: any = useState(null);
 
+  // get eligible controller accounts
+  const items = getEligibleControllers();
+
   // reset selected value on account change
   useEffect(() => {
     setSelected(null);
-  }, [activeAccount]);
+  }, [activeAccount, items]);
 
   // handle account selection change
   const handleOnChange = ({ selectedItem }: any) => {
@@ -66,11 +69,6 @@ export const UpdateController = () => {
     callbackInBlock: () => {},
   });
 
-  // remove active controller from selectable items
-  const accountsList = accounts.filter((acc: any) => {
-    return acc.address !== activeAccount && !isController(acc.address);
-  });
-
   return (
     <Wrapper>
       <HeadingWrapper>
@@ -86,9 +84,7 @@ export const UpdateController = () => {
           )}
         </div>
         <AccountDropdown
-          items={accountsList.filter(
-            (acc: any) => acc.address !== activeAccount
-          )}
+          items={items}
           onChange={handleOnChange}
           placeholder="Search Account"
           current={account}

--- a/src/pages/Stake/Setup/SetController.tsx
+++ b/src/pages/Stake/Setup/SetController.tsx
@@ -2,15 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';
-import { useApi } from 'contexts/Api';
-import { useBalances } from 'contexts/Balances';
 import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
 import { AccountSelect } from 'library/Form/AccountSelect';
-import { planckToUnit } from 'Utils';
-import { APIContextInterface } from 'types/api';
 import { ConnectContextInterface } from 'types/connect';
-import { BalancesContextInterface } from 'types/balances';
+import { getEligibleControllers } from 'library/Form/Utils/getEligibleControllers';
 import { Header } from './Header';
 import { Footer } from './Footer';
 import { Spacer } from '../Wrappers';
@@ -19,18 +15,17 @@ import { MotionContainer } from './MotionContainer';
 export const SetController = (props: any) => {
   const { section } = props;
 
-  const { network } = useApi() as APIContextInterface;
-  const { units } = network;
   const { activeAccount, accounts, getAccount } =
     useConnect() as ConnectContextInterface;
-  const { getAccountBalance, minReserve, isController } =
-    useBalances() as BalancesContextInterface;
   const { getSetupProgress, setActiveAccountSetup } = useUi();
   const setup = getSetupProgress(activeAccount);
 
   // store the currently selected controller account
   const _selected = setup.controller !== null ? setup.controller : null;
   const [selected, setSelected] = useState<any>(getAccount(_selected));
+
+  // get eligible controllers for input
+  const items = getEligibleControllers();
 
   // update selected value on account switch
   useEffect(() => {
@@ -47,31 +42,6 @@ export const SetController = (props: any) => {
       controller: selectedItem?.address ?? null,
     });
   };
-
-  // filter items that are already controller accounts
-  let items = accounts.filter((acc: any) => {
-    return !isController(acc.address);
-  });
-
-  // inject balances and whether account can be an active item
-  items = items.filter((acc: any) => acc.address !== activeAccount);
-  items = items.map((acc: any) => {
-    const balance = getAccountBalance(acc.address);
-
-    return {
-      ...acc,
-      balance,
-      active:
-        planckToUnit(balance.free.toNumber(), units) >=
-        planckToUnit(minReserve.toNumber(), units),
-      alert: `Not Enough ${network.unit}`,
-    };
-  });
-
-  // sort accounts with at least free balance first
-  items = items.sort((a: any, b: any) => {
-    return b.balance.free.sub(a.balance.free).toNumber();
-  });
 
   return (
     <>

--- a/src/pages/Stake/Setup/SetController.tsx
+++ b/src/pages/Stake/Setup/SetController.tsx
@@ -5,8 +5,9 @@ import { useState, useEffect } from 'react';
 import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
 import { AccountSelect } from 'library/Form/AccountSelect';
-import { ConnectContextInterface } from 'types/connect';
+import { ConnectContextInterface, ImportedAccount } from 'types/connect';
 import { getEligibleControllers } from 'library/Form/Utils/getEligibleControllers';
+import { InputItem } from 'library/Form/types';
 import { Header } from './Header';
 import { Footer } from './Footer';
 import { Spacer } from '../Wrappers';
@@ -22,7 +23,9 @@ export const SetController = (props: any) => {
 
   // store the currently selected controller account
   const _selected = setup.controller !== null ? setup.controller : null;
-  const [selected, setSelected] = useState<any>(getAccount(_selected));
+  const [selected, setSelected] = useState<ImportedAccount | null>(
+    getAccount(_selected)
+  );
 
   // get eligible controllers for input
   const items = getEligibleControllers();
@@ -35,7 +38,7 @@ export const SetController = (props: any) => {
     setSelected(_initial);
   }, [activeAccount, accounts]);
 
-  const handleOnChange = ({ selectedItem }: any) => {
+  const handleOnChange = ({ selectedItem }: { selectedItem: InputItem }) => {
     setSelected(selectedItem);
     setActiveAccountSetup({
       ...setup,


### PR DESCRIPTION
Introduces a `getEligibleControllers` hook, and ensures the `UpdateController` modal only allows accounts that are eligible (have ED, not already controller).

Accounts are ordered by whether they have ED and available as controllers, and disabled otherwise. `UpdateController`:

<img width="879" alt="Screenshot 2022-06-27 at 10 04 19" src="https://user-images.githubusercontent.com/13929023/175902454-6028347d-7f4f-40d6-a5f3-fd8a9d077cb1.png">