### PR TITLE
Formalise required extension properties in types

### DIFF
--- a/src/config/extensions/index.ts
+++ b/src/config/extensions/index.ts
@@ -1,20 +1,13 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { FunctionComponent, SVGProps } from 'react';
+import { ExtensionConfig } from 'contexts/Extensions/types';
 import { ReactComponent as NovaWalletSVG } from './icons/nova_wallet.svg';
 import { ReactComponent as PolkadotJSSVG } from './icons/polkadot_js.svg';
 import { ReactComponent as SignerSVG } from './icons/signer_icon.svg';
 import { ReactComponent as SubwalletSVG } from './icons/subwallet_icon.svg';
 import { ReactComponent as TalismanSVG } from './icons/talisman_icon.svg';
 
-export interface ExtensionConfig {
-  id: string;
-  title: string;
-  icon: FunctionComponent<
-    SVGProps<SVGSVGElement> & { title?: string | undefined }
-  >;
-}
 export const EXTENSIONS: ExtensionConfig[] = [
   {
     id: 'polkadot-js',

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -24,9 +24,9 @@ export const useImportExtension = () => {
   // connected extensions. Calls separate method to handle account importing.
   const handleImportExtension = (
     id: string,
-    accounts: Array<ExtensionAccount>,
+    currentAccounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
-    injected: Array<ExtensionAccount>,
+    newAccounts: Array<ExtensionAccount>,
     forget: (a: Array<ExternalAccount>) => void
   ) => {
     // update extensions status to connected.
@@ -34,8 +34,14 @@ export const useImportExtension = () => {
     // update local active extensions
     addToLocalExtensions(id);
 
-    if (injected.length) {
-      return handleInjectedAccounts(id, accounts, extension, injected, forget);
+    if (newAccounts.length) {
+      return handleInjectedAccounts(
+        id,
+        currentAccounts,
+        extension,
+        newAccounts,
+        forget
+      );
     }
     return [];
   };
@@ -47,7 +53,7 @@ export const useImportExtension = () => {
     id: string,
     accounts: Array<ExtensionAccount>,
     extension: ExtensionInteface,
-    injected: Array<ExtensionAccount>,
+    newAccounts: Array<ExtensionAccount>,
     forget: (a: Array<ExternalAccount>) => void
   ) => {
     // set network ss58 format
@@ -55,28 +61,28 @@ export const useImportExtension = () => {
     keyring.setSS58Format(network.ss58);
 
     // remove accounts that do not contain correctly formatted addresses.
-    injected = injected.filter((i: ExtensionAccount) => {
+    newAccounts = newAccounts.filter((i: ExtensionAccount) => {
       return isValidAddress(i.address);
     });
 
     // reformat addresses to ensure correct ss58 format
-    injected.forEach(async (account: ExtensionAccount) => {
+    newAccounts.forEach(async (account: ExtensionAccount) => {
       const { address } = keyring.addFromAddress(account.address);
       account.address = address;
       return account;
     });
 
-    // remove injected if they exist in local external accounts
-    forget(getInExternalAccounts(injected, network));
+    // remove newAccounts that exist in local external accounts
+    forget(getInExternalAccounts(newAccounts, network));
 
-    // remove accounts that have already been injected via another extension.
-    injected = injected.filter(
+    // remove accounts that have already been newAccounts via another extension
+    newAccounts = newAccounts.filter(
       (i: ExtensionAccount) =>
         !accounts.map((j: ImportedAccount) => j.address).includes(i.address)
     );
 
-    // format account properties.
-    injected = injected.map((a: ExtensionAccount) => {
+    // format account properties
+    newAccounts = newAccounts.map((a: ExtensionAccount) => {
       return {
         address: a.address,
         source: id,
@@ -84,14 +90,14 @@ export const useImportExtension = () => {
         signer: extension.signer,
       };
     });
-    return injected;
+    return newAccounts;
   };
 
   // Get active extension account.
   //
   // checks if the local active account is in the extension.
-  const getActiveExtensionAccount = (injected: Array<ImportedAccount>) =>
-    injected.find(
+  const getActiveExtensionAccount = (accounts: Array<ImportedAccount>) =>
+    accounts.find(
       (a: ExtensionAccount) => a.address === getActiveAccountLocal(network)
     ) ?? null;
 

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -4,10 +4,10 @@
 import Keyring from '@polkadot/keyring';
 import { useApi } from 'contexts/Api';
 import { useExtensions } from 'contexts/Extensions';
-import { ExtensionInteface } from 'contexts/Extensions/types';
+import { ExtensionAccount, ExtensionInteface } from 'contexts/Extensions/types';
 import { AnyFunction } from 'types';
 import { isValidAddress } from 'Utils';
-import { ExtensionAccount, ExternalAccount, ImportedAccount } from '../types';
+import { ExternalAccount, ImportedAccount } from '../types';
 import {
   addToLocalExtensions,
   getActiveAccountLocal,

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Keyring from '@polkadot/keyring';
+import { ExtensionAccount } from 'contexts/Extensions/types';
 import { Network } from 'types';
 import { localStorageOrDefault } from 'Utils';
-import { ExtensionAccount, ExternalAccount, ImportedAccount } from './types';
+import { ExternalAccount, ImportedAccount } from './types';
 
 // extension utils
 

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -11,7 +11,6 @@ import {
 } from 'contexts/Connect/types';
 import { useExtensions } from 'contexts/Extensions';
 import {
-  ExtensionAccount,
   ExtensionInjected,
   ExtensionInteface,
 } from 'contexts/Extensions/types';
@@ -238,39 +237,37 @@ export const ConnectProvider = ({
             const extension: ExtensionInteface = await enable(DappName);
 
             if (extension !== undefined) {
-              const unsub = (await extension.accounts.subscribe(
-                (newAccounts: Array<ExtensionAccount>) => {
-                  if (newAccounts) {
-                    newAccounts = handleImportExtension(
-                      id,
-                      accountsRef.current,
-                      extension,
-                      newAccounts,
-                      forgetAccounts
+              const unsub = extension.accounts.subscribe((newAccounts) => {
+                if (newAccounts) {
+                  newAccounts = handleImportExtension(
+                    id,
+                    accountsRef.current,
+                    extension,
+                    newAccounts,
+                    forgetAccounts
+                  );
+                  // store active wallet account if found in this extension
+                  if (!activeWalletAccount) {
+                    activeWalletAccount =
+                      getActiveExtensionAccount(newAccounts);
+                  }
+                  // set active account for network on final extension
+                  if (i === total && activeAccountRef.current === null) {
+                    connectActiveExtensionAccount(
+                      activeWalletAccount,
+                      connectToAccount
                     );
-                    // store active wallet account if found in this extension
-                    if (!activeWalletAccount) {
-                      activeWalletAccount =
-                        getActiveExtensionAccount(newAccounts);
-                    }
-                    // set active account for network on final extension
-                    if (i === total && activeAccountRef.current === null) {
-                      connectActiveExtensionAccount(
-                        activeWalletAccount,
-                        connectToAccount
-                      );
-                    }
-                    // concat accounts and store
-                    if (newAccounts.length) {
-                      setStateWithRef(
-                        [...accountsRef.current].concat(newAccounts),
-                        setAccounts,
-                        accountsRef
-                      );
-                    }
+                  }
+                  // concat accounts and store
+                  if (newAccounts.length) {
+                    setStateWithRef(
+                      [...accountsRef.current].concat(newAccounts),
+                      setAccounts,
+                      accountsRef
+                    );
                   }
                 }
-              )) as () => void;
+              });
 
               // update context state
               setStateWithRef(
@@ -318,32 +315,30 @@ export const ConnectProvider = ({
 
         if (extension !== undefined) {
           // subscribe to accounts
-          const unsub = (await extension.accounts.subscribe(
-            (newAccounts: Array<ExtensionAccount>) => {
-              if (newAccounts) {
-                newAccounts = handleImportExtension(
-                  id,
-                  accountsRef.current,
-                  extension,
-                  newAccounts,
-                  forgetAccounts
-                );
-                // set active account for network if not yet set
-                if (activeAccountRef.current === null) {
-                  connectActiveExtensionAccount(
-                    getActiveExtensionAccount(newAccounts),
-                    connectToAccount
-                  );
-                }
-                // concat accounts and store
-                setStateWithRef(
-                  [...accountsRef.current].concat(newAccounts),
-                  setAccounts,
-                  accountsRef
+          const unsub = extension.accounts.subscribe((newAccounts) => {
+            if (newAccounts) {
+              newAccounts = handleImportExtension(
+                id,
+                accountsRef.current,
+                extension,
+                newAccounts,
+                forgetAccounts
+              );
+              // set active account for network if not yet set
+              if (activeAccountRef.current === null) {
+                connectActiveExtensionAccount(
+                  getActiveExtensionAccount(newAccounts),
+                  connectToAccount
                 );
               }
+              // concat accounts and store
+              setStateWithRef(
+                [...accountsRef.current].concat(newAccounts),
+                setAccounts,
+                accountsRef
+              );
             }
-          )) as () => void;
+          });
 
           // update context state
           setStateWithRef(

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -11,8 +11,8 @@ import {
 } from 'contexts/Connect/types';
 import { useExtensions } from 'contexts/Extensions';
 import {
-  Extension,
   ExtensionAccount,
+  ExtensionInjected,
   ExtensionInteface,
 } from 'contexts/Extensions/types';
 import React, { useEffect, useRef, useState } from 'react';
@@ -221,7 +221,7 @@ export const ConnectProvider = ({
     }
 
     let i = 0;
-    extensions.forEach(async (e: Extension) => {
+    extensions.forEach(async (e: ExtensionInjected) => {
       i++;
 
       // ensure the extension carries an `id` property
@@ -300,7 +300,7 @@ export const ConnectProvider = ({
    * This is invoked by the user by clicking on an extension.
    * If activeAccount is not found here, it is simply ignored.
    */
-  const connectExtensionAccounts = async (e: Extension) => {
+  const connectExtensionAccounts = async (e: ExtensionInjected) => {
     const keyring = new Keyring();
     keyring.setSS58Format(network.ss58);
 

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -6,12 +6,15 @@ import { DappName } from 'consts';
 import { useApi } from 'contexts/Api';
 import {
   ConnectContextInterface,
-  ExtensionAccount,
   ExternalAccount,
   ImportedAccount,
 } from 'contexts/Connect/types';
 import { useExtensions } from 'contexts/Extensions';
-import { Extension, ExtensionInteface } from 'contexts/Extensions/types';
+import {
+  Extension,
+  ExtensionAccount,
+  ExtensionInteface,
+} from 'contexts/Extensions/types';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnyApi, MaybeAccount } from 'types';
 import { clipAddress, localStorageOrDefault, setStateWithRef } from 'Utils';
@@ -220,60 +223,67 @@ export const ConnectProvider = ({
     let i = 0;
     extensions.forEach(async (e: Extension) => {
       i++;
-      const { id, enable } = e;
 
-      // if extension is found locally, subscribe to accounts
-      if (extensionIsLocal(id)) {
-        try {
-          // summons extension popup
-          const extension: ExtensionInteface = await enable(DappName);
+      // ensure the extension carries an `id` property
+      const id = e?.id ?? undefined;
 
-          if (extension !== undefined) {
-            const unsub = (await extension.accounts.subscribe(
-              (injected: ExtensionAccount[]) => {
-                if (injected) {
-                  injected = handleImportExtension(
-                    id,
-                    accountsRef.current,
-                    extension,
-                    injected,
-                    forgetAccounts
-                  );
-                  // store active wallet account if found in this extension
-                  if (!activeWalletAccount) {
-                    activeWalletAccount = getActiveExtensionAccount(injected);
-                  }
-                  // set active account for network on final extension
-                  if (i === total && activeAccountRef.current === null) {
-                    connectActiveExtensionAccount(
-                      activeWalletAccount,
-                      connectToAccount
+      if (id) {
+        // if extension is found locally, subscribe to accounts
+        if (extensionIsLocal(id)) {
+          try {
+            // attempt to get extension `enable` property
+            const { enable } = e;
+
+            // summons extension popup
+            const extension: ExtensionInteface = await enable(DappName);
+
+            if (extension !== undefined) {
+              const unsub = (await extension.accounts.subscribe(
+                (injected: ExtensionAccount[]) => {
+                  if (injected) {
+                    injected = handleImportExtension(
+                      id,
+                      accountsRef.current,
+                      extension,
+                      injected,
+                      forgetAccounts
                     );
-                  }
-                  // concat accounts and store
-                  if (injected.length) {
-                    setStateWithRef(
-                      [...accountsRef.current].concat(injected),
-                      setAccounts,
-                      accountsRef
-                    );
+                    // store active wallet account if found in this extension
+                    if (!activeWalletAccount) {
+                      activeWalletAccount = getActiveExtensionAccount(injected);
+                    }
+                    // set active account for network on final extension
+                    if (i === total && activeAccountRef.current === null) {
+                      connectActiveExtensionAccount(
+                        activeWalletAccount,
+                        connectToAccount
+                      );
+                    }
+                    // concat accounts and store
+                    if (injected.length) {
+                      setStateWithRef(
+                        [...accountsRef.current].concat(injected),
+                        setAccounts,
+                        accountsRef
+                      );
+                    }
                   }
                 }
-              }
-            )) as () => void;
+              )) as () => void;
 
-            // update context state
-            setStateWithRef(
-              [...unsubscribeRef.current].concat({
-                key: id,
-                unsub,
-              }),
-              setUnsubscribe,
-              unsubscribeRef
-            );
+              // update context state
+              setStateWithRef(
+                [...unsubscribeRef.current].concat({
+                  key: id,
+                  unsub,
+                }),
+                setUnsubscribe,
+                unsubscribeRef
+              );
+            }
+          } catch (err) {
+            handleExtensionError(id, String(err));
           }
-        } catch (err) {
-          handleExtensionError(id, String(err));
         }
       }
 
@@ -293,53 +303,60 @@ export const ConnectProvider = ({
   const connectExtensionAccounts = async (e: Extension) => {
     const keyring = new Keyring();
     keyring.setSS58Format(network.ss58);
-    const { id, enable } = e;
 
-    try {
-      // summons extension popup
-      const extension: ExtensionInteface = await enable(DappName);
+    // ensure the extension carries an `id` property
+    const id = e?.id ?? undefined;
 
-      if (extension !== undefined) {
-        // subscribe to accounts
-        const unsub = (await extension.accounts.subscribe(
-          (injected: ExtensionAccount[]) => {
-            if (injected) {
-              injected = handleImportExtension(
-                id,
-                accountsRef.current,
-                extension,
-                injected,
-                forgetAccounts
-              );
-              // set active account for network if not yet set
-              if (activeAccountRef.current === null) {
-                connectActiveExtensionAccount(
-                  getActiveExtensionAccount(injected),
-                  connectToAccount
+    if (id) {
+      try {
+        // attempt to get extension `enable` property
+        const { enable } = e;
+
+        // summons extension popup
+        const extension: ExtensionInteface = await enable(DappName);
+
+        if (extension !== undefined) {
+          // subscribe to accounts
+          const unsub = (await extension.accounts.subscribe(
+            (injected: ExtensionAccount[]) => {
+              if (injected) {
+                injected = handleImportExtension(
+                  id,
+                  accountsRef.current,
+                  extension,
+                  injected,
+                  forgetAccounts
+                );
+                // set active account for network if not yet set
+                if (activeAccountRef.current === null) {
+                  connectActiveExtensionAccount(
+                    getActiveExtensionAccount(injected),
+                    connectToAccount
+                  );
+                }
+                // concat accounts and store
+                setStateWithRef(
+                  [...accountsRef.current].concat(injected),
+                  setAccounts,
+                  accountsRef
                 );
               }
-              // concat accounts and store
-              setStateWithRef(
-                [...accountsRef.current].concat(injected),
-                setAccounts,
-                accountsRef
-              );
             }
-          }
-        )) as () => void;
+          )) as () => void;
 
-        // update context state
-        setStateWithRef(
-          [...unsubscribeRef.current].concat({
-            key: id,
-            unsub,
-          }),
-          setUnsubscribe,
-          unsubscribeRef
-        );
+          // update context state
+          setStateWithRef(
+            [...unsubscribeRef.current].concat({
+              key: id,
+              unsub,
+            }),
+            setUnsubscribe,
+            unsubscribeRef
+          );
+        }
+      } catch (err) {
+        handleExtensionError(id, String(err));
       }
-    } catch (err) {
-      handleExtensionError(id, String(err));
     }
   };
 

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -239,18 +239,19 @@ export const ConnectProvider = ({
 
             if (extension !== undefined) {
               const unsub = (await extension.accounts.subscribe(
-                (injected: ExtensionAccount[]) => {
-                  if (injected) {
-                    injected = handleImportExtension(
+                (newAccounts: Array<ExtensionAccount>) => {
+                  if (newAccounts) {
+                    newAccounts = handleImportExtension(
                       id,
                       accountsRef.current,
                       extension,
-                      injected,
+                      newAccounts,
                       forgetAccounts
                     );
                     // store active wallet account if found in this extension
                     if (!activeWalletAccount) {
-                      activeWalletAccount = getActiveExtensionAccount(injected);
+                      activeWalletAccount =
+                        getActiveExtensionAccount(newAccounts);
                     }
                     // set active account for network on final extension
                     if (i === total && activeAccountRef.current === null) {
@@ -260,9 +261,9 @@ export const ConnectProvider = ({
                       );
                     }
                     // concat accounts and store
-                    if (injected.length) {
+                    if (newAccounts.length) {
                       setStateWithRef(
-                        [...accountsRef.current].concat(injected),
+                        [...accountsRef.current].concat(newAccounts),
                         setAccounts,
                         accountsRef
                       );
@@ -318,25 +319,25 @@ export const ConnectProvider = ({
         if (extension !== undefined) {
           // subscribe to accounts
           const unsub = (await extension.accounts.subscribe(
-            (injected: ExtensionAccount[]) => {
-              if (injected) {
-                injected = handleImportExtension(
+            (newAccounts: Array<ExtensionAccount>) => {
+              if (newAccounts) {
+                newAccounts = handleImportExtension(
                   id,
                   accountsRef.current,
                   extension,
-                  injected,
+                  newAccounts,
                   forgetAccounts
                 );
                 // set active account for network if not yet set
                 if (activeAccountRef.current === null) {
                   connectActiveExtensionAccount(
-                    getActiveExtensionAccount(injected),
+                    getActiveExtensionAccount(newAccounts),
                     connectToAccount
                   );
                 }
                 // concat accounts and store
                 setStateWithRef(
-                  [...accountsRef.current].concat(injected),
+                  [...accountsRef.current].concat(newAccounts),
                   setAccounts,
                   accountsRef
                 );

--- a/src/contexts/Connect/types.ts
+++ b/src/contexts/Connect/types.ts
@@ -1,12 +1,12 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Extension, ExtensionAccount } from 'contexts/Extensions/types';
+import { ExtensionAccount, ExtensionInjected } from 'contexts/Extensions/types';
 import { MaybeAccount } from 'types';
 
 export interface ConnectContextInterface {
   formatAccountSs58: (a: string) => string | null;
-  connectExtensionAccounts: (e: Extension) => void;
+  connectExtensionAccounts: (e: ExtensionInjected) => void;
   getAccount: (account: MaybeAccount) => ExtensionAccount | null;
   connectToAccount: (a: ExtensionAccount) => void;
   disconnectFromAccount: () => void;

--- a/src/contexts/Connect/types.ts
+++ b/src/contexts/Connect/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Extension } from 'contexts/Extensions/types';
+import { Extension, ExtensionAccount } from 'contexts/Extensions/types';
 import { MaybeAccount } from 'types';
 
 export interface ConnectContextInterface {
@@ -18,13 +18,6 @@ export interface ConnectContextInterface {
   accounts: Array<ExtensionAccount>;
   activeAccount: string | null;
   activeAccountMeta: ExtensionAccount | null;
-}
-export interface ExtensionAccount {
-  addedBy?: string;
-  address: string;
-  source: string;
-  name?: string;
-  signer?: unknown;
 }
 
 export type ImportedAccount = ExtensionAccount | ExternalAccount;

--- a/src/contexts/Extensions/index.tsx
+++ b/src/contexts/Extensions/index.tsx
@@ -3,8 +3,8 @@
 
 import { EXTENSIONS } from 'config/extensions';
 import {
-  Extension,
   ExtensionConfig,
+  ExtensionInjected,
   ExtensionsContextInterface,
 } from 'contexts/Extensions/types';
 import React, { useEffect, useRef, useState } from 'react';
@@ -26,7 +26,9 @@ export const ExtensionsProvider = ({
   const [injectedPresent, setInjectedPresent] = useState<boolean>(false);
 
   // store the installed extensions in state
-  const [extensions, setExtensions] = useState<Array<Extension> | null>(null);
+  const [extensions, setExtensions] = useState<Array<ExtensionInjected> | null>(
+    null
+  );
 
   // store whether extensions have been fetched
   const [extensionsFetched, setExtensionsFetched] = useState(false);
@@ -82,7 +84,7 @@ export const ExtensionsProvider = ({
 
   const getInstalledExtensions = () => {
     const { injectedWeb3 }: AnyApi = window;
-    const _exts: Extension[] = [];
+    const _exts: ExtensionInjected[] = [];
     EXTENSIONS.forEach((e: ExtensionConfig) => {
       if (injectedWeb3[e.id] !== undefined) {
         _exts.push({

--- a/src/contexts/Extensions/index.tsx
+++ b/src/contexts/Extensions/index.tsx
@@ -1,9 +1,10 @@
 // Copyright 2022 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ExtensionConfig, EXTENSIONS } from 'config/extensions';
+import { EXTENSIONS } from 'config/extensions';
 import {
   Extension,
+  ExtensionConfig,
   ExtensionsContextInterface,
 } from 'contexts/Extensions/types';
 import React, { useEffect, useRef, useState } from 'react';

--- a/src/contexts/Extensions/types.ts
+++ b/src/contexts/Extensions/types.ts
@@ -16,7 +16,7 @@ export interface ExtensionConfig {
 
 // top level required properties the extension must expose via their
 // `injectedWeb3` entry.
-export interface Extension extends ExtensionConfig {
+export interface ExtensionInjected extends ExtensionConfig {
   id: string;
   enable: (n: string) => Promise<ExtensionInteface>;
 }
@@ -46,10 +46,10 @@ export interface ExtensionMetadata {
 
 // dashboard specific: extensions context interface.
 export interface ExtensionsContextInterface {
-  extensions: Array<Extension>;
+  extensions: Array<ExtensionInjected>;
   extensionsStatus: { [key: string]: string };
   extensionsFetched: boolean;
   setExtensionStatus: (id: string, s: string) => void;
   setExtensionsFetched: (s: boolean) => void;
-  setExtensions: (s: Array<Extension>) => void;
+  setExtensions: (s: Array<ExtensionInjected>) => void;
 }

--- a/src/contexts/Extensions/types.ts
+++ b/src/contexts/Extensions/types.ts
@@ -24,7 +24,9 @@ export interface ExtensionInjected extends ExtensionConfig {
 // the rquired properties `enable` must provide after resolution.
 export interface ExtensionInteface {
   accounts: {
-    subscribe: AnyApi;
+    subscribe: {
+      (a: { (a: Array<ExtensionAccount>): void }): void;
+    };
   };
   provider: AnyApi;
   signer: AnyApi;
@@ -34,7 +36,7 @@ export interface ExtensionInteface {
 export interface ExtensionAccount extends ExtensionMetadata {
   address: string;
   name: string;
-  signer?: unknown;
+  signer?: AnyApi;
 }
 
 // dashboard specific: miscellaneous metadata added to an extension by the

--- a/src/contexts/Extensions/types.ts
+++ b/src/contexts/Extensions/types.ts
@@ -4,6 +4,47 @@
 import { FunctionComponent, SVGProps } from 'react';
 import { AnyApi } from 'types';
 
+// configuration item of an extension specific to the dashboard.
+// configured in src/config/extensions/index.tsx.
+export interface ExtensionConfig {
+  id: string;
+  title: string;
+  icon: FunctionComponent<
+    SVGProps<SVGSVGElement> & { title?: string | undefined }
+  >;
+}
+
+// top level required properties the extension must expose via their
+// `injectedWeb3` entry.
+export interface Extension extends ExtensionConfig {
+  id: string;
+  enable: (n: string) => Promise<ExtensionInteface>;
+}
+
+// the rquired properties `enable` must provide after resolution.
+export interface ExtensionInteface {
+  accounts: {
+    subscribe: AnyApi;
+  };
+  provider: AnyApi;
+  signer: AnyApi;
+}
+
+// the required properties returned after subscribing to accounts.
+export interface ExtensionAccount extends ExtensionMetadata {
+  address: string;
+  name: string;
+  signer?: unknown;
+}
+
+// dashboard specific: miscellaneous metadata added to an extension by the
+// dashboard.
+export interface ExtensionMetadata {
+  addedBy?: string;
+  source: string;
+}
+
+// dashboard specific: extensions context interface.
 export interface ExtensionsContextInterface {
   extensions: Array<Extension>;
   extensionsStatus: { [key: string]: string };
@@ -11,21 +52,4 @@ export interface ExtensionsContextInterface {
   setExtensionStatus: (id: string, s: string) => void;
   setExtensionsFetched: (s: boolean) => void;
   setExtensions: (s: Array<Extension>) => void;
-}
-
-export interface ExtensionInteface {
-  accounts: AnyApi;
-  metadata: AnyApi;
-  provider: AnyApi;
-  signer: AnyApi;
-}
-
-export interface Extension {
-  id: string;
-  title: string;
-  icon: FunctionComponent<
-    SVGProps<SVGSVGElement> & { title?: string | undefined }
-  >;
-  enable: (n: string) => Promise<ExtensionInteface>;
-  version: string;
 }

--- a/src/library/Form/types.ts
+++ b/src/library/Form/types.ts
@@ -3,7 +3,8 @@
 
 import BN from 'bn.js';
 import { Balance } from 'contexts/Balances/types';
-import { ExtensionAccount, ExternalAccount } from 'contexts/Connect/types';
+import { ExternalAccount } from 'contexts/Connect/types';
+import { ExtensionAccount } from 'contexts/Extensions/types';
 
 export interface ExtensionAccountItem extends ExtensionAccount {
   active?: boolean;

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -6,7 +6,7 @@ import { DappName } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useExtensions } from 'contexts/Extensions';
-import { Extension } from 'contexts/Extensions/types';
+import { ExtensionInjected } from 'contexts/Extensions/types';
 import { useExtrinsics } from 'contexts/Extrinsics';
 import { useNotifications } from 'contexts/Notifications';
 import { useTxFees } from 'contexts/TxFees';
@@ -71,7 +71,9 @@ export const useSubmitExtrinsic = ({
 
     const { signer, source } = account;
 
-    const extension = extensions.find((e: Extension) => e.id === source);
+    const extension = extensions.find(
+      (e: ExtensionInjected) => e.id === source
+    );
     if (extension === undefined) {
       throw new Error(t('walletNotFound') || '');
     } else {

--- a/src/modals/ConnectAccounts/Account.tsx
+++ b/src/modals/ConnectAccounts/Account.tsx
@@ -6,7 +6,7 @@ import { faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
 import { useExtensions } from 'contexts/Extensions';
-import { Extension } from 'contexts/Extensions/types';
+import { ExtensionInjected } from 'contexts/Extensions/types';
 import { useModal } from 'contexts/Modal';
 import Identicon from 'library/Identicon';
 import { clipAddress } from 'Utils';
@@ -56,7 +56,9 @@ export const AccountInner = (props: AccountElementProps) => {
   const { address, meta } = props;
 
   const { extensions } = useExtensions();
-  const extension = extensions.find((e: Extension) => e.id === meta?.source);
+  const extension = extensions.find(
+    (e: ExtensionInjected) => e.id === meta?.source
+  );
   const Icon = extension?.icon ?? null;
   const label = props.label ?? null;
   const source = meta?.source ?? null;

--- a/src/modals/ConnectAccounts/Extension.tsx
+++ b/src/modals/ConnectAccounts/Extension.tsx
@@ -5,7 +5,7 @@ import { faCheckCircle, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useConnect } from 'contexts/Connect';
 import { useExtensions } from 'contexts/Extensions';
-import { Extension as ExtensionInterface } from 'contexts/Extensions/types';
+import { ExtensionInjected } from 'contexts/Extensions/types';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExtensionProps } from './types';
@@ -18,7 +18,7 @@ export const Extension = (props: ExtensionProps) => {
   const { id } = meta;
   const { t } = useTranslation('modals');
 
-  const installed = extensions.find((e: ExtensionInterface) => e.id === id);
+  const installed = extensions.find((e: ExtensionInjected) => e.id === id);
   const status = !installed ? 'not_found' : extensionsStatus[id];
 
   // determine message to be displayed based on extension status.

--- a/src/modals/ConnectAccounts/Extensions.tsx
+++ b/src/modals/ConnectAccounts/Extensions.tsx
@@ -3,8 +3,9 @@
 
 import { faAngleDoubleRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { ExtensionConfig, EXTENSIONS } from 'config/extensions';
+import { EXTENSIONS } from 'config/extensions';
 import { useConnect } from 'contexts/Connect';
+import { ExtensionConfig } from 'contexts/Extensions/types';
 import { forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Extension } from './Extension';

--- a/src/modals/ConnectAccounts/types.ts
+++ b/src/modals/ConnectAccounts/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BalanceLedger } from 'contexts/Balances/types';
-import { ExtensionAccount } from 'contexts/Connect/types';
+import { ExtensionAccount } from 'contexts/Extensions/types';
 import { FunctionComponent, SVGProps } from 'react';
 import { MaybeAccount } from 'types';
 


### PR DESCRIPTION
This PR formalises the required properties an extension must provide the dashboard in its `injectedWeb3` object.

- [x] Corresponding types are collated and documented.
- [x] App cannot crash by attempting to access missing `injectedWeb3` `id` and `enable` properties. 