### PR TITLE
Refactor Connect context

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,36 +1,37 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { AccountProvider } from 'contexts/Account';
+import { APIProvider, useApi } from 'contexts/Api';
+import { BalancesProvider } from 'contexts/Balances';
+import { ConnectProvider } from 'contexts/Connect';
+import { ExtensionsProvider } from 'contexts/Extensions';
+import { ExtrinsicsProvider } from 'contexts/Extrinsics';
+import { FiltersProvider } from 'contexts/Filters';
+import { HelpProvider } from 'contexts/Help';
+import { MenuProvider } from 'contexts/Menu';
+import { ModalProvider } from 'contexts/Modal';
+import { NetworkMetricsProvider } from 'contexts/Network';
+import { NotificationsProvider } from 'contexts/Notifications';
+import { OverlayProvider } from 'contexts/Overlay';
+import { ActivePoolsProvider } from 'contexts/Pools/ActivePools';
+import { BondedPoolsProvider } from 'contexts/Pools/BondedPools';
+import { PoolMembersProvider } from 'contexts/Pools/PoolMembers';
+import { PoolMembershipsProvider } from 'contexts/Pools/PoolMemberships';
+import { PoolsConfigProvider } from 'contexts/Pools/PoolsConfig';
+import { SessionEraProvider } from 'contexts/SessionEra';
+import { StakingProvider } from 'contexts/Staking';
+import { SubscanProvider } from 'contexts/Subscan';
+import { useTheme } from 'contexts/Themes';
 import { TooltipProvider } from 'contexts/Tooltip';
 import { TransferOptionsProvider } from 'contexts/TransferOptions';
 import { TxFeesProvider } from 'contexts/TxFees';
+import { UIProvider } from 'contexts/UI';
+import { ValidatorsProvider } from 'contexts/Validators';
 import { withProviders } from 'library/Hooks';
 import Router from 'Router';
 import { ThemeProvider } from 'styled-components';
 import { EntryWrapper as Wrapper } from 'Wrappers';
-import { AccountProvider } from './contexts/Account';
-import { APIProvider, useApi } from './contexts/Api';
-import { BalancesProvider } from './contexts/Balances';
-import { ConnectProvider } from './contexts/Connect';
-import { ExtrinsicsProvider } from './contexts/Extrinsics';
-import { FiltersProvider } from './contexts/Filters';
-import { HelpProvider } from './contexts/Help';
-import { MenuProvider } from './contexts/Menu';
-import { ModalProvider } from './contexts/Modal';
-import { NetworkMetricsProvider } from './contexts/Network';
-import { NotificationsProvider } from './contexts/Notifications';
-import { OverlayProvider } from './contexts/Overlay';
-import { ActivePoolsProvider } from './contexts/Pools/ActivePools';
-import { BondedPoolsProvider } from './contexts/Pools/BondedPools';
-import { PoolMembersProvider } from './contexts/Pools/PoolMembers';
-import { PoolMembershipsProvider } from './contexts/Pools/PoolMemberships';
-import { PoolsConfigProvider } from './contexts/Pools/PoolsConfig';
-import { SessionEraProvider } from './contexts/SessionEra';
-import { StakingProvider } from './contexts/Staking';
-import { SubscanProvider } from './contexts/Subscan';
-import { useTheme } from './contexts/Themes';
-import { UIProvider } from './contexts/UI';
-import { ValidatorsProvider } from './contexts/Validators';
 
 // `polkadot-dashboard-ui` theme classes are inserted here.
 export const WrappedRouter = () => {
@@ -61,6 +62,7 @@ export const ThemedRouter = () => {
 export const Providers = withProviders(
   FiltersProvider,
   APIProvider,
+  ExtensionsProvider,
   ConnectProvider,
   HelpProvider,
   NetworkMetricsProvider,

--- a/src/contexts/Connect/Hooks/useImportAccounts.tsx
+++ b/src/contexts/Connect/Hooks/useImportAccounts.tsx
@@ -1,0 +1,6 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export const useImportAccounts = () => {
+  return {};
+};

--- a/src/contexts/Connect/Hooks/useImportAccounts.tsx
+++ b/src/contexts/Connect/Hooks/useImportAccounts.tsx
@@ -1,6 +1,0 @@
-// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
-export const useImportAccounts = () => {
-  return {};
-};

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -7,7 +7,7 @@ import { useExtensions } from 'contexts/Extensions';
 import { ExtensionInteface } from 'contexts/Extensions/types';
 import { AnyFunction } from 'types';
 import { isValidAddress } from 'Utils';
-import { ExtensionAccount, ImportedAccount } from '../types';
+import { ExtensionAccount, ExternalAccount, ImportedAccount } from '../types';
 import {
   addToLocalExtensions,
   getActiveAccountLocal,
@@ -27,7 +27,7 @@ export const useImportExtension = () => {
     accounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
-    callback: AnyFunction
+    forget: (a: Array<ExternalAccount>) => void
   ) => {
     // update extensions status to connected.
     setExtensionStatus(id, 'connected');
@@ -35,13 +35,7 @@ export const useImportExtension = () => {
     addToLocalExtensions(id);
 
     if (injected.length) {
-      return handleInjectedAccounts(
-        id,
-        accounts,
-        extension,
-        injected,
-        callback
-      );
+      return handleInjectedAccounts(id, accounts, extension, injected, forget);
     }
     return [];
   };
@@ -54,7 +48,7 @@ export const useImportExtension = () => {
     accounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
-    callback: AnyFunction
+    forget: (a: Array<ExternalAccount>) => void
   ) => {
     // set network ss58 format
     const keyring = new Keyring();
@@ -73,7 +67,7 @@ export const useImportExtension = () => {
     });
 
     // remove injected if they exist in local external accounts
-    callback(getInExternalAccounts(injected, network));
+    forget(getInExternalAccounts(injected, network));
 
     // remove accounts that have already been injected via another extension.
     injected = injected.filter(

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -13,7 +13,7 @@ export const useImportExtension = () => {
   const { network } = useApi();
   const { setExtensionStatus } = useExtensions();
 
-  // handles connecting to a new extension.
+  // Handles connecting to a new extension.
   //
   // Adds extension metadata to state and updates local storage with
   // connected extensions. Calls separate method to handle account importing.
@@ -44,7 +44,7 @@ export const useImportExtension = () => {
     return [];
   };
 
-  // handles importing of extension accounts.
+  // Handles importing of extension accounts.
   //
   // Gets accounts to be imported and commits them to state.
   const handleInjectedAccounts = (
@@ -90,6 +90,7 @@ export const useImportExtension = () => {
         signer: extension.signer,
       };
     });
+
     return injected;
   };
 

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -1,0 +1,68 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useExtensions } from 'contexts/Extensions';
+import { ExtensionInteface } from 'contexts/Extensions/types';
+import { isValidAddress } from 'Utils';
+import { ExtensionAccount, ImportedAccount } from '../types';
+import { addToLocalExtensions } from '../Utils';
+
+export const useImportExtension = (accounts: Array<ImportedAccount>) => {
+  const { setExtensionStatus } = useExtensions();
+
+  // handles connecting to a new extension.
+  //
+  // Adds extension metadata to state and updates local storage with
+  // connected extensions. Calls separate method to handle account importing.
+  const handleImportExtension = (
+    id: string,
+    extension: ExtensionInteface,
+    injected: Array<ExtensionAccount>
+  ) => {
+    // update extensions status to connected.
+    setExtensionStatus(id, 'connected');
+    // update local active extensions
+    addToLocalExtensions(id);
+
+    // exit if no accounts to be imported.
+    if (injected.length) {
+      return handleInjectedAccounts(id, extension, injected);
+    }
+    return [];
+  };
+
+  // handles importing of extension accounts.
+  //
+  // Gets accounts to be imported and commits them to state.
+  const handleInjectedAccounts = (
+    id: string,
+    extension: ExtensionInteface,
+    injected: Array<ExtensionAccount>
+  ) => {
+    // forget external accounts that are being injected now.
+
+    // remove accounts that have already been injected via another extension.
+    injected = injected.filter(
+      (i: ExtensionAccount) =>
+        !accounts.map((j: ImportedAccount) => j.address).includes(i.address)
+    );
+    // remove accounts that do not contain correctly formatted addresses.
+    injected = injected.filter((i: ExtensionAccount) => {
+      return isValidAddress(i.address);
+    });
+    // format account properties.
+    injected = injected.map((a: ExtensionAccount) => {
+      return {
+        address: a.address,
+        source: id,
+        name: a.name,
+        signer: extension.signer,
+      };
+    });
+    return injected;
+  };
+
+  return {
+    handleImportExtension,
+  };
+};

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -34,7 +34,6 @@ export const useImportExtension = () => {
     // update local active extensions
     addToLocalExtensions(id);
 
-    // exit if no accounts to be imported.
     if (injected.length) {
       return handleInjectedAccounts(
         id,
@@ -91,30 +90,26 @@ export const useImportExtension = () => {
         signer: extension.signer,
       };
     });
-
     return injected;
   };
 
   // Get active extension account.
   //
   // checks if the local active account is in the extension.
-  const getActiveExtensionAccount = (injected: Array<ImportedAccount>) => {
-    return (
-      injected.find(
-        (a: ExtensionAccount) => a.address === getActiveAccountLocal(network)
-      ) ?? null
-    );
-  };
+  const getActiveExtensionAccount = (injected: Array<ImportedAccount>) =>
+    injected.find(
+      (a: ExtensionAccount) => a.address === getActiveAccountLocal(network)
+    ) ?? null;
 
   // Connect active extension account.
   //
-  // Connects to active account if in extension.
+  // Connects to active account if it is provided.
   const connectActiveExtensionAccount = (
-    activeWalletAccount: ImportedAccount | null,
+    account: ImportedAccount | null,
     callback: AnyFunction
   ) => {
-    if (activeWalletAccount !== null) {
-      callback(activeWalletAccount);
+    if (account !== null) {
+      callback(account);
     }
   };
 

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -5,9 +5,14 @@ import Keyring from '@polkadot/keyring';
 import { useApi } from 'contexts/Api';
 import { useExtensions } from 'contexts/Extensions';
 import { ExtensionInteface } from 'contexts/Extensions/types';
+import { AnyFunction } from 'types';
 import { isValidAddress } from 'Utils';
 import { ExtensionAccount, ImportedAccount } from '../types';
-import { addToLocalExtensions, getInExternalAccounts } from '../Utils';
+import {
+  addToLocalExtensions,
+  getActiveAccountLocal,
+  getInExternalAccounts,
+} from '../Utils';
 
 export const useImportExtension = () => {
   const { network } = useApi();
@@ -23,7 +28,7 @@ export const useImportExtension = () => {
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
     callbacks: {
-      forgetAccounts: any;
+      forgetAccounts: AnyFunction;
     }
   ) => {
     // update extensions status to connected.
@@ -53,7 +58,7 @@ export const useImportExtension = () => {
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
     callbacks: {
-      forgetAccounts: any;
+      forgetAccounts: AnyFunction;
     }
   ) => {
     // set network ss58 format
@@ -94,7 +99,28 @@ export const useImportExtension = () => {
     return injected;
   };
 
+  // checks if the local active account is in the extension.
+  const getActiveExtensionAccount = (injected: Array<ImportedAccount>) => {
+    return (
+      injected.find(
+        (a: ExtensionAccount) => a.address === getActiveAccountLocal(network)
+      ) ?? null
+    );
+  };
+
+  // Connects to active account if in extension.
+  const connectActiveExtensionAccount = (
+    activeWalletAccount: ImportedAccount | null,
+    callback: AnyFunction
+  ) => {
+    if (activeWalletAccount !== null) {
+      callback(activeWalletAccount);
+    }
+  };
+
   return {
     handleImportExtension,
+    getActiveExtensionAccount,
+    connectActiveExtensionAccount,
   };
 };

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -27,9 +27,7 @@ export const useImportExtension = () => {
     accounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
-    callbacks: {
-      forgetAccounts: AnyFunction;
-    }
+    callback: AnyFunction
   ) => {
     // update extensions status to connected.
     setExtensionStatus(id, 'connected');
@@ -43,7 +41,7 @@ export const useImportExtension = () => {
         accounts,
         extension,
         injected,
-        callbacks
+        callback
       );
     }
     return [];
@@ -57,9 +55,7 @@ export const useImportExtension = () => {
     accounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
     injected: Array<ExtensionAccount>,
-    callbacks: {
-      forgetAccounts: AnyFunction;
-    }
+    callback: AnyFunction
   ) => {
     // set network ss58 format
     const keyring = new Keyring();
@@ -78,7 +74,7 @@ export const useImportExtension = () => {
     });
 
     // remove injected if they exist in local external accounts
-    callbacks.forgetAccounts(getInExternalAccounts(injected, network));
+    callback(getInExternalAccounts(injected, network));
 
     // remove accounts that have already been injected via another extension.
     injected = injected.filter(

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -18,7 +18,7 @@ export const useImportExtension = () => {
   const { network } = useApi();
   const { setExtensionStatus } = useExtensions();
 
-  // Handles connecting to a new extension.
+  // Handles importing of an extension.
   //
   // Adds extension metadata to state and updates local storage with
   // connected extensions. Calls separate method to handle account importing.
@@ -95,6 +95,8 @@ export const useImportExtension = () => {
     return injected;
   };
 
+  // Get active extension account.
+  //
   // checks if the local active account is in the extension.
   const getActiveExtensionAccount = (injected: Array<ImportedAccount>) => {
     return (
@@ -104,6 +106,8 @@ export const useImportExtension = () => {
     );
   };
 
+  // Connect active extension account.
+  //
   // Connects to active account if in extension.
   const connectActiveExtensionAccount = (
     activeWalletAccount: ImportedAccount | null,

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -4,7 +4,7 @@
 import Keyring from '@polkadot/keyring';
 import { Network } from 'types';
 import { localStorageOrDefault } from 'Utils';
-import { ExternalAccount, ImportedAccount } from './types';
+import { ExtensionAccount, ExternalAccount, ImportedAccount } from './types';
 
 // extension utils
 
@@ -57,7 +57,7 @@ export const extensionIsLocal = (id: string) => {
 
 // account utils
 
-// gets local `active_account` for a network
+// gets local `activeAccount` for a network
 export const getActiveAccountLocal = (network: Network) => {
   const keyring = new Keyring();
   keyring.setSS58Format(network.ss58);
@@ -82,14 +82,28 @@ export const getLocalExternalAccounts = (
     [],
     true
   ) as Array<ExternalAccount>;
-
-  // only fetch external accounts for active network
   if (activeNetworkOnly) {
     localExternalAccounts = localExternalAccounts.filter(
       (l: ExternalAccount) => l.network === network.name
     );
   }
   return localExternalAccounts;
+};
+
+// gets accounts that exist in local `external_accounts`
+export const getInExternalAccounts = (
+  accounts: Array<ExtensionAccount>,
+  network: Network
+) => {
+  const localExternalAccounts = getLocalExternalAccounts(network, true);
+  return (
+    localExternalAccounts.filter(
+      (l: ExternalAccount) =>
+        (accounts || []).find(
+          (a: ExtensionAccount) => a.address === l.address
+        ) !== undefined && l.addedBy === 'system'
+    ) || []
+  );
 };
 
 // removes local `external_accounts` from local storage.

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -19,7 +19,7 @@ export const removeFromLocalExtensions = (id: string) => {
   }
 };
 
-// Gets local activeAccount
+// gets local activeAccount
 export const getActiveAccountLocal = (network: Network) => {
   const keyring = new Keyring();
   keyring.setSS58Format(network.ss58);
@@ -70,4 +70,22 @@ export const extensionIsLocal = (id: string) => {
   }
 
   return foundExtensionLocally;
+};
+
+// adds an extension to local `active_extensions`
+export const addToLocalExtensions = (id: string) => {
+  const localExtensions = localStorageOrDefault<string[]>(
+    `active_extensions`,
+    [],
+    true
+  );
+  if (Array.isArray(localExtensions)) {
+    if (!localExtensions.includes(id)) {
+      localExtensions.push(id);
+      localStorage.setItem(
+        'active_extensions',
+        JSON.stringify(localExtensions)
+      );
+    }
+  }
 };

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -106,7 +106,7 @@ export const getInExternalAccounts = (
   );
 };
 
-// removes local `external_accounts` from local storage.
+// removes supplied accounts from local `external_accounts`.
 export const removeLocalExternalAccounts = (
   network: Network,
   accounts: Array<ExternalAccount>

--- a/src/contexts/Connect/defaults.ts
+++ b/src/contexts/Connect/defaults.ts
@@ -21,9 +21,7 @@ export const defaultConnectContext: ConnectContextInterface = {
   // eslint-disable-next-line
   isReadOnlyAccount: (a) => false,
   // eslint-disable-next-line
-  forgetAccounts: (a) => {},
-  extensions: [],
-  extensionsStatus: {},
+  forgetAccounts: (a) => { },
   accounts: [],
   activeAccount: null,
   activeAccountMeta: null,

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -216,9 +216,9 @@ export const ConnectProvider = ({
     }
 
     let i = 0;
-    extensions.forEach(async (_extension: Extension) => {
+    extensions.forEach(async (e: Extension) => {
       i++;
-      const { id, enable } = _extension;
+      const { id, enable } = e;
 
       // if extension is found locally, subscribe to accounts
       if (extensionIsLocal(id)) {
@@ -227,11 +227,10 @@ export const ConnectProvider = ({
           const extension: ExtensionInteface = await enable(DappName);
 
           if (extension !== undefined) {
-            const _unsubscribe = (await extension.accounts.subscribe(
+            const unsub = (await extension.accounts.subscribe(
               (injected: ExtensionAccount[]) => {
-                if (!injected) {
-                  return;
-                }
+                if (!injected) return;
+
                 injected = handleImportExtension(
                   id,
                   accountsRef.current,
@@ -243,7 +242,9 @@ export const ConnectProvider = ({
                 );
 
                 // store active wallet account if found in this extension
-                activeWalletAccount = getActiveExtensionAccount(injected);
+                if (!activeWalletAccount) {
+                  activeWalletAccount = getActiveExtensionAccount(injected);
+                }
 
                 // set active account for network on final extension
                 if (i === total && activeAccountRef.current === null) {
@@ -255,8 +256,11 @@ export const ConnectProvider = ({
 
                 // concat accounts and store
                 if (injected.length) {
-                  const _accounts = [...accountsRef.current].concat(injected);
-                  setStateWithRef(_accounts, setAccounts, accountsRef);
+                  setStateWithRef(
+                    [...accountsRef.current].concat(injected),
+                    setAccounts,
+                    accountsRef
+                  );
                 }
               }
             )) as () => void;
@@ -265,7 +269,7 @@ export const ConnectProvider = ({
             setStateWithRef(
               [...unsubscribeRef.current].concat({
                 key: id,
-                unsub: _unsubscribe,
+                unsub,
               }),
               setUnsubscribe,
               unsubscribeRef
@@ -288,10 +292,10 @@ export const ConnectProvider = ({
    * This is invoked by the user by clicking on an extension.
    * If activeAccount is not found here, it is simply ignored.
    */
-  const connectExtensionAccounts = async (_extension: Extension) => {
+  const connectExtensionAccounts = async (e: Extension) => {
     const keyring = new Keyring();
     keyring.setSS58Format(network.ss58);
-    const { id, enable } = _extension;
+    const { id, enable } = e;
 
     try {
       // summons extension popup
@@ -299,11 +303,10 @@ export const ConnectProvider = ({
 
       if (extension !== undefined) {
         // subscribe to accounts
-        const _unsubscribe = (await extension.accounts.subscribe(
+        const unsub = (await extension.accounts.subscribe(
           (injected: ExtensionAccount[]) => {
-            if (!injected) {
-              return;
-            }
+            if (!injected) return;
+
             injected = handleImportExtension(
               id,
               accountsRef.current,
@@ -324,8 +327,11 @@ export const ConnectProvider = ({
 
             // concat accounts and store
             if (injected.length) {
-              const _accounts = [...accountsRef.current].concat(injected);
-              setStateWithRef(_accounts, setAccounts, accountsRef);
+              setStateWithRef(
+                [...accountsRef.current].concat(injected),
+                setAccounts,
+                accountsRef
+              );
             }
           }
         )) as () => void;
@@ -334,7 +340,7 @@ export const ConnectProvider = ({
         setStateWithRef(
           [...unsubscribeRef.current].concat({
             key: id,
-            unsub: _unsubscribe,
+            unsub,
           }),
           setUnsubscribe,
           unsubscribeRef

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -236,9 +236,7 @@ export const ConnectProvider = ({
                   accountsRef.current,
                   extension,
                   injected,
-                  {
-                    forgetAccounts,
-                  }
+                  forgetAccounts
                 );
 
                 // store active wallet account if found in this extension
@@ -280,7 +278,8 @@ export const ConnectProvider = ({
         }
       }
 
-      // after last extension, import external accounts
+      // set extension fetched to allow external accounts
+      // to be imported.
       if (i === total) {
         setExtensionsFetched(true);
       }
@@ -312,9 +311,7 @@ export const ConnectProvider = ({
               accountsRef.current,
               extension,
               injected,
-              {
-                forgetAccounts,
-              }
+              forgetAccounts
             );
 
             // set active account for network if not yet set
@@ -326,13 +323,11 @@ export const ConnectProvider = ({
             }
 
             // concat accounts and store
-            if (injected.length) {
-              setStateWithRef(
-                [...accountsRef.current].concat(injected),
-                setAccounts,
-                accountsRef
-              );
-            }
+            setStateWithRef(
+              [...accountsRef.current].concat(injected),
+              setAccounts,
+              accountsRef
+            );
           }
         )) as () => void;
 

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -254,7 +254,7 @@ export const ConnectProvider = ({
                   return;
                 }
                 // update extensions status
-                updateExtensionStatus(id, 'connected');
+                setExtensionStatus(id, 'connected');
                 // update local active extensions
                 addToLocalExtensions(id);
 
@@ -379,7 +379,7 @@ export const ConnectProvider = ({
               return;
             }
             // update extensions status
-            updateExtensionStatus(id, 'connected');
+            setExtensionStatus(id, 'connected');
             // update local active extensions
             addToLocalExtensions(id);
 
@@ -472,18 +472,18 @@ export const ConnectProvider = ({
     // authentication error (extension not enabled)
     if (err.substring(0, 9) === 'AuthError') {
       removeFromLocalExtensions(id);
-      updateExtensionStatus(id, 'not_authenticated');
+      setExtensionStatus(id, 'not_authenticated');
     }
 
     // extension not found (does not exist)
     if (err.substring(0, 17) === 'NotInstalledError') {
       removeFromLocalExtensions(id);
-      updateExtensionStatus(id, 'not_found');
+      setExtensionStatus(id, 'not_found');
     }
 
     // general error (maybe enabled but no accounts trust app)
     if (err.substring(0, 5) === 'Error') {
-      updateExtensionStatus(id, 'no_accounts');
+      setExtensionStatus(id, 'no_accounts');
     }
   };
 
@@ -508,10 +508,6 @@ export const ConnectProvider = ({
     localStorage.removeItem(`${network.name.toLowerCase()}_active_account`);
     setActiveAccount(null);
     setStateWithRef(null, setActiveAccountMeta, activeAccountMetaRef);
-  };
-
-  const updateExtensionStatus = (id: string, status: string) => {
-    setExtensionStatus(id, status);
   };
 
   const addToLocalExtensions = (id: string) => {

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -43,11 +43,11 @@ export const ConnectProvider = ({
     setExtensionsFetched,
     extensions,
   } = useExtensions();
+  const { handleImportExtension } = useImportExtension();
+
   // store accounts list
   const [accounts, setAccounts] = useState<Array<ImportedAccount>>([]);
   const accountsRef = useRef(accounts);
-
-  const { handleImportExtension } = useImportExtension(accountsRef.current);
 
   // store the currently active account
   const [activeAccount, _setActiveAccount] = useState<string | null>(null);
@@ -230,32 +230,18 @@ export const ConnectProvider = ({
                 if (!injected) {
                   return;
                 }
-                injected = handleImportExtension(id, extension, injected);
+                injected = handleImportExtension(
+                  id,
+                  accountsRef.current,
+                  extension,
+                  injected,
+                  {
+                    forgetAccounts,
+                  }
+                );
 
                 if (injected.length) {
-                  // remove any injected accounts from local external if any exist
-                  const localExternalAccounts = getLocalExternalAccounts(
-                    network,
-                    true
-                  );
-                  const localAccountsToForget =
-                    localExternalAccounts.filter(
-                      (l: ExternalAccount) =>
-                        (injected || []).find(
-                          (a: ExtensionAccount) => a.address === l.address
-                        ) !== undefined && l.addedBy === 'system'
-                    ) || [];
-
-                  forgetAccounts(localAccountsToForget);
-
-                  // reformat address to ensure correct format
-                  injected.forEach(async (account: ExtensionAccount) => {
-                    const { address } = keyring.addFromAddress(account.address);
-                    account.address = address;
-                    return account;
-                  });
                   // connect to active account if found in extension
-                  // TODO: abstract this logic via a flag.
                   const activeAccountInWallet =
                     injected.find(
                       (a: ExtensionAccount) => a.address === _activeAccount
@@ -328,32 +314,17 @@ export const ConnectProvider = ({
             if (!injected) {
               return;
             }
-            injected = handleImportExtension(id, extension, injected);
+            injected = handleImportExtension(
+              id,
+              accountsRef.current,
+              extension,
+              injected,
+              {
+                forgetAccounts,
+              }
+            );
 
             if (injected.length) {
-              // remove injected if they exist in local external accounts
-              const localExternalAccounts = getLocalExternalAccounts(
-                network,
-                true
-              );
-
-              const localAccountsToForget =
-                localExternalAccounts.filter(
-                  (l: ExternalAccount) =>
-                    (injected || []).find(
-                      (a: ExtensionAccount) => a.address === l.address
-                    ) !== undefined && l.addedBy === 'system'
-                ) || [];
-
-              forgetAccounts(localAccountsToForget);
-
-              // reformat address to ensure correct format
-              injected.forEach(async (account: ExtensionAccount) => {
-                const { address } = keyring.addFromAddress(account.address);
-                account.address = address;
-                return account;
-              });
-
               // connect to active account if found in extension
               const activeAccountInWallet =
                 injected.find(

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -165,11 +165,11 @@ export const ConnectProvider = ({
 
     if (localExternalAccounts.length) {
       // get and format active account if present
-      const _activeAccount = getActiveAccountLocal(network);
+      const activeAccountLocal = getActiveAccountLocal(network);
 
       const activeAccountIsExternal =
         localExternalAccounts.find(
-          (a: ImportedAccount) => a.address === _activeAccount
+          (a: ImportedAccount) => a.address === activeAccountLocal
         ) ?? null;
 
       // remove already-imported accounts (extensions may have already imported)
@@ -202,7 +202,7 @@ export const ConnectProvider = ({
   const connectActiveExtensions = async () => {
     const keyring = new Keyring();
     keyring.setSS58Format(network.ss58);
-    const _activeAccount = getActiveAccountLocal(network);
+    const activeAccountLocal = getActiveAccountLocal(network);
 
     // iterate extensions and add accounts to state
     let extensionsCount = 0;
@@ -244,7 +244,7 @@ export const ConnectProvider = ({
                   // connect to active account if found in extension
                   const activeAccountInWallet =
                     injected.find(
-                      (a: ExtensionAccount) => a.address === _activeAccount
+                      (a: ExtensionAccount) => a.address === activeAccountLocal
                     ) ?? null;
                   if (activeAccountInWallet !== null) {
                     activeWalletAccount = activeAccountInWallet;
@@ -297,7 +297,7 @@ export const ConnectProvider = ({
     keyring.setSS58Format(network.ss58);
     const { id, enable } = _extension;
 
-    const _activeAccount = getActiveAccountLocal(network);
+    const activeAccountLocal = getActiveAccountLocal(network);
     try {
       // summons extension popup
       const extension: ExtensionInteface = await enable(DappName);
@@ -323,7 +323,7 @@ export const ConnectProvider = ({
               // connect to active account if found in extension
               const activeAccountInWallet =
                 injected.find(
-                  (a: ExtensionAccount) => a.address === _activeAccount
+                  (a: ExtensionAccount) => a.address === activeAccountLocal
                 ) ?? null;
               if (activeAccountInWallet !== null) {
                 connectToAccount(activeAccountInWallet);

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -257,14 +257,9 @@ export const ConnectProvider = ({
                   ) {
                     connectToAccount(activeWalletAccount);
                   }
-                  // remove accounts if they already exist
-                  let _accounts = [...accountsRef.current].filter(
-                    (a: ImportedAccount) => {
-                      return a?.source !== id;
-                    }
-                  );
+
                   // concat accounts and store
-                  _accounts = _accounts.concat(injected);
+                  const _accounts = [...accountsRef.current].concat(injected);
                   setStateWithRef(_accounts, setAccounts, accountsRef);
                 }
               }
@@ -334,14 +329,8 @@ export const ConnectProvider = ({
                 connectToAccount(activeAccountInWallet);
               }
 
-              // remove accounts if they already exist
-              let _accounts = [...accountsRef.current].filter(
-                (a: ImportedAccount) => {
-                  return a?.source !== id;
-                }
-              );
               // concat accounts and store
-              _accounts = _accounts.concat(injected);
+              const _accounts = [...accountsRef.current].concat(injected);
               setStateWithRef(_accounts, setAccounts, accountsRef);
             }
           }

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -229,36 +229,33 @@ export const ConnectProvider = ({
           if (extension !== undefined) {
             const unsub = (await extension.accounts.subscribe(
               (injected: ExtensionAccount[]) => {
-                if (!injected) return;
-
-                injected = handleImportExtension(
-                  id,
-                  accountsRef.current,
-                  extension,
-                  injected,
-                  forgetAccounts
-                );
-
-                // store active wallet account if found in this extension
-                if (!activeWalletAccount) {
-                  activeWalletAccount = getActiveExtensionAccount(injected);
-                }
-
-                // set active account for network on final extension
-                if (i === total && activeAccountRef.current === null) {
-                  connectActiveExtensionAccount(
-                    activeWalletAccount,
-                    connectToAccount
+                if (injected) {
+                  injected = handleImportExtension(
+                    id,
+                    accountsRef.current,
+                    extension,
+                    injected,
+                    forgetAccounts
                   );
-                }
-
-                // concat accounts and store
-                if (injected.length) {
-                  setStateWithRef(
-                    [...accountsRef.current].concat(injected),
-                    setAccounts,
-                    accountsRef
-                  );
+                  // store active wallet account if found in this extension
+                  if (!activeWalletAccount) {
+                    activeWalletAccount = getActiveExtensionAccount(injected);
+                  }
+                  // set active account for network on final extension
+                  if (i === total && activeAccountRef.current === null) {
+                    connectActiveExtensionAccount(
+                      activeWalletAccount,
+                      connectToAccount
+                    );
+                  }
+                  // concat accounts and store
+                  if (injected.length) {
+                    setStateWithRef(
+                      [...accountsRef.current].concat(injected),
+                      setAccounts,
+                      accountsRef
+                    );
+                  }
                 }
               }
             )) as () => void;
@@ -304,30 +301,28 @@ export const ConnectProvider = ({
         // subscribe to accounts
         const unsub = (await extension.accounts.subscribe(
           (injected: ExtensionAccount[]) => {
-            if (!injected) return;
-
-            injected = handleImportExtension(
-              id,
-              accountsRef.current,
-              extension,
-              injected,
-              forgetAccounts
-            );
-
-            // set active account for network if not yet set
-            if (activeAccountRef.current === null) {
-              connectActiveExtensionAccount(
-                getActiveExtensionAccount(injected),
-                connectToAccount
+            if (injected) {
+              injected = handleImportExtension(
+                id,
+                accountsRef.current,
+                extension,
+                injected,
+                forgetAccounts
+              );
+              // set active account for network if not yet set
+              if (activeAccountRef.current === null) {
+                connectActiveExtensionAccount(
+                  getActiveExtensionAccount(injected),
+                  connectToAccount
+                );
+              }
+              // concat accounts and store
+              setStateWithRef(
+                [...accountsRef.current].concat(injected),
+                setAccounts,
+                accountsRef
               );
             }
-
-            // concat accounts and store
-            setStateWithRef(
-              [...accountsRef.current].concat(injected),
-              setAccounts,
-              accountsRef
-            );
           }
         )) as () => void;
 

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'Utils';
 import { defaultConnectContext } from './defaults';
 import {
+  addToLocalExtensions,
   extensionIsLocal,
   getActiveAccountLocal,
   getLocalExternalAccounts,
@@ -508,24 +509,6 @@ export const ConnectProvider = ({
     localStorage.removeItem(`${network.name.toLowerCase()}_active_account`);
     setActiveAccount(null);
     setStateWithRef(null, setActiveAccountMeta, activeAccountMetaRef);
-  };
-
-  const addToLocalExtensions = (id: string) => {
-    const localExtensions = localStorageOrDefault<string[]>(
-      `active_extensions`,
-      [],
-      true
-    );
-
-    if (Array.isArray(localExtensions)) {
-      if (!localExtensions.includes(id)) {
-        localExtensions.push(id);
-        localStorage.setItem(
-          'active_extensions',
-          JSON.stringify(localExtensions)
-        );
-      }
-    }
   };
 
   const getAccount = (addr: MaybeAccount) => {

--- a/src/contexts/Connect/types.ts
+++ b/src/contexts/Connect/types.ts
@@ -1,8 +1,8 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { FunctionComponent, SVGProps } from 'react';
-import { AnyApi, MaybeAccount } from 'types';
+import { Extension } from 'contexts/Extensions/types';
+import { MaybeAccount } from 'types';
 
 export interface ConnectContextInterface {
   formatAccountSs58: (a: string) => string | null;
@@ -15,28 +15,9 @@ export interface ConnectContextInterface {
   accountHasSigner: (a: MaybeAccount) => boolean;
   isReadOnlyAccount: (a: MaybeAccount) => boolean;
   forgetAccounts: (a: Array<ExternalAccount>) => void;
-  extensions: Array<Extension>;
-  extensionsStatus: { [key: string]: string };
   accounts: Array<ExtensionAccount>;
   activeAccount: string | null;
   activeAccountMeta: ExtensionAccount | null;
-}
-
-export interface ExtensionInteface {
-  accounts: AnyApi;
-  metadata: AnyApi;
-  provider: AnyApi;
-  signer: AnyApi;
-}
-
-export interface Extension {
-  id: string;
-  title: string;
-  icon: FunctionComponent<
-    SVGProps<SVGSVGElement> & { title?: string | undefined }
-  >;
-  enable: (n: string) => Promise<ExtensionInteface>;
-  version: string;
 }
 export interface ExtensionAccount {
   addedBy?: string;

--- a/src/contexts/Extensions/defaults.ts
+++ b/src/contexts/Extensions/defaults.ts
@@ -1,0 +1,16 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ExtensionsContextInterface } from './types';
+
+export const defaultExtensionsContext: ExtensionsContextInterface = {
+  extensions: [],
+  extensionsStatus: {},
+  extensionsFetched: false,
+  // eslint-disable-next-line
+  setExtensionStatus: (id, s) => { },
+  // eslint-disable-next-line
+  setExtensionsFetched: (s) => { },
+  // eslint-disable-next-line
+  setExtensions: (s) => { },
+};

--- a/src/contexts/Extensions/index.tsx
+++ b/src/contexts/Extensions/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ExtensionConfig, EXTENSIONS } from 'config/extensions';
+import {
+  Extension,
+  ExtensionsContextInterface,
+} from 'contexts/Extensions/types';
+import React, { useEffect, useRef, useState } from 'react';
+import { AnyApi } from 'types';
+import { setStateWithRef } from 'Utils';
+import { defaultExtensionsContext } from './defaults';
+
+export const ExtensionsContext =
+  React.createContext<ExtensionsContextInterface>(defaultExtensionsContext);
+
+export const useExtensions = () => React.useContext(ExtensionsContext);
+
+export const ExtensionsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  // store the installed extensions in state
+  const [extensions, setExtensions] = useState<Array<Extension> | null>(null);
+
+  // store whether extensions have been fetched
+  const [extensionsFetched, setExtensionsFetched] = useState(false);
+
+  // store each extension's status in state.
+  const [extensionsStatus, setExtensionsStatus] = useState<{
+    [key: string]: string;
+  }>({});
+  const extensionsStatusRef = useRef(extensionsStatus);
+
+  // initialise extensions.
+  useEffect(() => {
+    if (!extensions) {
+      // timeout for initialising injectedWeb3
+      setTimeout(() => setExtensions(getInstalledExtensions()), 200);
+    }
+  });
+
+  const setExtensionStatus = (id: string, status: string) => {
+    setStateWithRef(
+      Object.assign(extensionsStatusRef.current, {
+        [id]: status,
+      }),
+      setExtensionsStatus,
+      extensionsStatusRef
+    );
+  };
+
+  const getInstalledExtensions = () => {
+    const { injectedWeb3 }: AnyApi = window;
+    const _exts: Extension[] = [];
+    EXTENSIONS.forEach((e: ExtensionConfig) => {
+      if (injectedWeb3[e.id] !== undefined) {
+        _exts.push({
+          ...e,
+          ...injectedWeb3[e.id],
+        });
+      }
+    });
+    return _exts;
+  };
+
+  return (
+    <ExtensionsContext.Provider
+      value={{
+        extensions: extensions ?? [],
+        setExtensionStatus,
+        extensionsStatus: extensionsStatusRef.current,
+        extensionsFetched,
+        setExtensionsFetched,
+        setExtensions,
+      }}
+    >
+      {children}
+    </ExtensionsContext.Provider>
+  );
+};

--- a/src/contexts/Extensions/types.ts
+++ b/src/contexts/Extensions/types.ts
@@ -1,0 +1,31 @@
+// Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { FunctionComponent, SVGProps } from 'react';
+import { AnyApi } from 'types';
+
+export interface ExtensionsContextInterface {
+  extensions: Array<Extension>;
+  extensionsStatus: { [key: string]: string };
+  extensionsFetched: boolean;
+  setExtensionStatus: (id: string, s: string) => void;
+  setExtensionsFetched: (s: boolean) => void;
+  setExtensions: (s: Array<Extension>) => void;
+}
+
+export interface ExtensionInteface {
+  accounts: AnyApi;
+  metadata: AnyApi;
+  provider: AnyApi;
+  signer: AnyApi;
+}
+
+export interface Extension {
+  id: string;
+  title: string;
+  icon: FunctionComponent<
+    SVGProps<SVGSVGElement> & { title?: string | undefined }
+  >;
+  enable: (n: string) => Promise<ExtensionInteface>;
+  version: string;
+}

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -5,7 +5,8 @@ import BN from 'bn.js';
 import { DappName } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import { Extension } from 'contexts/Connect/types';
+import { useExtensions } from 'contexts/Extensions';
+import { Extension } from 'contexts/Extensions/types';
 import { useExtrinsics } from 'contexts/Extrinsics';
 import { useNotifications } from 'contexts/Notifications';
 import { useTxFees } from 'contexts/TxFees';
@@ -24,7 +25,8 @@ export const useSubmitExtrinsic = ({
   const { setTxFees, setSender, txFees } = useTxFees();
   const { addNotification } = useNotifications();
   const { addPending, removePending } = useExtrinsics();
-  const { getAccount, extensions } = useConnect();
+  const { extensions } = useExtensions();
+  const { getAccount } = useConnect();
 
   // if null account is provided, fallback to empty string
   const submitAddress: string = from ?? '';

--- a/src/modals/ConnectAccounts/Account.tsx
+++ b/src/modals/ConnectAccounts/Account.tsx
@@ -5,7 +5,8 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
-import { Extension } from 'contexts/Connect/types';
+import { useExtensions } from 'contexts/Extensions';
+import { Extension } from 'contexts/Extensions/types';
 import { useModal } from 'contexts/Modal';
 import Identicon from 'library/Identicon';
 import { clipAddress } from 'Utils';
@@ -54,7 +55,7 @@ export const AccountButton = (props: AccountElementProps) => {
 export const AccountInner = (props: AccountElementProps) => {
   const { address, meta } = props;
 
-  const { extensions } = useConnect();
+  const { extensions } = useExtensions();
   const extension = extensions.find((e: Extension) => e.id === meta?.source);
   const Icon = extension?.icon ?? null;
   const label = props.label ?? null;

--- a/src/modals/ConnectAccounts/Extension.tsx
+++ b/src/modals/ConnectAccounts/Extension.tsx
@@ -4,14 +4,15 @@
 import { faCheckCircle, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
-import { Extension as ExtensionInterface } from 'contexts/Connect/types';
+import { useExtensions } from 'contexts/Extensions';
+import { Extension as ExtensionInterface } from 'contexts/Extensions/types';
 import { useState } from 'react';
 import { ExtensionProps } from './types';
 import { ExtensionWrapper } from './Wrappers';
 
 export const Extension = (props: ExtensionProps) => {
-  const { extensions } = useConnect();
-  const { extensionsStatus } = useConnect();
+  const { extensions } = useExtensions();
+  const { extensionsStatus } = useExtensions();
   const { meta } = props;
   const { id } = meta;
 

--- a/src/modals/ConnectAccounts/index.tsx
+++ b/src/modals/ConnectAccounts/index.tsx
@@ -3,6 +3,7 @@
 
 import { useConnect } from 'contexts/Connect';
 import { ImportedAccount } from 'contexts/Connect/types';
+import { useExtensions } from 'contexts/Extensions';
 import { useModal } from 'contexts/Modal';
 import { useEffect, useRef, useState } from 'react';
 import { Accounts } from './Accounts';
@@ -11,7 +12,8 @@ import { CardsWrapper, Wrapper } from './Wrappers';
 
 export const ConnectAccounts = () => {
   const modal = useModal();
-  const { activeAccount, extensions } = useConnect();
+  const { extensions } = useExtensions();
+  const { activeAccount } = useConnect();
   let { accounts } = useConnect();
   const { config } = modal;
   const _section = config?.section ?? null;


### PR DESCRIPTION
This PR simplifies the `Connect` context and makes it a lot more readable.

- Adds a new `Extensions` context and moves extension storage to it from `Connect`.
- Moves some logic from `Connect` into `Utils`.
- Introduces a new `useImportExtension` hook to abstract injected account connection logic and remove repeated code.