### PR TITLE
Nomination pool fixes + additional features

### DIFF
--- a/src/contexts/Pools/ActivePool/defaults.ts
+++ b/src/contexts/Pools/ActivePool/defaults.ts
@@ -25,7 +25,6 @@ export const activeBondedPool: ActiveBondedPool = {
   memberCounter: '0',
   points: '0',
   state: PoolState.Open,
-  slashingSpansCount: 0,
 };
 
 export const targets = {

--- a/src/contexts/Pools/ActivePool/defaults.ts
+++ b/src/contexts/Pools/ActivePool/defaults.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BN } from 'bn.js';
-import { MaybeAccount } from 'types';
+import { MaybeAccount, Sync } from 'types';
 import { ActiveBondedPool, ActivePoolContextState, PoolState } from '../types';
 
 export const nominationStatus = {};
@@ -64,5 +64,5 @@ export const defaultActivePoolContext: ActivePoolContextState = {
   activeBondedPool,
   targets,
   poolNominations,
-  synced: false,
+  synced: Sync.Unsynced,
 };

--- a/src/contexts/Pools/ActivePool/index.tsx
+++ b/src/contexts/Pools/ActivePool/index.tsx
@@ -465,10 +465,11 @@ export const ActivePoolProvider = ({
       .add(totalRewardsClaimed)
       .sub(lastRecordedTotalPayouts);
 
-    const currentRewardCounter = payoutsSinceLastRecord
-      .mul(rewardCounterBase)
-      .div(bondedPoolPoints)
-      .add(poolLastRecordedRewardCounter);
+    const currentRewardCounter = (
+      bondedPoolPoints.eq(new BN(0))
+        ? new BN(0)
+        : payoutsSinceLastRecord.mul(rewardCounterBase).div(bondedPoolPoints)
+    ).add(poolLastRecordedRewardCounter);
 
     const pendingRewards = currentRewardCounter
       .sub(memberLastRecordedRewardCounter)

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -12,6 +12,8 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   getPoolNominationStatus: (n, o) => {},
   // eslint-disable-next-line
   getPoolNominationStatusCode: (t) => '',
+  // eslint-disable-next-line
+   poolSearchFilter: (l, k, v) => {},
   bondedPools: [],
   meta: {},
 };

--- a/src/contexts/Pools/PoolMembers/defaults.ts
+++ b/src/contexts/Pools/PoolMembers/defaults.ts
@@ -10,6 +10,8 @@ export const defaultPoolMembers: PoolMemberContext = {
   getMembersOfPool: (p) => {},
   // eslint-disable-next-line
   getPoolMember: (w) => null,
+  // eslint-disable-next-line
+  removePoolMember: (w) => {},
   poolMembers: [],
   meta: {},
 };

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { PoolMemberContext } from 'contexts/Pools/types';
 import { AnyApi, AnyMetaBatch, Fn, MaybeAccount } from 'types';
 import { setStateWithRef } from 'Utils';
+import { useConnect } from 'contexts/Connect';
 import { defaultPoolMembers } from './defaults';
 import { useApi } from '../../Api';
 import { usePoolsConfig } from '../PoolsConfig';
@@ -20,6 +21,7 @@ export const PoolMembersProvider = ({
   children: React.ReactNode;
 }) => {
   const { api, network, isReady } = useApi();
+  const { activeAccount } = useConnect();
   const { enabled } = usePoolsConfig();
 
   // store pool members
@@ -39,8 +41,13 @@ export const PoolMembersProvider = ({
   // clear existing state for network refresh
   useEffect(() => {
     setPoolMembers([]);
-    setStateWithRef({}, setPoolMembersMetaBatch, poolMembersMetaBatchesRef);
+    unsubscribeAndResetMeta();
   }, [network]);
+
+  // clear meta state when activeAccount changes
+  useEffect(() => {
+    unsubscribeAndResetMeta();
+  }, [activeAccount]);
 
   // initial setup for fetching members
   useEffect(() => {
@@ -54,12 +61,17 @@ export const PoolMembersProvider = ({
   }, [network, isReady, enabled]);
 
   const unsubscribe = () => {
+    unsubscribeAndResetMeta();
+    setPoolMembers([]);
+  };
+
+  const unsubscribeAndResetMeta = () => {
     Object.values(poolMembersSubsRef.current).map((batch: Array<Fn>) => {
       return Object.entries(batch).map(([, v]) => {
         return v();
       });
     });
-    setPoolMembers([]);
+    setStateWithRef({}, setPoolMembersMetaBatch, poolMembersMetaBatchesRef);
   };
 
   // fetch all pool members entries
@@ -70,9 +82,11 @@ export const PoolMembersProvider = ({
     const exposures = _exposures.map(([_keys, _val]: AnyApi) => {
       const who = _keys.toHuman()[0];
       const membership = _val.toHuman();
+      const { poolId } = membership;
+
       return {
-        ...membership,
         who,
+        poolId,
       };
     });
 
@@ -148,6 +162,28 @@ export const PoolMembersProvider = ({
       poolMembersMetaBatchesRef
     );
 
+    const subscribeToPoolMembers = async (addr: string[]) => {
+      const unsub = await api.query.nominationPools.poolMembers.multi<AnyApi>(
+        addr,
+        (_pools) => {
+          const pools = [];
+          for (let i = 0; i < _pools.length; i++) {
+            pools.push(_pools[i].toHuman());
+          }
+          const _batchesUpdated = Object.assign(
+            poolMembersMetaBatchesRef.current
+          );
+          _batchesUpdated[key].poolMembers = pools;
+          setStateWithRef(
+            { ..._batchesUpdated },
+            setPoolMembersMetaBatch,
+            poolMembersMetaBatchesRef
+          );
+        }
+      );
+      return unsub;
+    };
+
     const subscribeToIdentities = async (addr: string[]) => {
       const unsub = await api.query.identity.identityOf.multi<AnyApi>(
         addr,
@@ -221,6 +257,7 @@ export const PoolMembersProvider = ({
     await Promise.all([
       subscribeToIdentities(addresses),
       subscribeToSuperIdentities(addresses),
+      subscribeToPoolMembers(addresses),
     ]).then((unsubs: Array<Fn>) => {
       addMetaBatchUnsubs(key, unsubs);
     });

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -264,6 +264,14 @@ export const PoolMembersProvider = ({
   };
 
   /*
+   * Removes a member from the member list and updates state.
+   */
+  const removePoolMember = (who: MaybeAccount) => {
+    const newMembers = poolMembers.filter((p: any) => p.who !== who);
+    setPoolMembers(newMembers);
+  };
+
+  /*
    * Helper: to add mataBatch unsubs by key.
    */
   const addMetaBatchUnsubs = (key: string, unsubs: Array<Fn>) => {
@@ -280,6 +288,7 @@ export const PoolMembersProvider = ({
         fetchPoolMembersMetaBatch,
         getMembersOfPool,
         getPoolMember,
+        removePoolMember,
         poolMembers,
         meta: poolMembersMetaBatchesRef.current,
       }}

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -56,14 +56,11 @@ export interface BondedPoolsContextState {
   meta: AnyMetaBatch;
 }
 
-export interface ActiveBondedPoolState {
-  pool: ActiveBondedPool | undefined;
-}
+export type ActiveBondedPoolState = ActiveBondedPool | null;
 
 export interface ActiveBondedPool extends BondedPool {
   roles: PoolRoles;
   unclaimedReward: BN;
-  slashingSpansCount: 0;
 }
 
 export interface BondedPool {
@@ -94,7 +91,7 @@ export interface ActivePoolContextState {
   getPoolRoles: () => PoolRoles;
   setTargets: (t: any) => void;
   getNominationsStatus: () => NominationStatuses;
-  activeBondedPool: ActiveBondedPool | undefined;
+  activeBondedPool: ActiveBondedPool | null;
   targets: any;
   poolNominations: any;
   synced: Sync;

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -102,6 +102,7 @@ export interface PoolMemberContext {
   fetchPoolMembersMetaBatch: (k: string, v: [], r: boolean) => void;
   getMembersOfPool: (p: number) => any;
   getPoolMember: (w: MaybeAccount) => any | null;
+  removePoolMember: (w: MaybeAccount) => void;
   poolMembers: any;
   meta: AnyMetaBatch;
 }

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
-import { AnyApi, AnyMetaBatch, MaybeAccount } from 'types';
+import { AnyApi, AnyMetaBatch, MaybeAccount, Sync } from 'types';
 
 // PoolsConfig types
 export interface PoolsConfigContextState {
@@ -97,7 +97,7 @@ export interface ActivePoolContextState {
   activeBondedPool: ActiveBondedPool | undefined;
   targets: any;
   poolNominations: any;
-  synced: boolean;
+  synced: Sync;
 }
 
 // PoolMembers types

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -52,6 +52,7 @@ export interface BondedPoolsContextState {
   getBondedPool: (p: number) => BondedPool | null;
   getPoolNominationStatus: (n: MaybeAccount, o: MaybeAccount) => any;
   getPoolNominationStatusCode: (t: NominationStatuses | null) => string;
+  poolSearchFilter: (l: any, k: string, v: string) => void;
   bondedPools: Array<BondedPool>;
   meta: AnyMetaBatch;
 }

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -6,7 +6,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { SERVICES, SIDE_MENU_STICKY_THRESHOLD } from 'consts';
 import { localStorageOrDefault, setStateWithRef } from 'Utils';
 import { ImportedAccount } from 'contexts/Connect/types';
-import { MaybeAccount } from 'types';
+import { MaybeAccount, Sync } from 'types';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
@@ -163,7 +163,7 @@ export const UIProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     // nomination pool contexts have synced
-    if (poolsEnabled && !activePoolSynced) {
+    if (poolsEnabled && activePoolSynced !== Sync.Synced) {
       syncing = true;
     }
 

--- a/src/library/Button/index.tsx
+++ b/src/library/Button/index.tsx
@@ -12,10 +12,11 @@ import {
 } from 'theme';
 import { ButtonProps, ButtonWrapperProps } from './types';
 
-export const ButtonRow = styled.div`
+export const ButtonRow = styled.div<{ verticalSpacing?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  margin-top: ${(props) => (props.verticalSpacing ? '1rem' : 0)};
 `;
 
 export const Wrapper = styled(motion.div)<ButtonWrapperProps>`

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -22,7 +22,7 @@ export const Connected = () => {
   const { isSyncing } = useUi();
 
   let poolAddress = '';
-  if (activeBondedPool !== undefined) {
+  if (activeBondedPool) {
     const { addresses } = activeBondedPool;
     poolAddress = addresses.stash;
   }
@@ -84,7 +84,7 @@ export const Connected = () => {
           )}
 
           {/* pool account display / hide if not in pool */}
-          {activeBondedPool !== undefined && !isSyncing && (
+          {activeBondedPool !== null && !isSyncing && (
             <HeadingWrapper>
               <PoolAccount
                 value={poolAddress}

--- a/src/library/List/SearchInput.tsx
+++ b/src/library/List/SearchInput.tsx
@@ -1,0 +1,19 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+export const SearchInput = (props: any) => {
+  const { handleChange, placeholder } = props;
+
+  return (
+    <div className="search">
+      <input
+        type="text"
+        className="search"
+        placeholder={placeholder}
+        onChange={(e: React.FormEvent<HTMLInputElement>) => handleChange(e)}
+      />
+    </div>
+  );
+};

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -83,6 +83,9 @@ export const Labels = styled.div`
     &.active {
       color: ${networkColor};
     }
+    &:disabled {
+      opacity: 0.35;
+    }
   }
 
   .label {

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -28,6 +28,7 @@ import { useValidators } from 'contexts/Validators';
 import { FavouritePool } from 'library/ListItem/Labels/FavouritePool';
 import { useUi } from 'contexts/UI';
 import { PoolBonded } from 'library/ListItem/Labels/PoolBonded';
+import { PoolState } from 'contexts/Pools/types';
 import { PoolProps } from './types';
 import { Members } from '../ListItem/Labels/Members';
 import { JoinPool } from '../ListItem/Labels/JoinPool';
@@ -35,7 +36,7 @@ import { PoolId } from '../ListItem/Labels/PoolId';
 
 export const Pool = (props: PoolProps) => {
   const { pool, batchKey, batchIndex } = props;
-  const { memberCounter, addresses, id } = pool;
+  const { memberCounter, addresses, id, state } = pool;
 
   const { openModalWith } = useModal();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -187,6 +188,7 @@ export const Pool = (props: PoolProps) => {
         <div className="row status">
           <PoolBonded pool={pool} batchIndex={batchIndex} batchKey={batchKey} />
           {!isSyncing &&
+            state === PoolState.Open &&
             !isBonding() &&
             !isReadOnlyAccount(activeAccount) &&
             activeAccount && (

--- a/src/library/Pool/types.ts
+++ b/src/library/Pool/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { PoolAddresses } from 'contexts/Pools/types';
+import { PoolAddresses, PoolState } from 'contexts/Pools/types';
 
 export interface PoolProps {
   pool: Pool;
@@ -14,4 +14,5 @@ export interface Pool {
   memberCounter: string;
   addresses: PoolAddresses;
   id: number;
+  state: PoolState;
 }

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -23,6 +23,7 @@ import { PoolListProps } from './types';
 export const PoolListInner = (props: PoolListProps) => {
   const { allowMoreCols, pagination, batchKey }: any = props;
   const disableThrottle = props.disableThrottle ?? false;
+  const allowSearch = props.allowSearch ?? false;
 
   const { mode } = useTheme();
   const { isReady, network } = useApi();
@@ -141,7 +142,7 @@ export const PoolListInner = (props: PoolListProps) => {
         </div>
       </Header>
       <List flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
-        {poolsDefault.length > 0 && (
+        {allowSearch && poolsDefault.length > 0 && (
           <SearchInput
             handleChange={handleSearchChange}
             placeholder="Search Pool Name or Address"

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -16,6 +16,7 @@ import { networkColors } from 'theme/default';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { Pagination } from 'library/List/Pagination';
 import { MotionContainer } from 'library/List/MotionContainer';
+import { SearchInput } from 'library/List/SearchInput';
 import { PoolListProvider, usePoolList } from './context';
 import { PoolListProps } from './types';
 
@@ -26,7 +27,7 @@ export const PoolListInner = (props: PoolListProps) => {
   const { mode } = useTheme();
   const { isReady, network } = useApi();
   const { metrics } = useNetworkMetrics();
-  const { fetchPoolsMetaBatch } = useBondedPools();
+  const { fetchPoolsMetaBatch, poolSearchFilter } = useBondedPools();
   const { listFormat, setListFormat } = usePoolList();
 
   // current page
@@ -100,9 +101,15 @@ export const PoolListInner = (props: PoolListProps) => {
     listPools = pools;
   }
 
-  if (!pools.length) {
-    return <></>;
-  }
+  const handleSearchChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const newValue = e.currentTarget.value;
+
+    let filteredPools = Object.assign(poolsDefault);
+    filteredPools = poolSearchFilter(filteredPools, batchKey, newValue);
+    setPage(1);
+    setRenderIteration(1);
+    setPools(filteredPools);
+  };
 
   return (
     <ListWrapper>
@@ -134,33 +141,51 @@ export const PoolListInner = (props: PoolListProps) => {
         </div>
       </Header>
       <List flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
-        {pagination && (
+        {poolsDefault.length > 0 && (
+          <SearchInput
+            handleChange={handleSearchChange}
+            placeholder="Search Pool Name or Address"
+          />
+        )}
+        {pagination && listPools.length > 0 && (
           <Pagination page={page} total={totalPages} setter={setPage} />
         )}
         <MotionContainer>
-          {listPools.map((pool: any, index: number) => {
-            // fetch batch data by referring to default list index.
-            const batchIndex = poolsDefault.indexOf(pool);
+          {listPools.length ? (
+            <>
+              {listPools.map((pool: any, index: number) => {
+                // fetch batch data by referring to default list index.
+                const batchIndex = poolsDefault.indexOf(pool);
 
-            return (
-              <motion.div
-                className={`item ${listFormat === 'row' ? 'row' : 'col'}`}
-                key={`nomination_${index}`}
-                variants={{
-                  hidden: {
-                    y: 15,
-                    opacity: 0,
-                  },
-                  show: {
-                    y: 0,
-                    opacity: 1,
-                  },
-                }}
-              >
-                <Pool pool={pool} batchKey={batchKey} batchIndex={batchIndex} />
-              </motion.div>
-            );
-          })}
+                return (
+                  <motion.div
+                    className={`item ${listFormat === 'row' ? 'row' : 'col'}`}
+                    key={`nomination_${index}`}
+                    variants={{
+                      hidden: {
+                        y: 15,
+                        opacity: 0,
+                      },
+                      show: {
+                        y: 0,
+                        opacity: 1,
+                      },
+                    }}
+                  >
+                    <Pool
+                      pool={pool}
+                      batchKey={batchKey}
+                      batchIndex={batchIndex}
+                    />
+                  </motion.div>
+                );
+              })}
+            </>
+          ) : (
+            <h4 style={{ padding: '1rem 1rem 0 1rem' }}>
+              No pools match this criteria.
+            </h4>
+          )}
         </MotionContainer>
       </List>
     </ListWrapper>

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -17,6 +17,7 @@ import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { Pagination } from 'library/List/Pagination';
 import { MotionContainer } from 'library/List/MotionContainer';
 import { SearchInput } from 'library/List/SearchInput';
+import { useUi } from 'contexts/UI';
 import { PoolListProvider, usePoolList } from './context';
 import { PoolListProps } from './types';
 
@@ -30,6 +31,7 @@ export const PoolListInner = (props: PoolListProps) => {
   const { metrics } = useNetworkMetrics();
   const { fetchPoolsMetaBatch, poolSearchFilter } = useBondedPools();
   const { listFormat, setListFormat } = usePoolList();
+  const { isSyncing } = useUi();
 
   // current page
   const [page, setPage] = useState<number>(1);
@@ -184,7 +186,9 @@ export const PoolListInner = (props: PoolListProps) => {
             </>
           ) : (
             <h4 style={{ padding: '1rem 1rem 0 1rem' }}>
-              No pools match this criteria.
+              {isSyncing
+                ? 'Syncing Pool list...'
+                : 'No pools match this criteria.'}
             </h4>
           )}
         </MotionContainer>

--- a/src/library/PoolList/types.ts
+++ b/src/library/PoolList/types.ts
@@ -3,6 +3,7 @@
 
 export interface PoolListProps {
   allowMoreCols?: string;
+  allowSearch?: boolean;
   pagination?: number;
   batchKey?: string;
   disableThrottle?: boolean;

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -24,6 +24,7 @@ import { useUi } from 'contexts/UI';
 import { Pagination } from 'library/List/Pagination';
 import { MotionContainer } from 'library/List/MotionContainer';
 import { Selectable } from 'library/List/Selectable';
+import { SearchInput } from 'library/List/SearchInput';
 import { Filters } from './Filters';
 import { useList, ListProvider } from '../List/context';
 
@@ -205,6 +206,7 @@ export const ValidatorListInner = (props: any) => {
     setPage(1);
     setRenderIteration(1);
   };
+
   return (
     <ListWrapper>
       <Header>
@@ -241,17 +243,12 @@ export const ValidatorListInner = (props: any) => {
       </Header>
       <List flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
         {allowSearch && (
-          <div className="search">
-            <input
-              type="text"
-              className="search"
-              placeholder="Search Address or Identity Name"
-              onChange={(e: React.FormEvent<HTMLInputElement>) =>
-                handleSearchChange(e)
-              }
-            />
-          </div>
+          <SearchInput
+            handleChange={handleSearchChange}
+            placeholder="Search Address or Identity"
+          />
         )}
+
         {allowFilters && <Filters />}
 
         {listValidators.length > 0 && pagination && (
@@ -303,7 +300,7 @@ export const ValidatorListInner = (props: any) => {
               })}
             </>
           ) : (
-            <h4 style={{ marginTop: '2rem' }}>
+            <h4 style={{ marginTop: '1rem' }}>
               No validators match this criteria.
             </h4>
           )}

--- a/src/modals/LeavePool/index.tsx
+++ b/src/modals/LeavePool/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
 import { UnbondAll } from 'modals/UpdateBond/Forms/UnbondAll';
 import { HeadingWrapper, PaddingWrapper } from '../Wrappers';
 
@@ -10,7 +10,7 @@ export const LeavePool = () => {
   return (
     <PaddingWrapper>
       <HeadingWrapper noPadding>
-        <FontAwesomeIcon transform="grow-2" icon={faPlus} />
+        <FontAwesomeIcon transform="grow-2" icon={faSignOutAlt} />
         Leave Pool
       </HeadingWrapper>
       <UnbondAll />

--- a/src/modals/UnbondPoolMember/index.tsx
+++ b/src/modals/UnbondPoolMember/index.tsx
@@ -20,18 +20,14 @@ import { Warning } from 'library/Form/Warning';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { ContentWrapper } from 'modals/UpdateBond/Wrappers';
 import BN from 'bn.js';
-import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 
 export const UnbondPoolMember = () => {
   const { api, network, consts } = useApi();
-  const { getPoolMember } = usePoolMembers();
   const { setStatus: setModalStatus, setResize, config } = useModal();
   const { activeAccount, accountHasSigner } = useConnect();
   const { units } = network;
   const { bondDuration } = consts;
-
-  const { who } = config;
-  const member = getPoolMember(who);
+  const { member, who } = config;
   const { points } = member;
   const freeToUnbond = planckBnToUnit(new BN(rmCommas(points)), units);
 

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -22,6 +22,7 @@ import { ContentWrapper } from 'modals/UpdateBond/Wrappers';
 import BN from 'bn.js';
 import { useNetworkMetrics } from 'contexts/Network';
 import { useStaking } from 'contexts/Staking';
+import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 
 export const WithdrawPoolMember = () => {
   const { api, network } = useApi();
@@ -29,6 +30,7 @@ export const WithdrawPoolMember = () => {
   const { staking } = useStaking();
   const { setStatus: setModalStatus, config } = useModal();
   const { metrics } = useNetworkMetrics();
+  const { removePoolMember } = usePoolMembers();
   const { activeEra } = metrics;
   const { member, who } = config;
   const { historyDepth } = staking;
@@ -68,7 +70,10 @@ export const WithdrawPoolMember = () => {
     callbackSubmit: () => {
       setModalStatus(0);
     },
-    callbackInBlock: () => {},
+    callbackInBlock: () => {
+      // important: remove the pool member from context
+      removePoolMember(who);
+    },
   });
 
   return (

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -34,7 +34,7 @@ export const WithdrawPoolMember = () => {
   const { activeEra } = metrics;
   const { member, who } = config;
   const { historyDepth } = staking;
-  const { unbondingEras } = member;
+  const { unbondingEras, points } = member;
 
   // calculate total for withdraw
   let totalWithdrawBase: BN = new BN(0);
@@ -45,6 +45,8 @@ export const WithdrawPoolMember = () => {
       totalWithdrawBase = totalWithdrawBase.add(new BN(rmCommas(amount)));
     }
   });
+
+  const bonded = planckBnToUnit(new BN(rmCommas(points)), network.units);
 
   const totalWithdraw = planckBnToUnit(
     new BN(totalWithdrawBase),
@@ -71,8 +73,10 @@ export const WithdrawPoolMember = () => {
       setModalStatus(0);
     },
     callbackInBlock: () => {
-      // important: remove the pool member from context
-      removePoolMember(who);
+      // important: remove the pool member from context if no more funds bonded
+      if (bonded === 0) {
+        removePoolMember(who);
+      }
     },
   });
 

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -21,19 +21,16 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { ContentWrapper } from 'modals/UpdateBond/Wrappers';
 import BN from 'bn.js';
 import { useNetworkMetrics } from 'contexts/Network';
-import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { useStaking } from 'contexts/Staking';
 
 export const WithdrawPoolMember = () => {
   const { api, network } = useApi();
   const { activeAccount, accountHasSigner } = useConnect();
   const { staking } = useStaking();
-  const { getPoolMember } = usePoolMembers();
   const { setStatus: setModalStatus, config } = useModal();
   const { metrics } = useNetworkMetrics();
   const { activeEra } = metrics;
-  const { who } = config;
-  const member = getPoolMember(who);
+  const { member, who } = config;
   const { historyDepth } = staking;
   const { unbondingEras } = member;
 

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -1,0 +1,108 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { PageRowWrapper } from 'Wrappers';
+import { CardWrapper } from 'library/Graphs/Wrappers';
+import { useApi } from 'contexts/Api';
+import { useActivePool } from 'contexts/Pools/ActivePool';
+import { useTheme } from 'contexts/Themes';
+import { PoolState } from 'contexts/Pools/types';
+import { faLockOpen } from '@fortawesome/free-solid-svg-icons';
+import { Button, ButtonRow } from 'library/Button';
+import { useModal } from 'contexts/Modal';
+import { useConnect } from 'contexts/Connect';
+import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
+import { useUi } from 'contexts/UI';
+
+export const ClosurePrompts = () => {
+  const { network } = useApi();
+  const { activeAccount } = useConnect();
+  const { mode } = useTheme();
+  const { openModalWith } = useModal();
+  const { membership } = usePoolMemberships();
+  const { isSyncing } = useUi();
+  const { isBonding, activeBondedPool, isDepositor, getPoolBondOptions } =
+    useActivePool();
+
+  const { state, memberCounter } = activeBondedPool || {};
+  const { active, totalUnlockChuncks } = getPoolBondOptions(activeAccount);
+  const networkColorsSecondary: any = network.colors.secondary;
+  const annuncementBorderColor = networkColorsSecondary[mode];
+
+  // is the pool in a state for the depositor to close
+  const depositorCanClose =
+    !isSyncing &&
+    isDepositor() &&
+    state === PoolState.Destroy &&
+    memberCounter === '1';
+
+  // depositor needs to unbond funds
+  const depositorCanUnbond = active.toNumber() > 0;
+
+  // depositor can withdraw & close pool
+  const depositorCanWithdraw =
+    active.toNumber() === 0 && totalUnlockChuncks === 0;
+
+  return (
+    <>
+      {depositorCanClose && (
+        <PageRowWrapper className="page-padding" noVerticalSpacer>
+          <CardWrapper
+            style={{ border: `1px solid ${annuncementBorderColor}` }}
+          >
+            <div className="content">
+              <h3>Destroy Pool</h3>
+              <h4>
+                All members have now left the pool.
+                {depositorCanWithdraw
+                  ? 'You can now withdraw and close the pool.'
+                  : depositorCanUnbond
+                  ? 'You can now unbond your funds.'
+                  : 'Withdraw your unlock chunk to proceed with pool closure.'}
+              </h4>
+              <ButtonRow verticalSpacing>
+                <Button
+                  small
+                  primary
+                  inline
+                  title="Unbond"
+                  disabled={isSyncing}
+                  onClick={() =>
+                    openModalWith(
+                      'UnbondPoolMember',
+                      { who: activeAccount, member: membership },
+                      'small'
+                    )
+                  }
+                />
+                <Button
+                  small
+                  primary
+                  icon={faLockOpen}
+                  title={String(totalUnlockChuncks ?? 0)}
+                  disabled={isSyncing || !isBonding()}
+                  onClick={() =>
+                    openModalWith('UnlockChunks', { bondType: 'pool' }, 'small')
+                  }
+                />
+                <Button
+                  small
+                  primary
+                  title="Withdraw &amp; Close Pool"
+                  disabled={isSyncing || true}
+                  onClick={() =>
+                    openModalWith(
+                      'UnbondPoolMember',
+                      { who: activeAccount, member: membership },
+                      'small'
+                    )
+                  }
+                />
+              </ButtonRow>
+            </div>
+          </CardWrapper>
+        </PageRowWrapper>
+      )}
+    </>
+  );
+};

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -61,7 +61,7 @@ export const ClosurePrompts = () => {
             <div className="content">
               <h3>Destroy Pool</h3>
               <h4>
-                All members have now left the pool.
+                All members have now left the pool.{' '}
                 {targets.length > 0
                   ? 'To continue with pool closure, stop nominating.'
                   : depositorCanWithdraw

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -21,11 +21,18 @@ export const ClosurePrompts = () => {
   const { openModalWith } = useModal();
   const { membership } = usePoolMemberships();
   const { isSyncing } = useUi();
-  const { isBonding, activeBondedPool, isDepositor, getPoolBondOptions } =
-    useActivePool();
+  const {
+    isBonding,
+    activeBondedPool,
+    isDepositor,
+    getPoolBondOptions,
+    poolNominations,
+  } = useActivePool();
 
   const { state, memberCounter } = activeBondedPool || {};
   const { active, totalUnlockChuncks } = getPoolBondOptions(activeAccount);
+  const targets = poolNominations?.targets ?? [];
+
   const networkColorsSecondary: any = network.colors.secondary;
   const annuncementBorderColor = networkColorsSecondary[mode];
 
@@ -34,14 +41,15 @@ export const ClosurePrompts = () => {
     !isSyncing &&
     isDepositor() &&
     state === PoolState.Destroy &&
-    memberCounter === '1';
+    memberCounter === '1' &&
+    !targets.length;
 
   // depositor needs to unbond funds
-  const depositorCanUnbond = active.toNumber() > 0;
+  const depositorCanUnbond = active.toNumber() > 0 && !targets.length;
 
   // depositor can withdraw & close pool
   const depositorCanWithdraw =
-    active.toNumber() === 0 && totalUnlockChuncks === 0;
+    active.toNumber() === 0 && totalUnlockChuncks === 0 && !targets.length;
 
   return (
     <>
@@ -54,7 +62,9 @@ export const ClosurePrompts = () => {
               <h3>Destroy Pool</h3>
               <h4>
                 All members have now left the pool.
-                {depositorCanWithdraw
+                {targets.length > 0
+                  ? 'To continue with pool closure, stop nominating.'
+                  : depositorCanWithdraw
                   ? 'You can now withdraw and close the pool.'
                   : depositorCanUnbond
                   ? 'You can now unbond your funds.'

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -66,7 +66,9 @@ export const ClosurePrompts = () => {
                   primary
                   inline
                   title="Unbond"
-                  disabled={isSyncing}
+                  disabled={
+                    isSyncing || (!depositorCanWithdraw && !depositorCanUnbond)
+                  }
                   onClick={() =>
                     openModalWith(
                       'UnbondPoolMember',
@@ -83,19 +85,6 @@ export const ClosurePrompts = () => {
                   disabled={isSyncing || !isBonding()}
                   onClick={() =>
                     openModalWith('UnlockChunks', { bondType: 'pool' }, 'small')
-                  }
-                />
-                <Button
-                  small
-                  primary
-                  title="Withdraw &amp; Close Pool"
-                  disabled={isSyncing || true}
-                  onClick={() =>
-                    openModalWith(
-                      'UnbondPoolMember',
-                      { who: activeAccount, member: membership },
-                      'small'
-                    )
                   }
                 />
               </ButtonRow>

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -13,6 +13,7 @@ import { useUi } from 'contexts/UI';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
 import { PoolState } from 'contexts/Pools/types';
+import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 
 export const ManageBond = () => {
   const { network } = useApi();
@@ -20,6 +21,7 @@ export const ManageBond = () => {
   const { openModalWith } = useModal();
   const { activeAccount } = useConnect();
   const { isSyncing } = useUi();
+  const { membership } = usePoolMemberships();
   const { getPoolBondOptions, isBonding, activeBondedPool } = useActivePool();
 
   const {
@@ -76,7 +78,7 @@ export const ManageBond = () => {
             primary
             icon={faLockOpen}
             title={String(totalUnlockChuncks ?? 0)}
-            disabled={isSyncing || !isBonding() || state === PoolState.Destroy}
+            disabled={isSyncing || !membership || state === PoolState.Destroy}
             onClick={() =>
               openModalWith('UnlockChunks', { bondType: 'pool' }, 'small')
             }
@@ -88,7 +90,7 @@ export const ManageBond = () => {
         unlocking={planckBnToUnit(totalUnlocking, units)}
         unlocked={planckBnToUnit(totalUnlocked, units)}
         free={planckBnToUnit(freeToBond, units)}
-        inactive={!isBonding()}
+        inactive={!membership}
       />
     </>
   );

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -12,6 +12,7 @@ import { useModal } from 'contexts/Modal';
 import { useUi } from 'contexts/UI';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
+import { PoolState } from 'contexts/Pools/types';
 
 export const ManageBond = () => {
   const { network } = useApi();
@@ -19,7 +20,7 @@ export const ManageBond = () => {
   const { openModalWith } = useModal();
   const { activeAccount } = useConnect();
   const { isSyncing } = useUi();
-  const { getPoolBondOptions, isBonding } = useActivePool();
+  const { getPoolBondOptions, isBonding, activeBondedPool } = useActivePool();
 
   const {
     active,
@@ -28,6 +29,8 @@ export const ManageBond = () => {
     totalUnlocked,
     totalUnlockChuncks,
   } = getPoolBondOptions(activeAccount);
+
+  const { state } = activeBondedPool || {};
 
   return (
     <>
@@ -45,7 +48,7 @@ export const ManageBond = () => {
             primary
             inline
             title="+"
-            disabled={isSyncing || !isBonding()}
+            disabled={isSyncing || !isBonding() || state === PoolState.Destroy}
             onClick={() =>
               openModalWith(
                 'UpdateBond',
@@ -58,7 +61,7 @@ export const ManageBond = () => {
             small
             primary
             title="-"
-            disabled={isSyncing || !isBonding()}
+            disabled={isSyncing || !isBonding() || state === PoolState.Destroy}
             onClick={() =>
               openModalWith(
                 'UpdateBond',
@@ -73,7 +76,7 @@ export const ManageBond = () => {
             primary
             icon={faLockOpen}
             title={String(totalUnlockChuncks ?? 0)}
-            disabled={isSyncing || !isBonding()}
+            disabled={isSyncing || !isBonding() || state === PoolState.Destroy}
             onClick={() =>
               openModalWith('UnlockChunks', { bondType: 'pool' }, 'small')
             }

--- a/src/pages/Pools/Home/ManagePool/index.tsx
+++ b/src/pages/Pools/Home/ManagePool/index.tsx
@@ -12,6 +12,7 @@ import Nominations from 'pages/Stake/Active/Nominations';
 import { GenerateNominations } from 'library/SetupSteps/GenerateNominations';
 import { useUi } from 'contexts/UI';
 import { useConnect } from 'contexts/Connect';
+import { PoolState } from 'contexts/Pools/types';
 
 export const ManagePool = () => {
   const { isSyncing } = useUi();
@@ -27,13 +28,14 @@ export const ManagePool = () => {
 
   const isNominating = !!poolNominations?.targets?.length;
   const nominator = activeBondedPool?.addresses?.stash ?? null;
+  const { state } = activeBondedPool || {};
 
   return (
     <PageRowWrapper className="page-padding" noVerticalSpacer>
       <CardWrapper>
         {isSyncing ? (
           <Nominations bondType="pool" nominator={activeAccount} />
-        ) : isNominator() && !isNominating ? (
+        ) : isNominator() && !isNominating && state !== PoolState.Destroy ? (
           <>
             <CardHeaderWrapper withAction>
               <h3>

--- a/src/pages/Pools/Home/MembersList/index.tsx
+++ b/src/pages/Pools/Home/MembersList/index.tsx
@@ -54,7 +54,7 @@ export const MembersListInner = (props: any) => {
   const [members, setMembers] = useState(props.members);
 
   // is this the initial fetch
-  const [fetched, setFetched] = useState<boolean>(false);
+  const [fetched, setFetched] = useState<number>(0);
 
   // render throttle iteration
   const renderIterationRef = useRef(renderIteration);
@@ -74,13 +74,13 @@ export const MembersListInner = (props: any) => {
   // refetch list when list changes
   useEffect(() => {
     if (props.members !== membersDefault) {
-      setFetched(false);
+      setFetched(0);
     }
   }, [props.members]);
 
   // configure list when network is ready to fetch
   useEffect(() => {
-    if (isReady && metrics.activeEra.index !== 0 && !fetched) {
+    if (isReady && metrics.activeEra.index !== 0 && fetched === 0) {
       setupMembersList();
     }
   }, [isReady, fetched, metrics.activeEra.index]);
@@ -103,10 +103,11 @@ export const MembersListInner = (props: any) => {
 
   // handle validator list bootstrapping
   const setupMembersList = () => {
-    setFetched(true);
+    setFetched(1);
     setMembersDefault(props.members);
     setMembers(props.members);
     fetchPoolMembersMetaBatch(batchKey, props.members, false);
+    setFetched(2);
   };
 
   // get list items to render

--- a/src/pages/Pools/Home/MembersList/index.tsx
+++ b/src/pages/Pools/Home/MembersList/index.tsx
@@ -11,7 +11,7 @@ import { useNetworkMetrics } from 'contexts/Network';
 import { LIST_ITEMS_PER_PAGE, LIST_ITEMS_PER_BATCH } from 'consts';
 import { networkColors } from 'theme/default';
 import { useTheme } from 'contexts/Themes';
-import { AnyApi } from 'types';
+import { AnyApi, Sync } from 'types';
 import { MotionContainer } from 'library/List/MotionContainer';
 import { Pagination } from 'library/List/Pagination';
 import { useList, ListProvider } from 'library/List/context';
@@ -54,7 +54,7 @@ export const MembersListInner = (props: any) => {
   const [members, setMembers] = useState(props.members);
 
   // is this the initial fetch
-  const [fetched, setFetched] = useState<number>(0);
+  const [fetched, setFetched] = useState<Sync>(Sync.Unsynced);
 
   // render throttle iteration
   const renderIterationRef = useRef(renderIteration);
@@ -74,13 +74,13 @@ export const MembersListInner = (props: any) => {
   // refetch list when list changes
   useEffect(() => {
     if (props.members !== membersDefault) {
-      setFetched(0);
+      setFetched(Sync.Unsynced);
     }
   }, [props.members]);
 
   // configure list when network is ready to fetch
   useEffect(() => {
-    if (isReady && metrics.activeEra.index !== 0 && fetched === 0) {
+    if (isReady && metrics.activeEra.index !== 0 && fetched === Sync.Unsynced) {
       setupMembersList();
     }
   }, [isReady, fetched, metrics.activeEra.index]);
@@ -103,11 +103,10 @@ export const MembersListInner = (props: any) => {
 
   // handle validator list bootstrapping
   const setupMembersList = () => {
-    setFetched(1);
     setMembersDefault(props.members);
     setMembers(props.members);
     fetchPoolMembersMetaBatch(batchKey, props.members, false);
-    setFetched(2);
+    setFetched(Sync.Synced);
   };
 
   // get list items to render

--- a/src/pages/Pools/Home/Status/Membership/index.tsx
+++ b/src/pages/Pools/Home/Status/Membership/index.tsx
@@ -23,7 +23,7 @@ export const Membership = ({ label }: { label: string }) => {
   const { activeBondedPool, isOwner, getPoolBondOptions } = useActivePool();
   const { active } = getPoolBondOptions(activeAccount);
 
-  const inPool = membership !== null && activeBondedPool !== undefined;
+  const inPool = membership !== null && activeBondedPool !== null;
 
   let display = 'Not in Pool';
   if (membership && activeBondedPool) {

--- a/src/pages/Pools/Home/Status/index.tsx
+++ b/src/pages/Pools/Home/Status/index.tsx
@@ -42,7 +42,7 @@ export const Status = ({ height }: { height: number }) => {
     (_v) => _v === 'active'
   ).length;
   const isNominating = !!poolNominations?.targets?.length;
-  const inPool = membership && activeBondedPool;
+  const inPool = membership;
 
   // Set the minimum unclaimed planck value to prevent e numbers
   const minUnclaimedDisplay = new BN(1_000_000);

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -19,6 +19,7 @@ import {
   SECTION_FULL_WIDTH_THRESHOLD,
   SIDE_MENU_STICKY_THRESHOLD,
 } from 'consts';
+import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import ActivePoolsStatBox from './Stats/ActivePools';
 import MinJoinBondStatBox from './Stats/MinJoinBond';
 import PoolMembershipBox from './Stats/PoolMembership';
@@ -38,8 +39,9 @@ export const HomeInner = (props: PageProps) => {
   const { title } = page;
   const { network } = useApi();
   const navigate = useNavigate();
+  const { membership } = usePoolMemberships();
   const { bondedPools } = useBondedPools();
-  const { isBonding, getPoolRoles, activeBondedPool } = useActivePool();
+  const { getPoolRoles, activeBondedPool } = useActivePool();
   const { activeTab, setActiveTab } = usePoolsTabs();
 
   // back to overview if pools are not supported on network
@@ -120,7 +122,7 @@ export const HomeInner = (props: PageProps) => {
               </CardWrapper>
             </RowSecondaryWrapper>
           </PageRowWrapper>
-          {isBonding() && (
+          {membership !== null && (
             <>
               <ManagePool />
               <PageRowWrapper className="page-padding" noVerticalSpacer>

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -147,6 +147,7 @@ export const HomeInner = (props: PageProps) => {
                 pools={bondedPools}
                 title="Active Pools"
                 allowMoreCols
+                allowSearch
                 pagination
               />
             </CardWrapper>

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -19,6 +19,14 @@ import {
   SECTION_FULL_WIDTH_THRESHOLD,
   SIDE_MENU_STICKY_THRESHOLD,
 } from 'consts';
+import { useTheme } from 'contexts/Themes';
+import { PoolState } from 'contexts/Pools/types';
+import { faLockOpen } from '@fortawesome/free-solid-svg-icons';
+import { Button, ButtonRow } from 'library/Button';
+import { useModal } from 'contexts/Modal';
+import { useConnect } from 'contexts/Connect';
+import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
+import { useUi } from 'contexts/UI';
 import ActivePoolsStatBox from './Stats/ActivePools';
 import MinJoinBondStatBox from './Stats/MinJoinBond';
 import PoolMembershipBox from './Stats/PoolMembership';
@@ -36,10 +44,26 @@ export const HomeInner = (props: PageProps) => {
   const { page } = props;
   const { title } = page;
   const { network } = useApi();
+  const { activeAccount } = useConnect();
+  const { mode } = useTheme();
   const navigate = useNavigate();
+  const { openModalWith } = useModal();
   const { bondedPools } = useBondedPools();
-  const { isBonding, getPoolRoles, activeBondedPool } = useActivePool();
+  const { membership } = usePoolMemberships();
+  const { isSyncing } = useUi();
+  const {
+    isBonding,
+    getPoolRoles,
+    activeBondedPool,
+    isDepositor,
+    getPoolBondOptions,
+  } = useActivePool();
   const { activeTab, setActiveTab } = usePoolsTabs();
+
+  const { state, memberCounter } = activeBondedPool || {};
+  const { active, totalUnlockChuncks } = getPoolBondOptions(activeAccount);
+  const networkColorsSecondary: any = network.colors.secondary;
+  const annuncementBorderColor = networkColorsSecondary[mode];
 
   // back to overview if pools are not supported on network
   useEffect(() => {
@@ -86,6 +110,20 @@ export const HomeInner = (props: PageProps) => {
     }
   );
 
+  // is the pool in a state for the depositor to close
+  const depositorCanClose =
+    !isSyncing &&
+    isDepositor() &&
+    state === PoolState.Destroy &&
+    memberCounter === '1';
+
+  // depositor needs to unbond funds
+  const depositorCanUnbond = active.toNumber() > 0;
+
+  // depositor can withdraw & close pool
+  const depositorCanWithdraw =
+    active.toNumber() === 0 && totalUnlockChuncks === 0;
+
   return (
     <>
       <PageTitle title={title} tabs={tabs} />
@@ -96,6 +134,69 @@ export const HomeInner = (props: PageProps) => {
             <MinJoinBondStatBox />
             <MinCreateBondStatBox />
           </StatBoxList>
+          {depositorCanClose && (
+            <PageRowWrapper className="page-padding" noVerticalSpacer>
+              <CardWrapper
+                style={{ border: `1px solid ${annuncementBorderColor}` }}
+              >
+                <div className="content">
+                  <h3>Destroy Pool</h3>
+                  <h4>
+                    All members have now left the pool.
+                    {depositorCanWithdraw
+                      ? 'You can now withdraw and close the pool.'
+                      : depositorCanUnbond
+                      ? 'You can now unbond your funds.'
+                      : 'Withdraw your unlock chunk to proceed with pool closure.'}
+                  </h4>
+                  <ButtonRow verticalSpacing>
+                    <Button
+                      small
+                      primary
+                      inline
+                      title="Unbond"
+                      disabled={isSyncing}
+                      onClick={() =>
+                        openModalWith(
+                          'UnbondPoolMember',
+                          { who: activeAccount, member: membership },
+                          'small'
+                        )
+                      }
+                    />
+                    <Button
+                      small
+                      primary
+                      icon={faLockOpen}
+                      title={String(totalUnlockChuncks ?? 0)}
+                      disabled={isSyncing || !isBonding()}
+                      onClick={() =>
+                        openModalWith(
+                          'UnlockChunks',
+                          { bondType: 'pool' },
+                          'small'
+                        )
+                      }
+                    />
+                    <Button
+                      small
+                      primary
+                      title="Withdraw &amp; Close Pool"
+                      disabled={isSyncing || true}
+                      onClick={() =>
+                        openModalWith(
+                          'UnbondPoolMember',
+                          { who: activeAccount, member: membership },
+                          'small'
+                        )
+                      }
+                    />
+                  </ButtonRow>
+                </div>
+              </CardWrapper>
+            </PageRowWrapper>
+          )}
+
           <PageRowWrapper className="page-padding" noVerticalSpacer>
             <RowPrimaryWrapper
               hOrder={1}

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -50,7 +50,7 @@ export const HomeInner = (props: PageProps) => {
 
   // back to tab 0 if not in a pool
   useEffect(() => {
-    if (activeBondedPool === undefined) {
+    if (!activeBondedPool) {
       setActiveTab(0);
     }
   }, [activeBondedPool]);

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -8,10 +8,9 @@ import {
   RowPrimaryWrapper,
   RowSecondaryWrapper,
 } from 'Wrappers';
-import { CardWrapper, CardHeaderWrapper } from 'library/Graphs/Wrappers';
+import { CardWrapper } from 'library/Graphs/Wrappers';
 import { PageTitle } from 'library/PageTitle';
 import { StatBoxList } from 'library/StatBoxList';
-import { OpenAssistantIcon } from 'library/OpenAssistantIcon';
 import { useApi } from 'contexts/Api';
 import { PoolList } from 'library/PoolList';
 import { useActivePool } from 'contexts/Pools/ActivePool';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,3 +97,10 @@ export type AnyApi = any;
 export type AnyMetaBatch = any;
 // eslint-disable-next-line
 export type AnySubscan = any;
+
+// track the status of a syncing / fetching process.
+export enum Sync {
+  Unsynced,
+  Syncing,
+  Synced,
+}


### PR DESCRIPTION
Continues the remaining tasks from #222 and fixes outstanding issues.

- [x] Allows pool member list entries to update once their membership status changes.
- [x] Fixed an issue that prevented the activeBondedPool subscription to update. 
- [x] Ability to search for a pool via metadata or stash address. 
- [x] Added a `ClosurePrompts` component that prompts the user the next steps to close the pool.
- [x] Fixed logic to account for pool closure + to not allow nominations after chill.
- [x] Pool nominations refresh fix.
- [x] Test final pool withdraw.