### PR TITLE
Timeleft refresh counter fix

### DIFF
--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -128,7 +128,6 @@ export const useTimeLeft = ({
     // either handle regular timeleft update, or refresh `to` via `refreshCallback` every
     // `refreshInterval` seconds.
     const handleRefresh = () => {
-      r--;
       if (r !== 0) {
         setTimeleft(getTimeleft());
       } else {
@@ -148,6 +147,7 @@ export const useTimeLeft = ({
             clearInterval(secIntervalRef.current);
             setStateWithRef(undefined, setSecInterval, secIntervalRef);
           }
+          r = Math.max(0, r - 1);
           handleRefresh();
         }, 1000);
 
@@ -162,6 +162,7 @@ export const useTimeLeft = ({
             clearInterval(minIntervalRef.current);
             setStateWithRef(undefined, setMinInterval, minIntervalRef);
           }
+          r = Math.max(0, r - 60);
           handleRefresh();
         }, 60000);
         setStateWithRef(interval, setMinInterval, minIntervalRef);


### PR DESCRIPTION
Small fix pertaining to refresh counter, deducting 60 seconds on minInterval and 1 second on secInterval. Previously it was deducting 1 second on both intervals.