### PR TITLE
Timeleft fixes + refresh intervals

### DIFF
--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -16,7 +16,7 @@ import {
 
 export const useTimeLeft = ({
   refreshCallback,
-  refreshInterval = 120,
+  refreshInterval,
 }: TimeleftHookProps) => {
   const { t, i18n } = useTranslation();
 

--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -10,10 +10,14 @@ import {
   TimeLeftAll,
   TimeleftDuration,
   TimeLeftFormatted,
+  TimeleftHookProps,
   TimeLeftRaw,
 } from './types';
 
-export const useTimeLeft = () => {
+export const useTimeLeft = ({
+  refreshCallback,
+  refreshInterval = 120,
+}: TimeleftHookProps) => {
   const { t, i18n } = useTranslation();
 
   // adds `seconds` to the current time and returns the resulting date.
@@ -104,42 +108,63 @@ export const useTimeLeft = () => {
   const [timeleft, setTimeleft] = useState<TimeLeftAll>(getTimeleft());
 
   // timeleft refresh intervals.
-  const [minInterval, setMinInterval] = useState<ReturnType<
-    typeof setInterval
-  > | null>(null);
-  const [secInterval, setSecInterval] = useState<ReturnType<
-    typeof setInterval
-  > | null>(null);
+  const [minInterval, setMinInterval] = useState<
+    ReturnType<typeof setInterval> | undefined
+  >(undefined);
+  const minIntervalRef = useRef(minInterval);
 
-  // refresh every minute, or every second if in last minute.
+  const [secInterval, setSecInterval] = useState<
+    ReturnType<typeof setInterval> | undefined
+  >(undefined);
+  const secIntervalRef = useRef(secInterval);
+
+  // refresh callback counter
+  let r = refreshInterval;
+
+  // refresh effects.
   useEffect(() => {
+    // handler for handling timeleft refresh.
+    //
+    // either handle regular timeleft update, or refresh `to` via `refreshCallback` every
+    // `refreshInterval` seconds.
+    const handleRefresh = () => {
+      r--;
+      if (r !== 0) {
+        setTimeleft(getTimeleft());
+      } else {
+        if (refreshCallback) {
+          setStateWithRef(fromNow(refreshCallback()), setTo, toRef);
+          setTimeleft(getTimeleft());
+        }
+        r = refreshInterval;
+      }
+    };
+
     if (inLastHour()) {
-      // refresh timeleft every second
-      if (!secInterval) {
-        setSecInterval(
-          setInterval(() => {
-            if (!inLastHour()) {
-              if (secInterval) clearInterval(secInterval);
-              setSecInterval(null);
-            }
-            setTimeleft(getTimeleft());
-          }, 1000)
-        );
+      // refresh timeleft every second.
+      if (!secIntervalRef.current) {
+        const interval = setInterval(() => {
+          if (!inLastHour()) {
+            clearInterval(secIntervalRef.current);
+            setStateWithRef(undefined, setSecInterval, secIntervalRef);
+          }
+          handleRefresh();
+        }, 1000);
+
+        setStateWithRef(interval, setSecInterval, secIntervalRef);
       }
     } else {
       setTimeleft(getTimeleft());
-
       // refresh timeleft every minute.
-      if (!minInterval) {
-        setMinInterval(
-          setInterval(() => {
-            if (inLastHour()) {
-              if (minInterval) clearInterval(minInterval);
-              setMinInterval(null);
-            }
-            setTimeleft(getTimeleft());
-          }, 60000)
-        );
+      if (!minIntervalRef.current) {
+        const interval = setInterval(() => {
+          if (inLastHour()) {
+            clearInterval(minIntervalRef.current);
+            setStateWithRef(undefined, setMinInterval, minIntervalRef);
+          }
+          handleRefresh();
+        }, 60000);
+        setStateWithRef(interval, setMinInterval, minIntervalRef);
       }
     }
   }, [to, inLastHour(), lastMinuteCountdown()]);
@@ -152,14 +177,8 @@ export const useTimeLeft = () => {
   // clear intervals on unmount
   useEffect(() => {
     return () => {
-      if (minInterval) {
-        clearInterval(minInterval);
-        setMinInterval(null);
-      }
-      if (secInterval) {
-        clearInterval(secInterval);
-        setSecInterval(null);
-      }
+      clearInterval(minInterval);
+      clearInterval(secInterval);
     };
   }, []);
 

--- a/src/library/Hooks/useTimeLeft/types.ts
+++ b/src/library/Hooks/useTimeLeft/types.ts
@@ -27,4 +27,7 @@ export interface TimeLeftAll {
   formatted: TimeLeftFormatted;
 }
 
-export type TimeleftProps = number;
+export interface TimeleftHookProps {
+  refreshCallback: () => number;
+  refreshInterval: number;
+}

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -12,13 +12,17 @@ import { humanNumber } from 'Utils';
 const ActiveEraStatBox = () => {
   const { t } = useTranslation('pages');
   const { metrics } = useNetworkMetrics();
-  const { timeleft, fromNow, setFromNow } = useTimeLeft();
   const { activeEra } = metrics;
   const {
     timeleft: eraTimeLeft,
     percentSurpassed,
     percentRemaining,
   } = useEraTimeLeft();
+
+  const { timeleft, fromNow, setFromNow } = useTimeLeft({
+    refreshInterval: 60,
+    refreshCallback: () => eraTimeLeft,
+  });
 
   // re-set timer on era change (also covers network change).
   useEffect(() => {


### PR DESCRIPTION
This PR fixes network switching bugs that did not clear intervals correctly.

It also introduces a way to update the estimated end time in `useTimeLeft` via a refresh callback function, as well as how often the end time should be updated.