### PR TITLE
ESLINT solution: Organize imports and remove non-used ones

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,97 +1,107 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "airbnb",
+    "plugin:prettier/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true,
+      "arrowFunctions": true
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended",
-        "airbnb",
-        "plugin:prettier/recommended"
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "@typescript-eslint",
+    "prefer-arrow-functions",
+    "simple-import-sort",
+    "unused-imports"
+  ],
+  "rules": {
+    // "simple-import-sort" rules
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    // "unused-imports rules
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true,
-            "arrowFunctions": true
-        },
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint",
-        "prefer-arrow-functions"
+    // The rest
+    "import/no-webpack-loader-syntax": "off",
+    "react/require-default-props": "off",
+    "react/no-access-state-in-setstate": "off",
+    "react/destructuring-assignment": "off",
+    "react/function-component-definition": "off",
+    "react/jsx-no-constructed-context-values": "off",
+    "react/no-array-index-key": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-props-no-spreading": "off",
+    "react/jsx-no-useless-fragment": "off",
+    "react/static-property-placement": "off",
+    "no-unused-vars": "off",
+    "no-param-reassign": "off",
+    "no-plusplus": "off",
+    "no-continue": "off",
+    "max-len": "off",
+    "no-underscore-dangle": "off",
+    "no-restricted-syntax": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "react/prop-types": "off",
+    "arrow-body-style": "off",
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "import/prefer-default-export": "off",
+    "consistent-return": "off",
+    "no-promise-executor-return": "off",
+    "prefer-destructuring": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "camelcase": "off",
+    "no-nested-ternary": "off",
+    "semi": [2, "always"],
+    "react/jsx-filename-extension": [
+      "warn",
+      {
+        "extensions": [".tsx"]
+      }
     ],
-    "rules": {
-        "import/no-webpack-loader-syntax": "off",
-        "react/require-default-props": "off",
-        "react/no-access-state-in-setstate": "off",
-        "react/destructuring-assignment": "off",
-        "react/function-component-definition": "off",
-        "react/jsx-no-constructed-context-values": "off",
-        "react/no-array-index-key": "off",
-        "react/react-in-jsx-scope": "off",
-        "react/jsx-props-no-spreading": "off",
-        "react/jsx-no-useless-fragment": "off",
-        "react/static-property-placement": "off",
-        "no-unused-vars": "off",
-        "no-param-reassign": "off",
-        "no-plusplus": "off",
-        "no-continue": "off",
-        "max-len": "off",
-        "no-underscore-dangle": "off",
-        "no-restricted-syntax": "off",
-        "@typescript-eslint/no-empty-function": "off",
-        "react/prop-types": "off",
-        "arrow-body-style": "off",
-        "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        "import/prefer-default-export": "off",
-        "consistent-return": "off",
-        "no-promise-executor-return": "off",
-        "prefer-destructuring": "off",
-        "@typescript-eslint/ban-ts-comment": "off",
-        "camelcase": "off",
-        "no-nested-ternary": "off",
-        "semi": [
-            2,
-            "always"
-        ],
-        "react/jsx-filename-extension": [
-            "warn",
-            {
-                "extensions": [
-                    ".tsx"
-                ]
-            }
-        ],
-        "import/extensions": [
-            "error",
-            "ignorePackages",
-            {
-                "ts": "never",
-                "tsx": "never"
-            }
-        ],
-        "no-shadow": "off",
-        "@typescript-eslint/no-shadow": [
-            "error"
-        ],
-        "prefer-arrow-functions/prefer-arrow-functions": [
-            "warn",
-            {
-                "classPropertiesAllowed": false,
-                "disallowPrototype": false,
-                "returnStyle": "unchanged",
-                "singleReturnOnly": false
-            }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "typescript": {}
-        }
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
+    "prefer-arrow-functions/prefer-arrow-functions": [
+      "warn",
+      {
+        "classPropertiesAllowed": false,
+        "disallowPrototype": false,
+        "returnStyle": "unchanged",
+        "singleReturnOnly": false
+      }
+    ]
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": {}
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "gh-pages": "^3.2.3",
     "prettier": "^2.6.2",
     "terser-webpack-plugin": "^5.3.3",

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -8,6 +8,7 @@ import { withProviders } from 'library/Hooks';
 import Router from 'Router';
 import { ThemeProvider } from 'styled-components';
 import { EntryWrapper as Wrapper } from 'Wrappers';
+
 import { AccountProvider } from './contexts/Account';
 import { APIProvider, useApi } from './contexts/Api';
 import { BalancesProvider } from './contexts/Balances';

--- a/src/config/extensions/index.ts
+++ b/src/config/extensions/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FunctionComponent, SVGProps } from 'react';
+
 import { ReactComponent as PolkadotJSSVG } from './icons/dot_icon.svg';
 import { ReactComponent as EnkryptSVG } from './icons/enkrypt_icon.svg';
 import { ReactComponent as NovaWalletSVG } from './icons/nova_wallet.svg';

--- a/src/contexts/Account/index.tsx
+++ b/src/contexts/Account/index.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, AnyMetaBatch } from 'types';
 import { setStateWithRef } from 'Utils';
+
 import { useApi } from '../Api';
 import { defaultAccountContext } from './defaults';
 import { AccountContextInterface } from './types';

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'contexts/Api/types';
 import React, { useEffect, useState } from 'react';
 import { AnyApi, Network, NetworkName } from 'types';
+
 import * as defaults from './defaults';
 
 export const APIContext = React.createContext<APIContextInterface>(

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -4,6 +4,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { U8aLike } from '@polkadot/util/types';
 import BN from 'bn.js';
+
 import { Network, NetworkName } from '../../types';
 
 export enum ConnectionStatus {

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -12,6 +12,7 @@ import { ImportedAccount } from 'contexts/Connect/types';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, MaybeAccount } from 'types';
 import { rmCommas, setStateWithRef } from 'Utils';
+
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
 import * as defaults from './defaults';

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -4,6 +4,7 @@
 import Keyring from '@polkadot/keyring';
 import { Network } from 'types';
 import { localStorageOrDefault } from 'Utils';
+
 import { ExternalAccount } from './types';
 
 // removes extension from localExtensions

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -20,6 +20,7 @@ import {
   localStorageOrDefault,
   setStateWithRef,
 } from 'Utils';
+
 import { useApi } from '../Api';
 import { defaultConnectContext } from './defaults';
 import {

--- a/src/contexts/Extrinsics/index.tsx
+++ b/src/contexts/Extrinsics/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useRef, useState } from 'react';
 import { setStateWithRef } from 'Utils';
+
 import { defaultExtrinsicsContext } from './defaults';
 import { ExtrinsicsContextInterface } from './types';
 

--- a/src/contexts/Help/index.tsx
+++ b/src/contexts/Help/index.tsx
@@ -5,6 +5,7 @@ import { useApi } from 'contexts/Api';
 import React, { useEffect, useState } from 'react';
 import { MaybeString } from 'types';
 import { replaceAll } from 'Utils';
+
 import * as defaults from './defaults';
 import {
   HelpConfig,

--- a/src/contexts/Menu/index.tsx
+++ b/src/contexts/Menu/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { RefObject, useState } from 'react';
+
 import { defaultMenuContext } from './defaults';
 import { MenuContextInterface } from './types';
 

--- a/src/contexts/Modal/index.tsx
+++ b/src/contexts/Modal/index.tsx
@@ -3,6 +3,7 @@
 
 import { useTxFees } from 'contexts/TxFees';
 import React, { useEffect, useState } from 'react';
+
 import { defaultModalContext } from './defaults';
 import { ModalConfig, ModalContextInterface, ModalContextState } from './types';
 

--- a/src/contexts/Network/defaults.ts
+++ b/src/contexts/Network/defaults.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
+
 import { NetworkMetrics, NetworkMetricsContextInterface } from './types';
 
 export const metrics: NetworkMetrics = {

--- a/src/contexts/Network/index.tsx
+++ b/src/contexts/Network/index.tsx
@@ -4,6 +4,7 @@
 import { BN } from 'bn.js';
 import React, { useEffect, useState } from 'react';
 import { AnyApi } from 'types';
+
 import { useApi } from '../Api';
 import * as defaults from './defaults';
 import { NetworkMetrics, NetworkMetricsContextInterface } from './types';

--- a/src/contexts/Notifications/index.tsx
+++ b/src/contexts/Notifications/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useRef, useState } from 'react';
 import { setStateWithRef } from 'Utils';
+
 import { defaultNotificationsContext } from './defaults';
 import {
   NotificationInterface,

--- a/src/contexts/Pools/ActivePools/defaults.ts
+++ b/src/contexts/Pools/ActivePools/defaults.ts
@@ -3,6 +3,7 @@
 
 import { BN } from 'bn.js';
 import { Sync } from 'types';
+
 import { ActivePool, ActivePoolsContextState } from '../types';
 
 export const nominationStatus = {};

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -12,6 +12,7 @@ import { useStaking } from 'contexts/Staking';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { AnyApi, Sync } from 'types';
 import { localStorageOrDefault, rmCommas, setStateWithRef } from 'Utils';
+
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import { useBondedPools } from '../BondedPools';

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -12,6 +12,7 @@ import { useStaking } from 'contexts/Staking';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, AnyMetaBatch, Fn, MaybeAccount } from 'types';
 import { setStateWithRef } from 'Utils';
+
 import { useApi } from '../../Api';
 import { usePoolsConfig } from '../PoolsConfig';
 import { defaultBondedPoolsContext } from './defaults';

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -6,6 +6,7 @@ import { PoolMemberContext } from 'contexts/Pools/types';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, AnyMetaBatch, Fn, MaybeAccount } from 'types';
 import { setStateWithRef } from 'Utils';
+
 import { useApi } from '../../Api';
 import { defaultPoolMembers } from './defaults';
 

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -10,6 +10,7 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, Fn } from 'types';
 import { rmCommas, setStateWithRef } from 'Utils';
+
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import * as defaults from './defaults';

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -8,6 +8,7 @@ import { PoolConfigState, PoolsConfigContextState } from 'contexts/Pools/types';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi } from 'types';
 import { rmCommas, setStateWithRef } from 'Utils';
+
 import { useApi } from '../../Api';
 import * as defaults from './defaults';
 

--- a/src/contexts/SessionEra/index.tsx
+++ b/src/contexts/SessionEra/index.tsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi } from 'types';
 import { setStateWithRef } from 'Utils';
+
 import { useApi } from '../Api';
 import * as defaults from './defaults';
 import { SessionEra, SessionEraContextInterface } from './types';

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
-import React, { useEffect, useRef, useState } from 'react';
 // eslint-disable-next-line import/no-webpack-loader-syntax, import/no-unresolved
 import { ExternalAccount, ImportedAccount } from 'contexts/Connect/types';
 import {
@@ -12,6 +11,7 @@ import {
   StakingMetrics,
   StakingTargets,
 } from 'contexts/Staking/types';
+import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, MaybeAccount } from 'types';
 import {
   localStorageOrDefault,
@@ -21,6 +21,7 @@ import {
 } from 'Utils';
 // eslint-disable-next-line import/no-unresolved
 import Worker from 'worker-loader!../../workers/stakers';
+
 import { useApi } from '../Api';
 import { useBalances } from '../Balances';
 import { useConnect } from '../Connect';

--- a/src/contexts/Subscan/index.tsx
+++ b/src/contexts/Subscan/index.tsx
@@ -5,6 +5,7 @@ import { API_ENDPOINTS, API_SUBSCAN_KEY } from 'consts';
 import { UIContextInterface } from 'contexts/UI/types';
 import React, { useEffect, useState } from 'react';
 import { AnyApi, AnySubscan } from 'types';
+
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
 import { useUi } from '../UI';

--- a/src/contexts/Themes/index.tsx
+++ b/src/contexts/Themes/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useRef } from 'react';
 import { setStateWithRef } from 'Utils';
+
 import { defaultThemeContext } from './defaults';
 import { ThemeContextInterface } from './types';
 

--- a/src/contexts/Tooltip/index.tsx
+++ b/src/contexts/Tooltip/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { RefObject, useState } from 'react';
+
 import { defaultTooltipContext } from './defaults';
 import { TooltipContextInterface } from './types';
 

--- a/src/contexts/TransferOptions/defaults.ts
+++ b/src/contexts/TransferOptions/defaults.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
+
 import { TransferOptions, TransferOptionsContextInterface } from './types';
 
 export const defaultBalancesContext: TransferOptionsContextInterface = {

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -7,6 +7,7 @@ import { useNetworkMetrics } from 'contexts/Network';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import React from 'react';
 import { MaybeAccount } from 'types';
+
 import * as defaults from './defaults';
 import { TransferOptions, TransferOptionsContextInterface } from './types';
 

--- a/src/contexts/TxFees/defaults.ts
+++ b/src/contexts/TxFees/defaults.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BN from 'bn.js';
+
 import { EstimatedFeeContext } from '.';
 
 export const defaultTxFees: EstimatedFeeContext = {

--- a/src/contexts/TxFees/index.tsx
+++ b/src/contexts/TxFees/index.tsx
@@ -6,6 +6,7 @@ import { useConnect } from 'contexts/Connect';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import React, { useEffect, useState } from 'react';
 import { MaybeAccount } from 'types';
+
 import * as defaults from './defaults';
 
 export interface EstimatedFeeContext {

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -9,6 +9,7 @@ import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import React, { useEffect, useRef, useState } from 'react';
 import { MaybeAccount, Sync } from 'types';
 import { localStorageOrDefault, setStateWithRef } from 'Utils';
+
 import { useApi } from '../Api';
 import { useBalances } from '../Balances';
 import { useConnect } from '../Connect';

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -22,6 +22,7 @@ import {
   sleep,
   toFixedIfNecessary,
 } from 'Utils';
+
 import { useApi } from '../Api';
 import { useBalances } from '../Balances';
 import { useConnect } from '../Connect';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import App from 'App';
 import 'index.css';
+
+import App from 'App';
 import { createRoot } from 'react-dom/client';
+
 import reportWebVitals from './reportWebVitals';
 
 const rootElement = document.getElementById('root');

--- a/src/library/Account/index.tsx
+++ b/src/library/Account/index.tsx
@@ -7,6 +7,7 @@ import { useConnect } from 'contexts/Connect';
 import { useTheme } from 'contexts/Themes';
 import { defaultThemes } from 'theme/default';
 import { clipAddress, convertRemToPixels } from 'Utils';
+
 import Identicon from '../Identicon';
 import { AccountProps } from './types';
 import Wrapper from './Wrapper';

--- a/src/library/Button/index.tsx
+++ b/src/library/Button/index.tsx
@@ -10,6 +10,7 @@ import {
   networkColorSecondary,
   textSecondary,
 } from 'theme';
+
 import { ButtonProps, ButtonWrapperProps } from './types';
 
 export const ButtonRow = styled.div<{ verticalSpacing?: boolean }>`

--- a/src/library/ErrorBoundary/index.tsx
+++ b/src/library/ErrorBoundary/index.tsx
@@ -3,6 +3,7 @@
 
 import { faBug } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { Wrapper } from './Wrapper';
 
 export const ErrorFallbackApp = ({

--- a/src/library/EstimatedTxFee/index.tsx
+++ b/src/library/EstimatedTxFee/index.tsx
@@ -7,6 +7,7 @@ import { EstimatedFeeContext, TxFeesContext, useTxFees } from 'contexts/TxFees';
 import React, { Context, useEffect } from 'react';
 import { defaultThemes } from 'theme/default';
 import { humanNumber, planckBnToUnit } from 'Utils';
+
 import { EstimatedTxFeeProps } from './types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/Filter/Container.tsx
+++ b/src/library/Filter/Container.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+
 import { Wrapper } from './Wrappers';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {

--- a/src/library/Filter/Item.tsx
+++ b/src/library/Filter/Item.tsx
@@ -3,6 +3,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
+
 import { ItemProps } from './types';
 import { ItemWrapper } from './Wrappers';
 

--- a/src/library/Filter/LargeItem.tsx
+++ b/src/library/Filter/LargeItem.tsx
@@ -3,6 +3,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
+
 import { LargeItemWrapper } from './Wrappers';
 
 export const LargeItem = (props: any) => {

--- a/src/library/Filter/context.tsx
+++ b/src/library/Filter/context.tsx
@@ -5,6 +5,7 @@ import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
 import { useApi } from 'contexts/Api';
 import { useValidators } from 'contexts/Validators';
 import React, { useState } from 'react';
+
 import * as defaults from './defaults';
 import { ValidatorFilterContextInterface } from './types';
 

--- a/src/library/Form/AccountDropdown/index.tsx
+++ b/src/library/Form/AccountDropdown/index.tsx
@@ -10,6 +10,7 @@ import Identicon from 'library/Identicon';
 import { useEffect, useState } from 'react';
 import { defaultThemes, networkColors } from 'theme/default';
 import { convertRemToPixels } from 'Utils';
+
 import { AccountDropdownProps, InputItem } from '../types';
 import { StyledController, StyledDownshift, StyledDropdown } from './Wrappers';
 

--- a/src/library/Form/AccountSelect/index.tsx
+++ b/src/library/Form/AccountSelect/index.tsx
@@ -11,6 +11,7 @@ import { StatusLabel } from 'library/StatusLabel';
 import { useEffect, useState } from 'react';
 import { defaultThemes, networkColors } from 'theme/default';
 import { clipAddress, convertRemToPixels } from 'Utils';
+
 import { AccountSelectProps, InputItem } from '../types';
 import { StyledController, StyledDownshift, StyledSelect } from './Wrappers';
 

--- a/src/library/Form/Bond/BondFeedback.tsx
+++ b/src/library/Form/Bond/BondFeedback.tsx
@@ -13,6 +13,7 @@ import { useTxFees } from 'contexts/TxFees';
 import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
 import { useEffect, useState } from 'react';
 import { humanNumber, planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { BondFeedbackProps } from '../types';
 import { Warning } from '../Warning';
 import { Spacer } from '../Wrappers';

--- a/src/library/Form/Bond/BondInput.tsx
+++ b/src/library/Form/Bond/BondInput.tsx
@@ -6,6 +6,7 @@ import { useConnect } from 'contexts/Connect';
 import { Button } from 'library/Button';
 import { useEffect, useState } from 'react';
 import { isNumeric } from 'Utils';
+
 import { BondInputProps } from '../types';
 import { InputWrapper, RowWrapper } from '../Wrappers';
 

--- a/src/library/Form/CreatePoolStatusBar/index.tsx
+++ b/src/library/Form/CreatePoolStatusBar/index.tsx
@@ -8,6 +8,7 @@ import { useApi } from 'contexts/Api';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useUi } from 'contexts/UI';
 import { planckBnToUnit } from 'Utils';
+
 import { NominateStatusBarProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/Form/Dropdown/index.tsx
+++ b/src/library/Form/Dropdown/index.tsx
@@ -8,6 +8,7 @@ import { useTheme } from 'contexts/Themes';
 import { useCombobox } from 'downshift';
 import { useState } from 'react';
 import { defaultThemes, networkColors } from 'theme/default';
+
 import { StyledDownshift, StyledDropdown } from '../AccountDropdown/Wrappers';
 import { DropdownInput, DropdownProps } from '../types';
 

--- a/src/library/Form/NominateStatusBar/index.tsx
+++ b/src/library/Form/NominateStatusBar/index.tsx
@@ -9,6 +9,7 @@ import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { planckBnToUnit } from 'Utils';
+
 import { NominateStatusBarProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/Form/Unbond/UnbondFeedback.tsx
+++ b/src/library/Form/Unbond/UnbondFeedback.tsx
@@ -13,6 +13,7 @@ import { useTxFees } from 'contexts/TxFees';
 import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
 import { useEffect, useState } from 'react';
 import { humanNumber, planckBnToUnit } from 'Utils';
+
 import { UnbondFeedbackProps } from '../types';
 import { Warning } from '../Warning';
 import { Spacer } from '../Wrappers';

--- a/src/library/Form/Unbond/UnbondInput.tsx
+++ b/src/library/Form/Unbond/UnbondInput.tsx
@@ -6,6 +6,7 @@ import { useConnect } from 'contexts/Connect';
 import { Button } from 'library/Button';
 import React, { useEffect, useState } from 'react';
 import { isNumeric } from 'Utils';
+
 import { UnbondInputProps } from '../types';
 import { InputWrapper, RowWrapper } from '../Wrappers';
 

--- a/src/library/Form/Utils/getEligibleControllers.tsx
+++ b/src/library/Form/Utils/getEligibleControllers.tsx
@@ -8,6 +8,7 @@ import { useConnect } from 'contexts/Connect';
 import { ImportedAccount } from 'contexts/Connect/types';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit } from 'Utils';
+
 import { InputItem } from '../types';
 
 export const getEligibleControllers = (): Array<InputItem> => {

--- a/src/library/Form/Warning/index.tsx
+++ b/src/library/Form/Warning/index.tsx
@@ -3,6 +3,7 @@
 
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { WarningProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/GenerateNominations/index.tsx
+++ b/src/library/GenerateNominations/index.tsx
@@ -21,6 +21,7 @@ import { SelectableWrapper } from 'library/List';
 import { ValidatorList } from 'library/ValidatorList';
 import { Wrapper } from 'pages/Overview/NetworkSats/Wrappers';
 import { useEffect, useRef, useState } from 'react';
+
 import {
   GenerateNominationsInnerProps,
   Nominations,

--- a/src/library/Graphs/Bonded.tsx
+++ b/src/library/Graphs/Bonded.tsx
@@ -7,6 +7,7 @@ import { useTheme } from 'contexts/Themes';
 import { Doughnut } from 'react-chartjs-2';
 import { defaultThemes, networkColors } from 'theme/default';
 import { humanNumber } from 'Utils';
+
 import { BondedProps } from './types';
 import { GraphWrapper } from './Wrappers';
 

--- a/src/library/Graphs/EraPoints.tsx
+++ b/src/library/Graphs/EraPoints.tsx
@@ -15,6 +15,7 @@ import { useApi } from 'contexts/Api';
 import { useTheme } from 'contexts/Themes';
 import { Line } from 'react-chartjs-2';
 import { defaultThemes, networkColors } from 'theme/default';
+
 import { EraPointsProps } from './types';
 
 ChartJS.register(

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -28,6 +28,7 @@ import {
 } from 'theme/default';
 import { AnySubscan } from 'types';
 import { humanNumber } from 'Utils';
+
 import { PayoutBarProps } from './types';
 import { formatRewardsForGraphs } from './Utils';
 

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -25,6 +25,7 @@ import {
 } from 'theme/default';
 import { AnySubscan } from 'types';
 import { humanNumber } from 'Utils';
+
 import { PayoutLineProps } from './types';
 import { combineRewardsByDay, formatRewardsForGraphs } from './Utils';
 

--- a/src/library/Graphs/StatBoxPie.tsx
+++ b/src/library/Graphs/StatBoxPie.tsx
@@ -10,6 +10,7 @@ import {
   networkColors,
   networkColorsTransparent,
 } from 'theme/default';
+
 import { StatPieProps } from './types';
 
 ChartJS.register(ArcElement, Tooltip);

--- a/src/library/Graphs/Wrappers.ts
+++ b/src/library/Graphs/Wrappers.ts
@@ -13,6 +13,7 @@ import {
   textPrimary,
   textSecondary,
 } from 'theme';
+
 import {
   CardHeaderWrapperProps,
   CardWrapperProps,

--- a/src/library/Headers/Connect.tsx
+++ b/src/library/Headers/Connect.tsx
@@ -5,6 +5,7 @@ import { faWallet } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
 import { useModal } from 'contexts/Modal';
+
 import { HeadingWrapper, Item } from './Wrappers';
 
 export const Connect = () => {

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -8,6 +8,7 @@ import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { PoolAccount } from 'library/PoolAccount';
 import { clipAddress } from 'Utils';
+
 import { Account } from '../Account';
 import { HeadingWrapper } from './Wrappers';
 

--- a/src/library/Headers/Dropdown.tsx
+++ b/src/library/Headers/Dropdown.tsx
@@ -3,6 +3,7 @@
 
 import { useOutsideAlerter } from 'library/Hooks';
 import { useRef } from 'react';
+
 import { DropdownProps } from './types';
 
 export const Dropdown = (props: DropdownProps) => {

--- a/src/library/Headers/SideMenuToggle.tsx
+++ b/src/library/Headers/SideMenuToggle.tsx
@@ -4,6 +4,7 @@
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useUi } from 'contexts/UI';
+
 import { Item } from './Wrappers';
 
 export const SideMenuToggle = () => {

--- a/src/library/Headers/index.tsx
+++ b/src/library/Headers/index.tsx
@@ -6,6 +6,7 @@ import { useUi } from 'contexts/UI';
 import { useValidators } from 'contexts/Validators';
 import { useLocation } from 'react-router-dom';
 import { pageFromUri } from 'Utils';
+
 import { Connect } from './Connect';
 import { Connected } from './Connected';
 import { SideMenuToggle } from './SideMenuToggle';

--- a/src/library/Help/Items/Definition.tsx
+++ b/src/library/Help/Items/Definition.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState } from 'react';
+
 import { DefinitionWrapper } from '../Wrappers';
 
 export const Heading = (props: any) => {

--- a/src/library/Help/Items/External.tsx
+++ b/src/library/Help/Items/External.tsx
@@ -4,6 +4,7 @@
 import { faExternalLinkAlt as faExt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
+
 import { ItemWrapper } from '../Wrappers';
 
 export const External = (props: any) => {

--- a/src/library/Help/index.tsx
+++ b/src/library/Help/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'contexts/Help/types';
 import { useAnimation } from 'framer-motion';
 import { useEffect } from 'react';
+
 import Definition from './Items/Definition';
 import External from './Items/External';
 import { ContentWrapper, HeightWrapper, Wrapper } from './Wrappers';

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -11,6 +11,7 @@ import { useNotifications } from 'contexts/Notifications';
 import { useTxFees } from 'contexts/TxFees';
 import { useEffect, useState } from 'react';
 import { AnyApi } from 'types';
+
 import { UseSubmitExtrinsic, UseSubmitExtrinsicProps } from './types';
 
 export const useSubmitExtrinsic = (

--- a/src/library/Identicon/index.tsx
+++ b/src/library/Identicon/index.tsx
@@ -4,6 +4,7 @@
 import { Identicon as IdenticonDefault } from '@polkadot/react-identicon';
 import styled from 'styled-components';
 import { backgroundIdenticon } from 'theme';
+
 import { IdenticonProps } from './types';
 
 const Wrapper = styled.div`

--- a/src/library/List/Selectable.tsx
+++ b/src/library/List/Selectable.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { SelectableWrapper } from '.';
 import { useList } from './context';
 

--- a/src/library/List/context.tsx
+++ b/src/library/List/context.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
+
 import * as defaults from './defaults';
 
 export const ListContext: React.Context<any> = React.createContext(

--- a/src/library/List/index.ts
+++ b/src/library/List/index.ts
@@ -3,6 +3,7 @@
 
 import styled from 'styled-components';
 import { borderPrimary, networkColor, textPrimary, textSecondary } from 'theme';
+
 import { ListProps, PaginationWrapperProps } from './types';
 
 export const Wrapper = styled.div`

--- a/src/library/ListItem/Labels/Blocked.tsx
+++ b/src/library/ListItem/Labels/Blocked.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTooltip } from 'contexts/Tooltip';
 import { TooltipPosition, TooltipTrigger } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { BlockedProps } from '../types';
 
 export const Blocked = (props: BlockedProps) => {

--- a/src/library/ListItem/Labels/CopyAddress.tsx
+++ b/src/library/ListItem/Labels/CopyAddress.tsx
@@ -6,6 +6,7 @@ import { faCopy } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useNotifications } from 'contexts/Notifications';
 import { NotificationText } from 'contexts/Notifications/types';
+
 import { CopyAddressProps } from '../types';
 
 export const CopyAddress = (props: CopyAddressProps) => {

--- a/src/library/ListItem/Labels/FavoritePool.tsx
+++ b/src/library/ListItem/Labels/FavoritePool.tsx
@@ -10,6 +10,7 @@ import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useTooltip } from 'contexts/Tooltip';
 import { TooltipPosition, TooltipTrigger } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { FavoriteProps } from '../types';
 
 export const FavoritePool = (props: FavoriteProps) => {

--- a/src/library/ListItem/Labels/FavoriteValidator.tsx
+++ b/src/library/ListItem/Labels/FavoriteValidator.tsx
@@ -10,6 +10,7 @@ import { useTooltip } from 'contexts/Tooltip';
 import { useValidators } from 'contexts/Validators';
 import { TooltipPosition, TooltipTrigger } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { FavoriteProps } from '../types';
 
 export const FavoriteValidator = (props: FavoriteProps) => {

--- a/src/library/ListItem/Labels/Identity.tsx
+++ b/src/library/ListItem/Labels/Identity.tsx
@@ -4,6 +4,7 @@
 import Identicon from 'library/Identicon';
 import { IdentityWrapper } from 'library/ListItem/Wrappers';
 import { clipAddress } from 'Utils';
+
 import { getIdentityDisplay } from '../../ValidatorList/Validator/Utils';
 import { IdentityProps } from '../types';
 

--- a/src/library/ListItem/Labels/Metrics.tsx
+++ b/src/library/ListItem/Labels/Metrics.tsx
@@ -4,6 +4,7 @@
 import { faChartLine } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useModal } from 'contexts/Modal';
+
 import { MetricsProps } from '../types';
 
 export const Metrics = (props: MetricsProps) => {

--- a/src/library/ListItem/Labels/NominationStatus.tsx
+++ b/src/library/ListItem/Labels/NominationStatus.tsx
@@ -12,6 +12,7 @@ import {
   planckBnToUnit,
   rmCommas,
 } from 'Utils';
+
 import { NominationStatusProps } from '../types';
 
 export const NominationStatus = (props: NominationStatusProps) => {

--- a/src/library/ListItem/Labels/Oversubscribed.tsx
+++ b/src/library/ListItem/Labels/Oversubscribed.tsx
@@ -13,6 +13,7 @@ import {
   TooltipTrigger,
 } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { OversubscribedProps } from '../types';
 
 export const Oversubscribed = (props: OversubscribedProps) => {

--- a/src/library/ListItem/Labels/ParaValidator.tsx
+++ b/src/library/ListItem/Labels/ParaValidator.tsx
@@ -7,6 +7,7 @@ import { useTooltip } from 'contexts/Tooltip';
 import { useValidators } from 'contexts/Validators';
 import { TooltipPosition, TooltipTrigger } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { ParaValidatorProps } from '../types';
 
 export const ParaValidator = ({ address }: ParaValidatorProps) => {

--- a/src/library/ListItem/Labels/PoolIdentity.tsx
+++ b/src/library/ListItem/Labels/PoolIdentity.tsx
@@ -5,6 +5,7 @@ import { useBondedPools } from 'contexts/Pools/BondedPools';
 import Identicon from 'library/Identicon';
 import { IdentityWrapper } from 'library/ListItem/Wrappers';
 import { clipAddress, determinePoolDisplay } from 'Utils';
+
 import { PoolIdentityProps } from '../types';
 
 export const PoolIdentity = (props: PoolIdentityProps) => {

--- a/src/library/ListItem/Labels/Select.tsx
+++ b/src/library/ListItem/Labels/Select.tsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { SelectWrapper } from 'library/ListItem/Wrappers';
 import { useTheme } from 'styled-components';
 import { defaultThemes } from 'theme/default';
+
 import { useList } from '../../List/context';
 import { SelectProps } from '../types';
 

--- a/src/library/Menu/index.tsx
+++ b/src/library/Menu/index.tsx
@@ -4,6 +4,7 @@
 import { useMenu } from 'contexts/Menu';
 import { useOutsideAlerter } from 'library/Hooks';
 import { useEffect, useRef } from 'react';
+
 import { ItemWrapper, Wrapper } from './Wrappers';
 
 export const Menu = () => {

--- a/src/library/Modal/Title.tsx
+++ b/src/library/Modal/Title.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useModal } from 'contexts/Modal';
 import { ReactComponent as CrossSVG } from 'img/cross.svg';
 import { FunctionComponent } from 'react';
+
 import { TitleWrapper } from './Wrappers';
 
 interface TitleProps {

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -6,6 +6,7 @@ import { useUi } from 'contexts/UI';
 import { useOutsideAlerter } from 'library/Hooks';
 import { usePrices } from 'library/Hooks/usePrices';
 import { useEffect, useRef, useState } from 'react';
+
 import { Status } from './Status';
 import { NetworkInfo, Separator, Summary, Wrapper } from './Wrappers';
 

--- a/src/library/Notifications/index.tsx
+++ b/src/library/Notifications/index.tsx
@@ -3,6 +3,7 @@
 
 import { useNotifications } from 'contexts/Notifications';
 import { AnimatePresence, motion } from 'framer-motion';
+
 import Wrapper from './Wrapper';
 
 export const Notifications = () => {

--- a/src/library/OpenHelpIcon/index.tsx
+++ b/src/library/OpenHelpIcon/index.tsx
@@ -3,6 +3,7 @@
 
 import { useHelp } from 'contexts/Help';
 import { ReactComponent as IconSVG } from 'img/info-outline.svg';
+
 import { OpenHelpIconProps } from './types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/PageTitle/index.tsx
+++ b/src/library/PageTitle/index.tsx
@@ -5,6 +5,7 @@ import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useRef, useState } from 'react';
 import { MenuPaddingWrapper, PageTitleWrapper } from 'Wrappers';
+
 import { PageTitleProps } from './types';
 
 export const PageTitle = (props: PageTitleProps) => {

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -27,6 +27,7 @@ import {
 } from 'library/ListItem/Wrappers';
 import { usePoolsTabs } from 'pages/Pools/Home/context';
 import { useEffect, useRef, useState } from 'react';
+
 import { JoinPool } from '../ListItem/Labels/JoinPool';
 import { Members } from '../ListItem/Labels/Members';
 import { PoolId } from '../ListItem/Labels/PoolId';

--- a/src/library/PoolAccount/Wrapper.ts
+++ b/src/library/PoolAccount/Wrapper.ts
@@ -4,6 +4,7 @@
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 import { borderSecondary, textSecondary } from 'theme';
+
 import { WrapperProps } from './types';
 
 export const Wrapper = styled(motion.button)<WrapperProps>`

--- a/src/library/PoolAccount/index.tsx
+++ b/src/library/PoolAccount/index.tsx
@@ -9,6 +9,7 @@ import { useTheme } from 'contexts/Themes';
 import Identicon from 'library/Identicon';
 import { useEffect, useState } from 'react';
 import { defaultThemes } from 'theme/default';
+
 import { clipAddress, convertRemToPixels } from '../../Utils';
 import { PoolAccountProps } from './types';
 import Wrapper from './Wrapper';

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -18,6 +18,7 @@ import { SearchInput } from 'library/List/SearchInput';
 import { Pool } from 'library/Pool';
 import React, { useEffect, useRef, useState } from 'react';
 import { networkColors } from 'theme/default';
+
 import { PoolListProvider, usePoolList } from './context';
 import { PoolListProps } from './types';
 

--- a/src/library/SetupSteps/Footer/index.tsx
+++ b/src/library/SetupSteps/Footer/index.tsx
@@ -4,6 +4,7 @@
 import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
 import { Button } from 'library/Button';
+
 import { FooterProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/SetupSteps/Header/index.tsx
+++ b/src/library/SetupSteps/Header/index.tsx
@@ -5,6 +5,7 @@ import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
 import { Button } from 'library/Button';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
+
 import { HeaderProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/SetupSteps/Nominate.tsx
+++ b/src/library/SetupSteps/Nominate.tsx
@@ -7,6 +7,7 @@ import { useUi } from 'contexts/UI';
 import { Footer } from 'library/SetupSteps/Footer';
 import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
+
 import { GenerateNominations } from '../GenerateNominations';
 import { NominationsProps } from './types';
 

--- a/src/library/SideMenu/Main.tsx
+++ b/src/library/SideMenu/Main.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { PAGES_CONFIG, PAGE_CATEGORIES } from 'config/pages';
+import { PAGE_CATEGORIES, PAGES_CONFIG } from 'config/pages';
 import { POLKADOT_URL, URI_PREFIX } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
@@ -14,6 +14,7 @@ import { UIContextInterface } from 'contexts/UI/types';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { PageCategory, PageItem, PagesConfig } from 'types';
+
 import Heading from './Heading/Heading';
 import { Primary } from './Primary';
 import { LogoWrapper } from './Wrapper';

--- a/src/library/SideMenu/Primary/Wrappers.tsx
+++ b/src/library/SideMenu/Primary/Wrappers.tsx
@@ -12,6 +12,7 @@ import {
   warning,
   warningTransparent,
 } from 'theme';
+
 import { MinimisedProps } from '../types';
 
 export const Wrapper = styled(motion.div)<MinimisedProps>`

--- a/src/library/SideMenu/Primary/index.tsx
+++ b/src/library/SideMenu/Primary/index.tsx
@@ -8,6 +8,7 @@ import { useUi } from 'contexts/UI';
 import { useState } from 'react';
 import Lottie from 'react-lottie';
 import { Link } from 'react-router-dom';
+
 import { PrimaryProps } from '../types';
 import { MinimisedWrapper, Wrapper } from './Wrappers';
 

--- a/src/library/SideMenu/Secondary/Wrappers.tsx
+++ b/src/library/SideMenu/Secondary/Wrappers.tsx
@@ -10,6 +10,7 @@ import {
   textPrimary,
   textSecondary,
 } from 'theme';
+
 import { MinimisedProps } from '../types';
 
 export const Wrapper = styled(motion.button)<MinimisedProps>`

--- a/src/library/SideMenu/Secondary/index.tsx
+++ b/src/library/SideMenu/Secondary/index.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 import Lottie from 'react-lottie';
+
 import { SecondaryProps } from '../types';
 import { IconWrapper, MinimisedWrapper, Wrapper } from './Wrappers';
 

--- a/src/library/SideMenu/Wrapper.ts
+++ b/src/library/SideMenu/Wrapper.ts
@@ -14,6 +14,7 @@ import {
   networkColor,
   textSecondary,
 } from 'theme';
+
 import { MinimisedProps } from './types';
 
 export const Wrapper = styled.div<MinimisedProps>`

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -21,6 +21,7 @@ import { useOutsideAlerter } from 'library/Hooks';
 import throttle from 'lodash.throttle';
 import { useEffect, useRef } from 'react';
 import { defaultThemes } from 'theme/default';
+
 import Heading from './Heading/Heading';
 import { Main } from './Main';
 import { Secondary } from './Secondary';

--- a/src/library/Stat/index.tsx
+++ b/src/library/Stat/index.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from 'library/Button';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import React from 'react';
+
 import { StatProps } from './types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/StatBoxList/Item.tsx
+++ b/src/library/StatBoxList/Item.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+
 import { Number } from './Number';
 import { Pie } from './Pie';
 import { Text } from './Text';

--- a/src/library/StatBoxList/Number.tsx
+++ b/src/library/StatBoxList/Number.tsx
@@ -3,6 +3,7 @@
 
 import NumberEasing from 'che-react-number-easing';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
+
 import { StatBox } from './Item';
 import { NumberProps } from './types';
 

--- a/src/library/StatBoxList/Pie.tsx
+++ b/src/library/StatBoxList/Pie.tsx
@@ -4,6 +4,7 @@
 import NumberEasing from 'che-react-number-easing';
 import { StatPie } from 'library/Graphs/StatBoxPie';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
+
 import { StatBox } from './Item';
 import { PieProps } from './types';
 

--- a/src/library/StatBoxList/Text.tsx
+++ b/src/library/StatBoxList/Text.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
+
 import { StatBox } from './Item';
 import { TextProps } from './types';
 

--- a/src/library/StatBoxList/Wrapper.ts
+++ b/src/library/StatBoxList/Wrapper.ts
@@ -3,7 +3,6 @@
 
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
-
 import {
   backgroundSecondary,
   borderPrimary,

--- a/src/library/StatBoxList/index.tsx
+++ b/src/library/StatBoxList/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+
 import { ListWrapper, Wrapper } from './Wrapper';
 
 export const StatBoxList = ({ children }: { children: React.ReactNode }) => {

--- a/src/library/StatusButton/index.tsx
+++ b/src/library/StatusButton/index.tsx
@@ -5,6 +5,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faCircle } from '@fortawesome/free-regular-svg-icons';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { StatusButtonProps } from './types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/StatusLabel/Wrapper.ts
+++ b/src/library/StatusLabel/Wrapper.ts
@@ -3,6 +3,7 @@
 
 import styled from 'styled-components';
 import { backgroundLabel, textSecondary } from 'theme';
+
 import { WrapperProps } from './types';
 
 export const Wrapper = styled.div<WrapperProps>`

--- a/src/library/StatusLabel/index.tsx
+++ b/src/library/StatusLabel/index.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
+
 import { StatusLabelProps } from './types';
 import { Wrapper } from './Wrapper';
 

--- a/src/library/SubscanButton/index.tsx
+++ b/src/library/SubscanButton/index.tsx
@@ -8,6 +8,7 @@ import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
 import styled from 'styled-components';
 import { defaultThemes, networkColors } from 'theme/default';
+
 import { WrapperProps } from './types';
 
 const Wrapper = styled.div<WrapperProps>`

--- a/src/library/Tooltip/index.tsx
+++ b/src/library/Tooltip/index.tsx
@@ -3,6 +3,7 @@
 
 import { useTooltip } from 'contexts/Tooltip';
 import { useEffect, useRef } from 'react';
+
 import { Wrapper } from './Wrapper';
 
 export const Tooltip = () => {

--- a/src/library/ValidatorList/Validator/Default.tsx
+++ b/src/library/ValidatorList/Validator/Default.tsx
@@ -18,6 +18,7 @@ import {
   Wrapper,
 } from 'library/ListItem/Wrappers';
 import { useRef } from 'react';
+
 import { useValidators } from '../../../contexts/Validators';
 import { useList } from '../../List/context';
 import { Blocked } from '../../ListItem/Labels/Blocked';

--- a/src/library/ValidatorList/Validator/Nomination.tsx
+++ b/src/library/ValidatorList/Validator/Nomination.tsx
@@ -4,6 +4,7 @@
 import { useValidators } from 'contexts/Validators';
 import { ParaValidator } from 'library/ListItem/Labels/ParaValidator';
 import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
+
 import { useList } from '../../List/context';
 import { Blocked } from '../../ListItem/Labels/Blocked';
 import { Commission } from '../../ListItem/Labels/Commission';

--- a/src/library/ValidatorList/Validator/index.tsx
+++ b/src/library/ValidatorList/Validator/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+
 import { Default } from './Default';
 import { Nomination } from './Nomination';
 

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -25,6 +25,7 @@ import { Selectable } from 'library/List/Selectable';
 import { Validator } from 'library/ValidatorList/Validator';
 import React, { useEffect, useRef, useState } from 'react';
 import { networkColors } from 'theme/default';
+
 import { ListProvider, useList } from '../List/context';
 import { Filters } from './Filters';
 

--- a/src/modals/AccountPoolRoles/index.tsx
+++ b/src/modals/AccountPoolRoles/index.tsx
@@ -11,6 +11,7 @@ import { BondedPool } from 'contexts/Pools/types';
 import Identicon from 'library/Identicon';
 import { Title } from 'library/Modal/Title';
 import { useStatusButtons } from 'pages/Pools/Home/Status/useStatusButtons';
+
 import { PaddingWrapper } from '../Wrappers';
 import { ContentWrapper, StyledButton } from './Wrappers';
 

--- a/src/modals/Bio/index.tsx
+++ b/src/modals/Bio/index.tsx
@@ -3,6 +3,7 @@
 
 import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
+
 import { PaddingWrapper } from '../Wrappers';
 import { Wrapper } from './Wrapper';
 

--- a/src/modals/ChangeNominations/index.tsx
+++ b/src/modals/ChangeNominations/index.tsx
@@ -16,6 +16,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
+
 import {
   FooterWrapper,
   NotesWrapper,

--- a/src/modals/ChangePoolRoles/RoleChange.tsx
+++ b/src/modals/ChangePoolRoles/RoleChange.tsx
@@ -5,6 +5,7 @@ import { faAnglesRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Identicon from 'library/Identicon';
 import { clipAddress, convertRemToPixels } from 'Utils';
+
 import { RoleChangeWrapper } from './Wrapper';
 
 export const RoleChange = ({ roleName, oldAddress, newAddress }: any) => {

--- a/src/modals/ChangePoolRoles/index.tsx
+++ b/src/modals/ChangePoolRoles/index.tsx
@@ -13,6 +13,7 @@ import { useTxFees } from 'contexts/TxFees';
 import { EstimatedTxFee } from 'library/EstimatedTxFee';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
+
 import { FooterWrapper, NotesWrapper } from '../Wrappers';
 import { RoleChange } from './RoleChange';
 import Wrapper from './Wrapper';

--- a/src/modals/ClaimReward/index.tsx
+++ b/src/modals/ClaimReward/index.tsx
@@ -17,6 +17,7 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit } from 'Utils';
+
 import { FooterWrapper, PaddingWrapper, Separator } from '../Wrappers';
 
 export const ClaimReward = () => {

--- a/src/modals/ConnectAccounts/Account.tsx
+++ b/src/modals/ConnectAccounts/Account.tsx
@@ -9,6 +9,7 @@ import { Extension } from 'contexts/Connect/types';
 import { useModal } from 'contexts/Modal';
 import Identicon from 'library/Identicon';
 import { clipAddress } from 'Utils';
+
 import { AccountElementProps } from './types';
 import { AccountWrapper } from './Wrappers';
 

--- a/src/modals/ConnectAccounts/Accounts.tsx
+++ b/src/modals/ConnectAccounts/Accounts.tsx
@@ -17,6 +17,7 @@ import { PoolMembership } from 'contexts/Pools/types';
 import Button from 'library/Button';
 import { forwardRef, useEffect, useState } from 'react';
 import { AnyJson } from 'types';
+
 import { AccountButton, AccountElement } from './Account';
 import {
   ActivelyStakingAccount,

--- a/src/modals/ConnectAccounts/Extension.tsx
+++ b/src/modals/ConnectAccounts/Extension.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
 import { Extension as ExtensionInterface } from 'contexts/Connect/types';
 import { useState } from 'react';
+
 import { ExtensionProps } from './types';
 import { ExtensionWrapper } from './Wrappers';
 

--- a/src/modals/ConnectAccounts/Extensions.tsx
+++ b/src/modals/ConnectAccounts/Extensions.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ExtensionConfig, EXTENSIONS } from 'config/extensions';
 import { useConnect } from 'contexts/Connect';
 import { forwardRef } from 'react';
+
 import { Extension } from './Extension';
 import { ReadOnly } from './ReadOnly';
 import { forwardRefProps } from './types';

--- a/src/modals/ConnectAccounts/ReadOnly/index.tsx
+++ b/src/modals/ConnectAccounts/ReadOnly/index.tsx
@@ -5,6 +5,7 @@ import { faCog, faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
 import { ExternalAccount, ImportedAccount } from 'contexts/Connect/types';
+
 import { ReadOnlyInput } from '../ReadOnlyInput';
 import { ReadOnlyProps } from '../types';
 import { ExtensionWrapper } from '../Wrappers';

--- a/src/modals/ConnectAccounts/ReadOnlyInput/index.tsx
+++ b/src/modals/ConnectAccounts/ReadOnlyInput/index.tsx
@@ -6,6 +6,7 @@ import { ImportedAccount } from 'contexts/Connect/types';
 import Button from 'library/Button';
 import React, { useState } from 'react';
 import { isValidAddress } from 'Utils';
+
 import { Wrapper } from './Wrapper';
 
 export const ReadOnlyInput = () => {

--- a/src/modals/ConnectAccounts/index.tsx
+++ b/src/modals/ConnectAccounts/index.tsx
@@ -5,6 +5,7 @@ import { useConnect } from 'contexts/Connect';
 import { ImportedAccount } from 'contexts/Connect/types';
 import { useModal } from 'contexts/Modal';
 import { useEffect, useRef, useState } from 'react';
+
 import { Accounts } from './Accounts';
 import { Extensions } from './Extensions';
 import { CardsWrapper, Wrapper } from './Wrappers';

--- a/src/modals/GoToFeedback/index.tsx
+++ b/src/modals/GoToFeedback/index.tsx
@@ -5,6 +5,7 @@ import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ReactComponent as ForumSVG } from 'img/forum.svg';
 import { Title } from 'library/Modal/Title';
+
 import { NotesWrapper, PaddingWrapper } from '../Wrappers';
 
 export const GoToFeedback = () => {

--- a/src/modals/JoinPool/Forms.tsx
+++ b/src/modals/JoinPool/Forms.tsx
@@ -18,6 +18,7 @@ import { BondFeedback } from 'library/Form/Bond/BondFeedback';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { FooterWrapper, NotesWrapper } from '../Wrappers';
 import { ContentWrapper } from './Wrapper';
 

--- a/src/modals/JoinPool/index.tsx
+++ b/src/modals/JoinPool/index.tsx
@@ -3,6 +3,7 @@
 
 import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { Title } from 'library/Modal/Title';
+
 import { PaddingWrapper } from '../Wrappers';
 import { Forms } from './Forms';
 

--- a/src/modals/LeavePool/index.tsx
+++ b/src/modals/LeavePool/index.tsx
@@ -4,6 +4,7 @@
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
 import { Title } from 'library/Modal/Title';
 import { UnbondAll } from 'modals/UpdateBond/Forms/UnbondAll';
+
 import { PaddingWrapper } from '../Wrappers';
 
 export const LeavePool = () => {

--- a/src/modals/ManagePool/Forms.tsx
+++ b/src/modals/ManagePool/Forms.tsx
@@ -18,6 +18,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import React, { forwardRef, useEffect, useState } from 'react';
 import { Separator } from 'Wrappers';
+
 import { FooterWrapper, NotesWrapper } from '../Wrappers';
 import { ContentWrapper } from './Wrappers';
 

--- a/src/modals/ManagePool/Tasks.tsx
+++ b/src/modals/ManagePool/Tasks.tsx
@@ -7,6 +7,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { PoolState } from 'contexts/Pools/types';
 import { Warning } from 'library/Form/Warning';
 import { forwardRef } from 'react';
+
 import { ContentWrapper } from './Wrappers';
 
 export const Tasks = forwardRef((props: any, ref: any) => {

--- a/src/modals/ManagePool/index.tsx
+++ b/src/modals/ManagePool/index.tsx
@@ -5,6 +5,7 @@ import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useRef, useState } from 'react';
+
 import { Forms } from './Forms';
 import { Tasks } from './Tasks';
 import { CardsWrapper, FixedContentWrapper, Wrapper } from './Wrappers';

--- a/src/modals/Networks/Wrapper.ts
+++ b/src/modals/Networks/Wrapper.ts
@@ -11,6 +11,7 @@ import {
   textSecondary,
   textSuccess,
 } from 'theme';
+
 import { NetworkButtonProps } from './types';
 
 export const Wrapper = styled.div`

--- a/src/modals/Networks/index.tsx
+++ b/src/modals/Networks/index.tsx
@@ -9,6 +9,7 @@ import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
 import { NetworkName } from 'types';
+
 import { ReactComponent as BraveIconSVG } from '../../img/brave-logo.svg';
 import { PaddingWrapper } from '../Wrappers';
 import {

--- a/src/modals/Nominate/index.tsx
+++ b/src/modals/Nominate/index.tsx
@@ -17,6 +17,7 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit } from 'Utils';
+
 import {
   FooterWrapper,
   NotesWrapper,

--- a/src/modals/NominateFromFavorites/index.tsx
+++ b/src/modals/NominateFromFavorites/index.tsx
@@ -18,6 +18,7 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { ValidatorList } from 'library/ValidatorList';
 import { useEffect, useState } from 'react';
+
 import { FooterWrapper, NotesWrapper, PaddingWrapper } from '../Wrappers';
 import { ListWrapper } from './Wrappers';
 

--- a/src/modals/NominatePool/index.tsx
+++ b/src/modals/NominatePool/index.tsx
@@ -15,6 +15,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
+
 import {
   FooterWrapper,
   NotesWrapper,

--- a/src/modals/PoolNominations/index.tsx
+++ b/src/modals/PoolNominations/index.tsx
@@ -4,6 +4,7 @@
 import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
 import { ValidatorList } from 'library/ValidatorList';
+
 import { PaddingWrapper } from '../Wrappers';
 import { ListWrapper } from './Wrappers';
 

--- a/src/modals/SelectFavorites/index.tsx
+++ b/src/modals/SelectFavorites/index.tsx
@@ -8,6 +8,7 @@ import { Validator } from 'contexts/Validators/types';
 import { Title } from 'library/Modal/Title';
 import { ValidatorList } from 'library/ValidatorList';
 import { useEffect, useState } from 'react';
+
 import { PaddingWrapper } from '../Wrappers';
 import { FooterWrapper, ListWrapper } from './Wrappers';
 

--- a/src/modals/Settings/index.tsx
+++ b/src/modals/Settings/index.tsx
@@ -4,6 +4,7 @@
 import { useUi } from 'contexts/UI';
 import { Title } from 'library/Modal/Title';
 import { StatusButton } from 'library/StatusButton';
+
 import { PaddingWrapper } from '../Wrappers';
 
 export const Settings = () => {

--- a/src/modals/UnlockChunks/Forms.tsx
+++ b/src/modals/UnlockChunks/Forms.tsx
@@ -21,6 +21,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { forwardRef, useEffect, useState } from 'react';
 import { planckBnToUnit, rmCommas } from 'Utils';
+
 import { FooterWrapper, NotesWrapper, Separator } from '../Wrappers';
 import { ContentWrapper } from './Wrappers';
 

--- a/src/modals/UnlockChunks/Overview.tsx
+++ b/src/modals/UnlockChunks/Overview.tsx
@@ -7,6 +7,7 @@ import { useNetworkMetrics } from 'contexts/Network';
 import Button from 'library/Button';
 import { forwardRef } from 'react';
 import { planckBnToUnit } from 'Utils';
+
 import { NotesWrapper, Separator } from '../Wrappers';
 import { ChunkWrapper, ContentWrapper } from './Wrappers';
 

--- a/src/modals/UnlockChunks/index.tsx
+++ b/src/modals/UnlockChunks/index.tsx
@@ -8,6 +8,7 @@ import { useModal } from 'contexts/Modal';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useRef, useState } from 'react';
+
 import { Forms } from './Forms';
 import { Overview } from './Overview';
 import { CardsWrapper, FixedContentWrapper, Wrapper } from './Wrappers';

--- a/src/modals/UpdateBond/Forms/BondAll.tsx
+++ b/src/modals/UpdateBond/Forms/BondAll.tsx
@@ -15,6 +15,7 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { defaultThemes } from 'theme/default';
 import { planckBnToUnit } from 'Utils';
+
 import { NotesWrapper, Separator } from '../../Wrappers';
 import { FormsProps } from '../types';
 import { FormFooter } from './FormFooter';

--- a/src/modals/UpdateBond/Forms/BondSome.tsx
+++ b/src/modals/UpdateBond/Forms/BondSome.tsx
@@ -15,6 +15,7 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { defaultThemes } from 'theme/default';
 import { planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { NotesWrapper } from '../../Wrappers';
 import { FormsProps } from '../types';
 import { FormFooter } from './FormFooter';

--- a/src/modals/UpdateBond/Forms/FormFooter.tsx
+++ b/src/modals/UpdateBond/Forms/FormFooter.tsx
@@ -5,6 +5,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faArrowAltCircleUp } from '@fortawesome/free-regular-svg-icons';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { FooterWrapper } from '../../Wrappers';
 
 export const FormFooter = ({

--- a/src/modals/UpdateBond/Forms/UnbondAll.tsx
+++ b/src/modals/UpdateBond/Forms/UnbondAll.tsx
@@ -13,6 +13,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { NotesWrapper, Separator } from '../../Wrappers';
 import { FormsProps } from '../types';
 import { FormFooter } from './FormFooter';

--- a/src/modals/UpdateBond/Forms/UnbondPoolToMinimum.tsx
+++ b/src/modals/UpdateBond/Forms/UnbondPoolToMinimum.tsx
@@ -14,6 +14,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { NotesWrapper, Separator } from '../../Wrappers';
 import { FormsProps } from '../types';
 import { FormFooter } from './FormFooter';

--- a/src/modals/UpdateBond/Forms/UnbondSome.tsx
+++ b/src/modals/UpdateBond/Forms/UnbondSome.tsx
@@ -15,6 +15,7 @@ import { UnbondFeedback } from 'library/Form/Unbond/UnbondFeedback';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { useEffect, useState } from 'react';
 import { planckBnToUnit, unitToPlanckBn } from 'Utils';
+
 import { NotesWrapper } from '../../Wrappers';
 import { FormsProps } from '../types';
 import { FormFooter } from './FormFooter';

--- a/src/modals/UpdateBond/Forms/index.tsx
+++ b/src/modals/UpdateBond/Forms/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { forwardRef } from 'react';
+
 import { ContentWrapper } from '../Wrappers';
 import { BondAll } from './BondAll';
 import { BondSome } from './BondSome';

--- a/src/modals/UpdateBond/Tasks.tsx
+++ b/src/modals/UpdateBond/Tasks.tsx
@@ -9,6 +9,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { forwardRef } from 'react';
 import { planckBnToUnit } from 'Utils';
+
 import { ContentWrapper } from './Wrappers';
 
 export const Tasks = forwardRef((props: any, ref: any) => {

--- a/src/modals/UpdateBond/index.tsx
+++ b/src/modals/UpdateBond/index.tsx
@@ -5,6 +5,7 @@ import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useRef, useState } from 'react';
+
 import { Forms } from './Forms';
 import { Tasks } from './Tasks';
 import { CardsWrapper, FixedContentWrapper, Wrapper } from './Wrappers';

--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -19,6 +19,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
+
 import { FooterWrapper, NotesWrapper } from '../Wrappers';
 import Wrapper from './Wrapper';
 

--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -18,6 +18,7 @@ import { Warning } from 'library/Form/Warning';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Title } from 'library/Modal/Title';
 import { useEffect, useState } from 'react';
+
 import { FooterWrapper, PaddingWrapper } from '../Wrappers';
 
 export const UpdatePayee = () => {

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -6,6 +6,7 @@ import { useAnimation } from 'framer-motion';
 import { ErrorFallbackModal } from 'library/ErrorBoundary';
 import { useEffect, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+
 import { AccountPoolRoles } from './AccountPoolRoles';
 import { Bio } from './Bio';
 import { ChangeNominations } from './ChangeNominations';

--- a/src/pages/Community/Entity.tsx
+++ b/src/pages/Community/Entity.tsx
@@ -10,6 +10,7 @@ import ValidatorList from 'library/ValidatorList';
 import { useEffect, useState } from 'react';
 import { shuffle } from 'Utils';
 import { PageRowWrapper, TopBarWrapper } from 'Wrappers';
+
 import { useCommunitySections } from './context';
 import { Item } from './Item';
 import { ItemsWrapper } from './Wrappers';

--- a/src/pages/Community/Item.tsx
+++ b/src/pages/Community/Item.tsx
@@ -11,6 +11,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useApi } from 'contexts/Api';
 import { useModal } from 'contexts/Modal';
+
 import { useCommunitySections } from './context';
 import { ItemProps } from './types';
 import { ItemWrapper } from './Wrappers';

--- a/src/pages/Community/List.tsx
+++ b/src/pages/Community/List.tsx
@@ -5,6 +5,7 @@ import { useApi } from 'contexts/Api';
 import { useValidators } from 'contexts/Validators';
 import { useEffect, useState } from 'react';
 import { PageRowWrapper } from 'Wrappers';
+
 import { useCommunitySections } from './context';
 import { Item } from './Item';
 import { ItemsWrapper } from './Wrappers';

--- a/src/pages/Community/context.tsx
+++ b/src/pages/Community/context.tsx
@@ -3,6 +3,7 @@
 
 import { useApi } from 'contexts/Api';
 import React, { useEffect, useState } from 'react';
+
 import * as defaults from './defaults';
 
 export const CommunitySectionsContext: React.Context<any> = React.createContext(

--- a/src/pages/Community/index.tsx
+++ b/src/pages/Community/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PageTitle } from 'library/PageTitle';
+
 import { PageProps } from '../types';
 import { CommunitySectionsProvider, useCommunitySections } from './context';
 import { Entity } from './Entity';

--- a/src/pages/Favorites/index.tsx
+++ b/src/pages/Favorites/index.tsx
@@ -7,6 +7,7 @@ import { CardWrapper } from 'library/Graphs/Wrappers';
 import { PageTitle } from 'library/PageTitle';
 import { ValidatorList } from 'library/ValidatorList';
 import { PageRowWrapper } from 'Wrappers';
+
 import { PageProps } from '../types';
 
 export const Favorites = (props: PageProps) => {

--- a/src/pages/Nominate/Active/Controller/index.tsx
+++ b/src/pages/Nominate/Active/Controller/index.tsx
@@ -12,6 +12,7 @@ import { Identicon } from 'library/Identicon';
 import OpenHelpIcon from 'library/OpenHelpIcon';
 import { Wrapper as StatWrapper } from 'library/Stat/Wrapper';
 import { clipAddress } from 'Utils';
+
 import { Wrapper } from './Wrapper';
 
 export const Controller = ({ label }: { label: string }) => {

--- a/src/pages/Nominate/Active/Nominations/index.tsx
+++ b/src/pages/Nominate/Active/Nominations/index.tsx
@@ -15,6 +15,7 @@ import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { ValidatorList } from 'library/ValidatorList';
 import { MaybeAccount } from 'types';
+
 import { Wrapper } from './Wrapper';
 
 export const Nominations = ({

--- a/src/pages/Nominate/Active/Status.tsx
+++ b/src/pages/Nominate/Active/Status.tsx
@@ -21,6 +21,7 @@ import { CardWrapper } from 'library/Graphs/Wrappers';
 import Stat from 'library/Stat';
 import { planckBnToUnit, rmCommas } from 'Utils';
 import { Separator } from 'Wrappers';
+
 import { Controller } from './Controller';
 
 export const Status = ({ height }: { height: number }) => {

--- a/src/pages/Nominate/Active/index.tsx
+++ b/src/pages/Nominate/Active/index.tsx
@@ -22,6 +22,7 @@ import {
   RowPrimaryWrapper,
   RowSecondaryWrapper,
 } from 'Wrappers';
+
 import { ControllerNotImported } from './ControllerNotImported';
 import { ManageBond } from './ManageBond';
 import { Nominations } from './Nominations';

--- a/src/pages/Nominate/Setup/Payee/index.tsx
+++ b/src/pages/Nominate/Setup/Payee/index.tsx
@@ -10,6 +10,7 @@ import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { useEffect, useState } from 'react';
 import { isNumeric } from 'Utils';
+
 import { Spacer } from '../../Wrappers';
 import { Item, Items } from './Wrappers';
 

--- a/src/pages/Nominate/Setup/SetController.tsx
+++ b/src/pages/Nominate/Setup/SetController.tsx
@@ -12,6 +12,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { useEffect, useState } from 'react';
+
 import { Spacer } from '../Wrappers';
 
 export const SetController = (props: SetupStepProps) => {

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -18,6 +18,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { humanNumber } from 'Utils';
+
 import { SummaryWrapper } from './Wrapper';
 
 export const Summary = (props: SetupStepProps) => {

--- a/src/pages/Nominate/Setup/index.tsx
+++ b/src/pages/Nominate/Setup/index.tsx
@@ -11,6 +11,7 @@ import { PageTitle } from 'library/PageTitle';
 import { Nominate } from 'library/SetupSteps/Nominate';
 import { Element } from 'react-scroll';
 import { PageRowWrapper, TopBarWrapper } from 'Wrappers';
+
 import { Bond } from './Bond';
 import { Payee } from './Payee';
 import { SetController } from './SetController';

--- a/src/pages/Nominate/index.tsx
+++ b/src/pages/Nominate/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useUi } from 'contexts/UI';
+
 import { Active } from './Active';
 import { Setup } from './Setup';
 import { Wrapper } from './Wrappers';

--- a/src/pages/Overview/ActiveAccount.tsx
+++ b/src/pages/Overview/ActiveAccount.tsx
@@ -9,6 +9,7 @@ import { useNotifications } from 'contexts/Notifications';
 import { NotificationText } from 'contexts/Notifications/types';
 import { Identicon } from 'library/Identicon';
 import { clipAddress, convertRemToPixels } from 'Utils';
+
 import { ActiveAccounWrapper } from './Wrappers';
 
 export const ActiveAccount = () => {

--- a/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -18,6 +18,7 @@ import {
   rmCommas,
   toFixedIfNecessary,
 } from 'Utils';
+
 import { Item } from './Wrappers';
 
 export const Announcements = () => {

--- a/src/pages/Overview/NetworkSats/Inflation.tsx
+++ b/src/pages/Overview/NetworkSats/Inflation.tsx
@@ -7,6 +7,7 @@ import { useStaking } from 'contexts/Staking';
 import useInflation from 'library/Hooks/useInflation';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { toFixedIfNecessary } from 'Utils';
+
 import { InflationWrapper } from './Wrappers';
 
 export const Inflation = () => {

--- a/src/pages/Overview/NetworkSats/index.tsx
+++ b/src/pages/Overview/NetworkSats/index.tsx
@@ -3,6 +3,7 @@
 
 import { CardHeaderWrapper, CardWrapper } from 'library/Graphs/Wrappers';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
+
 import { Announcements } from './Announcements';
 import { Inflation } from './Inflation';
 import { Wrapper } from './Wrappers';

--- a/src/pages/Overview/Reserve.tsx
+++ b/src/pages/Overview/Reserve.tsx
@@ -7,6 +7,7 @@ import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { planckBnToUnit, toFixedIfNecessary } from 'Utils';
+
 import { ReserveProps } from './types';
 import { ReserveWrapper, SectionWrapper, Separator } from './Wrappers';
 

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -21,6 +21,7 @@ import {
   RowSecondaryWrapper,
   TopBarWrapper,
 } from 'Wrappers';
+
 import { ActiveAccount } from './ActiveAccount';
 import BalanceGraph from './BalanceGraph';
 import { NetworkStats } from './NetworkSats';

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -23,6 +23,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { networkColors } from 'theme/default';
 import { AnySubscan } from 'types';
 import { clipAddress, planckToUnit } from 'Utils';
+
 import { PayoutListProps } from '../types';
 import { ItemWrapper } from '../Wrappers';
 import { PayoutListProvider, usePayoutList } from './context';

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -23,6 +23,7 @@ import moment from 'moment';
 import { useRef } from 'react';
 import { AnySubscan } from 'types';
 import { PageRowWrapper } from 'Wrappers';
+
 import { PageProps } from '../types';
 import { PayoutList } from './PayoutList';
 import LastEraPayoutStatBox from './Stats/LastEraPayout';

--- a/src/pages/Pools/Create/PoolName/index.tsx
+++ b/src/pages/Pools/Create/PoolName/index.tsx
@@ -9,6 +9,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { useEffect, useState } from 'react';
+
 import { Input } from './Input';
 
 export const PoolName = (props: SetupStepProps) => {

--- a/src/pages/Pools/Create/PoolRoles/index.tsx
+++ b/src/pages/Pools/Create/PoolRoles/index.tsx
@@ -9,6 +9,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { useEffect, useState } from 'react';
+
 import { Roles } from '../../Roles';
 
 export const PoolRoles = (props: SetupStepProps) => {

--- a/src/pages/Pools/Create/Summary/index.tsx
+++ b/src/pages/Pools/Create/Summary/index.tsx
@@ -22,6 +22,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import { SetupStepProps } from 'library/SetupSteps/types';
 import { humanNumber, unitToPlanckBn } from 'Utils';
+
 import { SummaryWrapper } from './Wrapper';
 
 export const Summary = (props: SetupStepProps) => {

--- a/src/pages/Pools/Create/index.tsx
+++ b/src/pages/Pools/Create/index.tsx
@@ -11,6 +11,7 @@ import { PageTitle } from 'library/PageTitle';
 import { Nominate } from 'library/SetupSteps/Nominate';
 import { Element } from 'react-scroll';
 import { PageRowWrapper, TopBarWrapper } from 'Wrappers';
+
 import { Bond } from './Bond';
 import { PoolName } from './PoolName';
 import { PoolRoles } from './PoolRoles';

--- a/src/pages/Pools/Home/Members.tsx
+++ b/src/pages/Pools/Home/Members.tsx
@@ -10,6 +10,7 @@ import { PoolState } from 'contexts/Pools/types';
 import { useTheme } from 'contexts/Themes';
 import { CardWrapper } from 'library/Graphs/Wrappers';
 import { PageRowWrapper } from 'Wrappers';
+
 import { MembersList } from './MembersList';
 
 export const Members = () => {

--- a/src/pages/Pools/Home/MembersList/index.tsx
+++ b/src/pages/Pools/Home/MembersList/index.tsx
@@ -17,6 +17,7 @@ import { Selectable } from 'library/List/Selectable';
 import { useEffect, useRef, useState } from 'react';
 import { networkColors } from 'theme/default';
 import { AnyApi, Sync } from 'types';
+
 import { Member } from './Member';
 
 export const MembersListInner = (props: any) => {

--- a/src/pages/Pools/Home/PoolStats/Announcements.tsx
+++ b/src/pages/Pools/Home/PoolStats/Announcements.tsx
@@ -15,6 +15,7 @@ import {
   rmCommas,
   toFixedIfNecessary,
 } from 'Utils';
+
 import { Item } from './Wrappers';
 
 export const Announcements = () => {

--- a/src/pages/Pools/Home/PoolStats/Header.tsx
+++ b/src/pages/Pools/Home/PoolStats/Header.tsx
@@ -7,6 +7,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { PoolState } from 'contexts/Pools/types';
 import { planckBnToUnit, rmCommas, toFixedIfNecessary } from 'Utils';
+
 import { HeaderWrapper } from './Wrappers';
 
 export const Header = () => {

--- a/src/pages/Pools/Home/PoolStats/index.tsx
+++ b/src/pages/Pools/Home/PoolStats/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CardHeaderWrapper, CardWrapper } from 'library/Graphs/Wrappers';
+
 import { Announcements } from './Announcements';
 import { Header } from './Header';
 import { Wrapper } from './Wrappers';

--- a/src/pages/Pools/Home/Status/Membership/index.tsx
+++ b/src/pages/Pools/Home/Status/Membership/index.tsx
@@ -14,6 +14,7 @@ import OpenHelpIcon from 'library/OpenHelpIcon';
 import { Wrapper as StatWrapper } from 'library/Stat/Wrapper';
 import React from 'react';
 import { determinePoolDisplay } from 'Utils';
+
 import { Wrapper } from './Wrapper';
 
 export const Membership = ({ label }: { label: string }) => {

--- a/src/pages/Pools/Home/Status/index.tsx
+++ b/src/pages/Pools/Home/Status/index.tsx
@@ -20,6 +20,7 @@ import { CardWrapper } from 'library/Graphs/Wrappers';
 import { Stat } from 'library/Stat';
 import { planckBnToUnit, rmCommas } from 'Utils';
 import { Separator } from 'Wrappers';
+
 import { Membership } from './Membership';
 import { useStatusButtons } from './useStatusButtons';
 

--- a/src/pages/Pools/Home/Status/useStatusButtons.tsx
+++ b/src/pages/Pools/Home/Status/useStatusButtons.tsx
@@ -10,6 +10,7 @@ import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { useUi } from 'contexts/UI';
+
 import { usePoolsTabs } from '../context';
 
 export const useStatusButtons = () => {

--- a/src/pages/Pools/Home/context.tsx
+++ b/src/pages/Pools/Home/context.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
+
 import { PoolsTabsContextInterface } from '../types';
 
 export const PoolsTabsContext: React.Context<PoolsTabsContextInterface> =

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -19,6 +19,7 @@ import {
   RowPrimaryWrapper,
   RowSecondaryWrapper,
 } from 'Wrappers';
+
 import { Roles } from '../Roles';
 import { ClosurePrompts } from './ClosurePrompts';
 import { PoolsTabsProvider, usePoolsTabs } from './context';

--- a/src/pages/Pools/PoolAccount/index.tsx
+++ b/src/pages/Pools/PoolAccount/index.tsx
@@ -11,6 +11,7 @@ import { motion } from 'framer-motion';
 import { Identicon } from 'library/Identicon';
 import { getIdentityDisplay } from 'library/ValidatorList/Validator/Utils';
 import { clipAddress, convertRemToPixels } from 'Utils';
+
 import { PoolAccountProps } from '../types';
 import { Wrapper } from './Wrapper';
 

--- a/src/pages/Pools/Roles/RoleEditInput/index.tsx
+++ b/src/pages/Pools/Roles/RoleEditInput/index.tsx
@@ -4,6 +4,7 @@
 import { useConnect } from 'contexts/Connect';
 import React from 'react';
 import { isValidAddress } from 'Utils';
+
 import { Wrapper } from './Wrapper';
 
 export const RoleEditInput = ({ setRoleEdit, roleKey, roleEdit }: any) => {

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -16,6 +16,7 @@ import Button from 'library/Button';
 import { CardHeaderWrapper } from 'library/Graphs/Wrappers';
 import { OpenHelpIcon } from 'library/OpenHelpIcon';
 import { useEffect, useState } from 'react';
+
 import { RolesWrapper } from '../Home/ManagePool/Wrappers';
 import { PoolAccount } from '../PoolAccount';
 import RoleEditInput from './RoleEditInput';

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -3,6 +3,7 @@
 
 // import { useUi } from 'contexts/UI';
 import { useUi } from 'contexts/UI';
+
 import { Create } from './Create';
 import { Home } from './Home';
 

--- a/src/pages/Validators/index.tsx
+++ b/src/pages/Validators/index.tsx
@@ -8,6 +8,7 @@ import { PageTitle } from 'library/PageTitle';
 import { StatBoxList } from 'library/StatBoxList';
 import { ValidatorList } from 'library/ValidatorList';
 import { PageRowWrapper } from 'Wrappers';
+
 import { PageProps } from '../types';
 import ActiveValidatorsStatBox from './Stats/ActiveValidators';
 import AverageCommissionStatBox from './Stats/AverageCommission';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import theme from 'styled-theming';
+
 import {
   cardThemes,
   defaultThemes,


### PR DESCRIPTION
Added 2 eslint plugins ([eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort) and [eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports)) that organizes imports and remove non-used ones.

_**I'm not sure I like the "import sort" that these plugins do but I prefer the way prettier does**_. If you prefer the [prettier](https://github.com/paritytech/polkadot-staking-dashboard/pull/269) solution as well, please close this and merge that