### PR TITLE
Add Expected Value to Moving Average Graph

### DIFF
--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -48,6 +48,8 @@ export const defaultStakingContext: StakingContextInterface = {
   // eslint-disable-next-line
   getControllerNotImported: (a) => null,
   isBonding: () => false,
+  bondedAmount: () => new BN(0),
+  estimatedYearlyRewards: () => 0,
   isNominating: () => false,
   inSetup: () => true,
   staking: stakingMetrics,

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -20,6 +20,8 @@ import {
   StakingMetrics,
   StakingTargets,
 } from 'contexts/Staking/types';
+import useInflation from 'library/Hooks/useInflation';
+
 import { useApi } from '../Api';
 import { useNetworkMetrics } from '../Network';
 import { useBalances } from '../Balances';
@@ -54,6 +56,9 @@ export const StakingProvider = ({
   } = useBalances();
   const { units } = network;
   const { maxNominatorRewardedPerValidator } = consts;
+  const { stakedReturn } = useInflation();
+
+  console.log('shawn stk', stakedReturn);
 
   // store staking metrics in state
   const [stakingMetrics, setStakingMetrics] = useState<StakingMetrics>(
@@ -378,6 +383,29 @@ export const StakingProvider = ({
   };
 
   /*
+   * Helper function to determine how much the active account
+   * has bonded.
+   */
+  const bondedAmount = () => {
+    if (!hasController() || !activeAccount) {
+      return new BN(0);
+    }
+
+    const ledger = getLedgerForStash(activeAccount);
+    return ledger.active;
+  };
+
+  /*
+   * Helper function to determine how much the active account
+   * is expected to receive in yearly rewards
+   */
+  const estimatedYearlyRewards = () => {
+    console.log('shawn', stakedReturn, bondedAmount().toString());
+    const numAmount = planckBnToUnit(bondedAmount(), units);
+    return (stakedReturn / 100) * numAmount;
+  };
+
+  /*
    * Helper function to determine whether the active account
    * has funds unlocking.
    */
@@ -420,6 +448,8 @@ export const StakingProvider = ({
         hasController,
         getControllerNotImported,
         isBonding,
+        bondedAmount,
+        estimatedYearlyRewards,
         isNominating,
         inSetup,
         staking: stakingMetrics,

--- a/src/contexts/Staking/types.ts
+++ b/src/contexts/Staking/types.ts
@@ -40,6 +40,8 @@ export interface StakingContextInterface {
   hasController: () => boolean;
   getControllerNotImported: (a: MaybeAccount) => any;
   isBonding: () => boolean;
+  bondedAmount: () => BN;
+  estimatedYearlyRewards: () => number;
   isNominating: () => boolean;
   inSetup: () => any;
   staking: StakingMetrics;

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -40,7 +40,7 @@ ChartJS.register(
 );
 
 export const PayoutLine = (props: PayoutLineProps) => {
-  const { days, average, height, background } = props;
+  const { days, average, height, background, expected } = props;
 
   const { mode } = useTheme();
   const { network } = useApi();
@@ -63,6 +63,17 @@ export const PayoutLine = (props: PayoutLineProps) => {
 
   // combine payouts and pool claims into one dataset
   const combinedPayouts = combineRewardsByDay(payoutsByDay, poolClaimsByDay);
+
+  // create an expected value graph
+  const expectedValue = [];
+  if (expected) {
+    for (const payout of combinedPayouts) {
+      expectedValue.push({
+        amount: expected,
+        block_timestamp: payout.block_timestamp,
+      });
+    }
+  }
 
   // determine color for payouts
   const color = notStaking
@@ -146,6 +157,18 @@ export const PayoutLine = (props: PayoutLineProps) => {
           return item?.amount ?? 0;
         }),
         borderColor: color,
+        backgroundColor: color,
+        pointStyle: undefined,
+        pointRadius: 0,
+        borderWidth: 2,
+      },
+      {
+        label: 'Expected',
+        data: expectedValue.map((item: AnySubscan) => {
+          return item?.amount ?? 0;
+        }),
+        borderDash: [10, 5],
+        borderColor: 'grey',
         backgroundColor: color,
         pointStyle: undefined,
         pointRadius: 0,

--- a/src/library/Graphs/types.ts
+++ b/src/library/Graphs/types.ts
@@ -26,6 +26,7 @@ export interface PayoutLineProps {
   average: number;
   height: string;
   background?: string;
+  expected?: number;
 }
 
 export interface StatPieProps {

--- a/src/pages/Overview/Payouts.tsx
+++ b/src/pages/Overview/Payouts.tsx
@@ -8,16 +8,31 @@ import { PayoutBar } from 'library/Graphs/PayoutBar';
 import { useSize, formatSize } from 'library/Graphs/Utils';
 import { StatusLabel } from 'library/StatusLabel';
 import { useStaking } from 'contexts/Staking';
+import useInflation from 'library/Hooks/useInflation';
+import { useConnect } from 'contexts/Connect';
+import { planckBnToUnit, humanNumber } from 'Utils';
+import { useApi } from 'contexts/Api';
+import { useBalances } from 'contexts/Balances';
+import BN from 'bn.js';
 
 export const Payouts = () => {
+  const { network } = useApi();
+  const { units } = network;
   const { isSyncing, services } = useUi();
   const { inSetup } = useStaking();
   const notStaking = !isSyncing && inSetup();
+  const { stakedReturn } = useInflation();
+  const { activeAccount } = useConnect();
+  const { getLedgerForStash } = useBalances();
+  const ledger = getLedgerForStash(activeAccount);
+  const { active }: { active: BN } = ledger;
 
   const ref = React.useRef<HTMLDivElement>(null);
 
   const size = useSize(ref.current);
   const { width, height, minHeight } = formatSize(size, 306);
+
+  const bondedAmount = planckBnToUnit(active, units);
 
   return (
     <div className="inner" ref={ref} style={{ minHeight }}>
@@ -48,7 +63,12 @@ export const Payouts = () => {
       >
         <PayoutBar days={19} height="180px" />
         <div style={{ marginTop: '1rem' }}>
-          <PayoutLine days={19} average={10} height="90px" />
+          <PayoutLine
+            days={19}
+            average={10}
+            height="90px"
+            expected={((stakedReturn / 100) * bondedAmount) / 365}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/Overview/Payouts.tsx
+++ b/src/pages/Overview/Payouts.tsx
@@ -8,31 +8,18 @@ import { PayoutBar } from 'library/Graphs/PayoutBar';
 import { useSize, formatSize } from 'library/Graphs/Utils';
 import { StatusLabel } from 'library/StatusLabel';
 import { useStaking } from 'contexts/Staking';
-import useInflation from 'library/Hooks/useInflation';
-import { useConnect } from 'contexts/Connect';
-import { planckBnToUnit, humanNumber } from 'Utils';
-import { useApi } from 'contexts/Api';
-import { useBalances } from 'contexts/Balances';
-import BN from 'bn.js';
 
 export const Payouts = () => {
-  const { network } = useApi();
-  const { units } = network;
   const { isSyncing, services } = useUi();
-  const { inSetup } = useStaking();
+  const { inSetup, estimatedYearlyRewards } = useStaking();
   const notStaking = !isSyncing && inSetup();
-  const { stakedReturn } = useInflation();
-  const { activeAccount } = useConnect();
-  const { getLedgerForStash } = useBalances();
-  const ledger = getLedgerForStash(activeAccount);
-  const { active }: { active: BN } = ledger;
 
   const ref = React.useRef<HTMLDivElement>(null);
 
   const size = useSize(ref.current);
   const { width, height, minHeight } = formatSize(size, 306);
 
-  const bondedAmount = planckBnToUnit(active, units);
+  console.log('hi shawn', estimatedYearlyRewards());
 
   return (
     <div className="inner" ref={ref} style={{ minHeight }}>
@@ -67,7 +54,7 @@ export const Payouts = () => {
             days={19}
             average={10}
             height="90px"
-            expected={((stakedReturn / 100) * bondedAmount) / 365}
+            expected={estimatedYearlyRewards() / 365}
           />
         </div>
       </div>


### PR DESCRIPTION
Doesn't work for whatever reason. `stakedReturn` returns 0

When working, looks something like:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/1860335/185768443-7fd6abcd-6a3c-48c6-a8a5-9b5192f5f7e4.png">
