### PR TITLE
Era Timeleft as Function

### DIFF
--- a/src/library/Hooks/useEraTimeLeft/index.tsx
+++ b/src/library/Hooks/useEraTimeLeft/index.tsx
@@ -11,28 +11,33 @@ export const useEraTimeLeft = () => {
   const { metrics } = useNetworkMetrics();
   const { activeEra } = metrics;
 
-  // get timestamp of era start and convert to seconds.
-  let { start } = activeEra;
-  start *= 0.001;
+  // important to fetch the actual timeleft from when other components ask for it.
+  const get = () => {
+    // get timestamp of era start and convert to seconds.
+    let { start } = activeEra;
+    start *= 0.001;
 
-  // store the duration of an era in block numbers.
-  const eraDurationBlocks = epochDuration * sessionsPerEra;
+    // store the duration of an era in block numbers.
+    const eraDurationBlocks = epochDuration * sessionsPerEra;
 
-  // estimate the duration of the era in seconds
-  const eraDuration = eraDurationBlocks * expectedBlockTime * 0.001;
+    // estimate the duration of the era in seconds
+    const eraDuration = eraDurationBlocks * expectedBlockTime * 0.001;
 
-  // estimate the end time of the era
-  const end = start + eraDuration;
+    // estimate the end time of the era
+    const end = start + eraDuration;
 
-  // estimate remaining time of era.
-  const timeleft = Math.max(0, end - getUnixTime(new Date()));
+    // estimate remaining time of era.
+    const timeleft = Math.max(0, end - getUnixTime(new Date()));
 
-  // percentage of eraDuration
-  const percentage = eraDuration * 0.01;
-  const percentRemaining = timeleft / percentage;
-  const percentSurpassed = 100 - percentRemaining;
+    // percentage of eraDuration
+    const percentage = eraDuration * 0.01;
+    const percentRemaining = timeleft / percentage;
+    const percentSurpassed = 100 - percentRemaining;
 
-  return { timeleft, percentSurpassed, percentRemaining };
+    return { timeleft, percentSurpassed, percentRemaining };
+  };
+
+  return { get };
 };
 
 export default useEraTimeLeft;

--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -128,7 +128,7 @@ export const useTimeLeft = (props?: TimeleftHookProps) => {
           }
           r = Math.max(0, r - 60);
           handleRefresh();
-        }, 2000);
+        }, 60000);
         setStateWithRef(interval, setMinInterval, minIntervalRef);
       }
     }

--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -128,7 +128,7 @@ export const useTimeLeft = (props?: TimeleftHookProps) => {
           }
           r = Math.max(0, r - 60);
           handleRefresh();
-        }, 60000);
+        }, 2000);
         setStateWithRef(interval, setMinInterval, minIntervalRef);
       }
     }

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -12,25 +12,24 @@ import { useTranslation } from 'react-i18next';
 import { humanNumber } from 'Utils';
 
 const ActiveEraStatBox = () => {
-  const { status: connectionStatus } = useApi();
   const { t } = useTranslation('pages');
+  const { status: connectionStatus } = useApi();
   const { metrics } = useNetworkMetrics();
   const { activeEra } = metrics;
-  const {
-    timeleft: eraTimeLeft,
-    percentSurpassed,
-    percentRemaining,
-  } = useEraTimeLeft();
+  const { get: getEraTimeleft } = useEraTimeLeft();
 
   const { timeleft, setFromNow } = useTimeLeft({
     refreshInterval: 60,
-    refreshCallback: () => eraTimeLeft,
+    refreshCallback: () => getEraTimeleft().timeleft,
   });
 
   // re-set timer on era change (also covers network change).
   useEffect(() => {
-    setFromNow(fromNow(eraTimeLeft));
+    setFromNow(fromNow(getEraTimeleft().timeleft));
   }, [connectionStatus, activeEra]);
+
+  // NOTE: this maybe should be called in an interval. Needs more testing.
+  const { percentSurpassed, percentRemaining } = getEraTimeleft();
 
   const params = {
     label: t('overview.timeRemainingThisEra'),


### PR DESCRIPTION
Fixes an issue where `refreshCallback` as not getting the live era time left from the hook. Fix: refactor to a callable function.