### PR TITLE
CTA Part 2: start staking modal + quick links

### DIFF
--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -137,4 +137,4 @@ export interface PoolAddresses {
 
 export type MaybePool = number | null;
 
-export type PoolState = 'open' | 'blocked' | 'destroying';
+export type PoolState = 'Open' | 'Blocked' | 'Destroying';

--- a/src/contexts/Setup/defaults.ts
+++ b/src/contexts/Setup/defaults.ts
@@ -38,6 +38,6 @@ export const defaultSetupContext: SetupContextInterface = {
   setOnNominatorSetup: (v) => {},
   // eslint-disable-next-line
   setOnPoolSetup: (v) => {},
-  onNominatorSetup: 0,
-  onPoolSetup: 0,
+  onNominatorSetup: false,
+  onPoolSetup: false,
 };

--- a/src/contexts/Setup/index.tsx
+++ b/src/contexts/Setup/index.tsx
@@ -26,10 +26,10 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
   const { membership: poolMembership } = usePoolMemberships();
 
   // is the user actively on the setup page
-  const [onNominatorSetup, setOnNominatorSetup] = useState(0);
+  const [onNominatorSetup, setOnNominatorSetup] = useState<boolean>(false);
 
   // is the user actively on the pool creation page
-  const [onPoolSetup, setOnPoolSetup] = useState(0);
+  const [onPoolSetup, setOnPoolSetup] = useState<boolean>(false);
 
   // staking setup persist
   const [setup, setSetup]: any = useState([]);
@@ -38,10 +38,10 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
   // move away from setup pages on completion / network change
   useEffect(() => {
     if (!inSetup()) {
-      setOnNominatorSetup(0);
+      setOnNominatorSetup(false);
     }
     if (poolMembership) {
-      setOnPoolSetup(0);
+      setOnPoolSetup(false);
     }
   }, [inSetup(), network, poolMembership]);
 
@@ -135,7 +135,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   /*
-   * Sets stake setup progress for an address.
+   * Sets stak∑e setup progress for an address.
    * Updates localStorage followed by app state.
    */
   const setActiveAccountSetup = (type: SetupType, progress: AnyJson) => {

--- a/src/contexts/Setup/types.ts
+++ b/src/contexts/Setup/types.ts
@@ -27,8 +27,8 @@ export interface SetupContextInterface {
   getPoolSetupProgressPercent: (a: MaybeAccount) => number;
   setActiveAccountSetup: (t: SetupType, p: any) => void;
   setActiveAccountSetupSection: (t: SetupType, s: number) => void;
-  setOnNominatorSetup: (v: number) => void;
-  setOnPoolSetup: (v: number) => void;
-  onNominatorSetup: number;
-  onPoolSetup: number;
+  setOnNominatorSetup: (v: boolean) => void;
+  setOnPoolSetup: (v: boolean) => void;
+  onNominatorSetup: boolean;
+  onPoolSetup: boolean;
 }

--- a/src/library/Hooks/usePoolFilters/index.tsx
+++ b/src/library/Hooks/usePoolFilters/index.tsx
@@ -68,7 +68,7 @@ export const usePoolFilters = () => {
    * Returns the updated filtered list.
    */
   const includeLocked = (list: any) => {
-    return list.filter((p: BondedPool) => p.state.toLowerCase() === 'blocked');
+    return list.filter((p: BondedPool) => p.state.toLowerCase() === 'Blocked');
   };
 
   /*
@@ -77,9 +77,7 @@ export const usePoolFilters = () => {
    * Returns the updated filtered list.
    */
   const includeDestroying = (list: any) => {
-    return list.filter(
-      (p: BondedPool) => p.state.toLowerCase() === 'destroying'
-    );
+    return list.filter((p: BondedPool) => p.state === 'Destroying');
   };
 
   /*
@@ -88,7 +86,7 @@ export const usePoolFilters = () => {
    * Returns the updated filtered list.
    */
   const excludeLocked = (list: any) => {
-    return list.filter((p: BondedPool) => p.state.toLowerCase() !== 'blocked');
+    return list.filter((p: BondedPool) => p.state !== 'Blocked');
   };
 
   /*
@@ -97,9 +95,7 @@ export const usePoolFilters = () => {
    * Returns the updated filtered list.
    */
   const excludeDestroying = (list: any) => {
-    return list.filter(
-      (p: BondedPool) => p.state.toLowerCase() !== 'destroying'
-    );
+    return list.filter((p: BondedPool) => p.state !== 'Destroying');
   };
 
   // includes to be listed in filter overlay.

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -141,7 +141,7 @@ export const Pool = (props: PoolProps) => {
         <div className="row status">
           <PoolBonded pool={pool} batchIndex={batchIndex} batchKey={batchKey} />
           {!poolsSyncing &&
-            state === 'open' &&
+            state === 'Open' &&
             !membership &&
             !isReadOnlyAccount(activeAccount) &&
             activeAccount && (

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -175,6 +175,8 @@ export const PoolListInner = ({
     setSearchTerm('pools', newValue);
   };
 
+  console.log(excludes);
+
   const filterTabsConfig = [
     {
       label: t('active'),

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -175,8 +175,6 @@ export const PoolListInner = ({
     setSearchTerm('pools', newValue);
   };
 
-  console.log(excludes);
-
   const filterTabsConfig = [
     {
       label: t('active'),

--- a/src/library/SideMenu/Main.tsx
+++ b/src/library/SideMenu/Main.tsx
@@ -30,6 +30,8 @@ export const Main = () => {
   const { membership } = usePoolMemberships();
   const controller = getBondedAccount(activeAccount);
   const {
+    onNominatorSetup,
+    onPoolSetup,
     getPoolSetupProgressPercent,
     getStakeSetupProgressPercent,
   }: SetupContextInterface = useSetup();
@@ -65,12 +67,14 @@ export const Main = () => {
             status: 'success',
             text: t('active'),
           };
-        } else if (warning) {
+        }
+        if (warning) {
           _pages[i].action = {
             type: 'bullet',
             status: 'warning',
           };
-        } else if (setupPercent > 0 && !staking) {
+        }
+        if (!staking && (onNominatorSetup || setupPercent > 0)) {
           _pages[i].action = {
             type: 'text',
             status: 'warning',
@@ -90,7 +94,8 @@ export const Main = () => {
             status: 'success',
             text: t('active'),
           };
-        } else if (setupPercent > 0 && !inPool) {
+        }
+        if (!inPool && (setupPercent > 0 || onPoolSetup)) {
           _pages[i].action = {
             type: 'text',
             status: 'warning',
@@ -114,6 +119,8 @@ export const Main = () => {
     getStakeSetupProgressPercent(activeAccount),
     getPoolSetupProgressPercent(activeAccount),
     i18n.resolvedLanguage,
+    onNominatorSetup,
+    onPoolSetup,
   ]);
 
   // remove pages that network does not support

--- a/src/library/SideMenu/Primary/index.tsx
+++ b/src/library/SideMenu/Primary/index.tsx
@@ -11,11 +11,16 @@ import { Link } from 'react-router-dom';
 import { PrimaryProps } from '../types';
 import { MinimisedWrapper, Wrapper } from './Wrappers';
 
-export const Primary = (props: PrimaryProps) => {
+export const Primary = ({
+  name,
+  active,
+  to,
+  icon,
+  action,
+  minimised,
+  animate,
+}: PrimaryProps) => {
   const { setSideMenu } = useUi();
-
-  const { name, active, to, icon, action, minimised } = props;
-
   const StyledWrapper = minimised ? MinimisedWrapper : Wrapper;
 
   let Action = null;
@@ -40,9 +45,6 @@ export const Primary = (props: PrimaryProps) => {
       Action = null;
   }
 
-  // animate icon config
-
-  const { animate } = props;
   const [isStopped, setIsStopped] = useState(true);
 
   const animateOptions = {

--- a/src/modals/ManagePool/Forms.tsx
+++ b/src/modals/ManagePool/Forms.tsx
@@ -100,11 +100,11 @@ export const Forms = forwardRef((props: any, ref: any) => {
   const poolStateFromTask = (s: string) => {
     switch (s) {
       case 'destroy_pool':
-        return 'destroying';
+        return 'Destroying';
       case 'lock_pool':
-        return 'blocked';
+        return 'Blocked';
       default:
-        return 'open';
+        return 'Open';
     }
   };
 
@@ -122,13 +122,13 @@ export const Forms = forwardRef((props: any, ref: any) => {
         tx = api.tx.nominationPools.setMetadata(poolId, metadata);
         break;
       case 'destroy_pool':
-        tx = api.tx.nominationPools.setState(poolId, 'destroying');
+        tx = api.tx.nominationPools.setState(poolId, 'Destroying');
         break;
       case 'unlock_pool':
-        tx = api.tx.nominationPools.setState(poolId, 'open');
+        tx = api.tx.nominationPools.setState(poolId, 'Open');
         break;
       case 'lock_pool':
-        tx = api.tx.nominationPools.setState(poolId, 'blocked');
+        tx = api.tx.nominationPools.setState(poolId, 'Blocked');
         break;
       default:
         tx = null;

--- a/src/modals/ManagePool/Tasks.tsx
+++ b/src/modals/ManagePool/Tasks.tsx
@@ -14,8 +14,8 @@ export const Tasks = forwardRef((props: any, ref: any) => {
   const { t } = useTranslation('modals');
 
   const { selectedActivePool, isOwner, isStateToggler } = useActivePools();
-  const poolLocked = selectedActivePool?.bondedPool?.state === 'blocked';
-  const poolDestroying = selectedActivePool?.bondedPool?.state === 'destroying';
+  const poolLocked = selectedActivePool?.bondedPool?.state === 'Blocked';
+  const poolDestroying = selectedActivePool?.bondedPool?.state === 'Destroying';
 
   return (
     <ContentWrapper>

--- a/src/modals/StartStaking/index.tsx
+++ b/src/modals/StartStaking/index.tsx
@@ -1,0 +1,49 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { faChevronRight, faCog } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Title } from 'library/Modal/Title';
+import { PaddingWrapper } from 'modals/Wrappers';
+
+export const StartStaking = () => {
+  return (
+    <>
+      <Title title="Start Staking" icon={faCog} />
+      <PaddingWrapper>
+        <button
+          type="button"
+          className="action-button"
+          disabled={false}
+          onClick={() => {
+            /* navigate */
+          }}
+        >
+          <div>
+            <h3>Directly Nominate</h3>
+            <p>Have full control over your nominations.</p>
+          </div>
+          <div>
+            <FontAwesomeIcon transform="shrink-2" icon={faChevronRight} />
+          </div>
+        </button>
+        <button
+          type="button"
+          className="action-button"
+          disabled={false}
+          onClick={() => {
+            /* navigate */
+          }}
+        >
+          <div>
+            <h3>Join a Nomination Pool</h3>
+            <p>Easy staking with competitive rewards.</p>
+          </div>
+          <div>
+            <FontAwesomeIcon transform="shrink-2" icon={faChevronRight} />
+          </div>
+        </button>
+      </PaddingWrapper>
+    </>
+  );
+};

--- a/src/modals/StartStaking/index.tsx
+++ b/src/modals/StartStaking/index.tsx
@@ -42,7 +42,7 @@ export const StartStaking = () => {
           className="action-button"
           disabled={false}
           onClick={() => {
-            navigate('/pools'); // TODO: support tab switching
+            navigate('/pools?t=2');
             setStatus(2);
           }}
         >

--- a/src/modals/StartStaking/index.tsx
+++ b/src/modals/StartStaking/index.tsx
@@ -8,6 +8,7 @@ import { useSetup } from 'contexts/Setup';
 import { Title } from 'library/Modal/Title';
 import { PaddingWrapper } from 'modals/Wrappers';
 import { useNavigate } from 'react-router-dom';
+import { varToUrlHash } from 'Utils';
 
 export const StartStaking = () => {
   const navigate = useNavigate();
@@ -23,12 +24,13 @@ export const StartStaking = () => {
           disabled={false}
           onClick={() => {
             setOnNominatorSetup(true);
+            varToUrlHash('t', String(3), true);
             navigate('/nominate');
             setStatus(2);
           }}
         >
           <div>
-            <h3>Directly Nominate</h3>
+            <h3>Become a Nominator</h3>
             <p>Have full control over your nominations.</p>
           </div>
           <div>

--- a/src/modals/StartStaking/index.tsx
+++ b/src/modals/StartStaking/index.tsx
@@ -3,10 +3,16 @@
 
 import { faChevronRight, faCog } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useModal } from 'contexts/Modal';
+import { useSetup } from 'contexts/Setup';
 import { Title } from 'library/Modal/Title';
 import { PaddingWrapper } from 'modals/Wrappers';
+import { useNavigate } from 'react-router-dom';
 
 export const StartStaking = () => {
+  const navigate = useNavigate();
+  const { setOnNominatorSetup } = useSetup();
+  const { setStatus } = useModal();
   return (
     <>
       <Title title="Start Staking" icon={faCog} />
@@ -16,7 +22,9 @@ export const StartStaking = () => {
           className="action-button"
           disabled={false}
           onClick={() => {
-            /* navigate */
+            setOnNominatorSetup(true);
+            navigate('/nominate');
+            setStatus(2);
           }}
         >
           <div>
@@ -32,7 +40,8 @@ export const StartStaking = () => {
           className="action-button"
           disabled={false}
           onClick={() => {
-            /* navigate */
+            navigate('/pools'); // TODO: support tab switching
+            setStatus(2);
           }}
         >
           <div>

--- a/src/modals/StartStaking/index.tsx
+++ b/src/modals/StartStaking/index.tsx
@@ -31,7 +31,7 @@ export const StartStaking = () => {
         >
           <div>
             <h3>Become a Nominator</h3>
-            <p>Have full control over your nominations.</p>
+            <p>Have full control over who you nominate.</p>
           </div>
           <div>
             <FontAwesomeIcon transform="shrink-2" icon={faChevronRight} />

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -26,6 +26,7 @@ import { NominatePool } from './NominatePool';
 import { PoolNominations } from './PoolNominations';
 import { SelectFavorites } from './SelectFavorites';
 import { Settings } from './Settings';
+import { StartStaking } from './StartStaking';
 import { Unbond } from './Unbond';
 import { UnbondPoolMember } from './UnbondPoolMember';
 import { UnlockChunks } from './UnlockChunks';
@@ -130,6 +131,7 @@ export const Modal = () => {
               {modal === 'PoolNominations' && <PoolNominations />}
               {modal === 'SelectFavorites' && <SelectFavorites />}
               {modal === 'Settings' && <Settings />}
+              {modal === 'StartStaking' && <StartStaking />}
               {modal === 'ValidatorMetrics' && <ValidatorMetrics />}
               {modal === 'UnbondPoolMember' && <UnbondPoolMember />}
               {modal === 'UnlockChunks' && <UnlockChunks />}

--- a/src/pages/Nominate/Active/Nominations/index.tsx
+++ b/src/pages/Nominate/Active/Nominations/index.tsx
@@ -87,7 +87,7 @@ export const Nominations = ({
   // determine whether buttons are disabled
   const poolDestroying =
     isPool &&
-    selectedActivePool?.bondedPool?.state === 'destroying' &&
+    selectedActivePool?.bondedPool?.state === 'Destroying' &&
     !nominating;
 
   const stopBtnDisabled =

--- a/src/pages/Nominate/Active/Status.tsx
+++ b/src/pages/Nominate/Active/Status.tsx
@@ -118,7 +118,7 @@ export const Status = ({ height }: { height: number }) => {
                     !isReady ||
                     isReadOnlyAccount(activeAccount) ||
                     !activeAccount,
-                  onClick: () => setOnNominatorSetup(1),
+                  onClick: () => setOnNominatorSetup(true),
                 },
               ]
         }

--- a/src/pages/Nominate/Setup/index.tsx
+++ b/src/pages/Nominate/Setup/index.tsx
@@ -31,7 +31,7 @@ export const Setup = () => {
               text={t('nominate.back')}
               iconLeft={faChevronLeft}
               iconTransform="shrink-3"
-              onClick={() => setOnNominatorSetup(0)}
+              onClick={() => setOnNominatorSetup(false)}
             />
           </span>
           <span>
@@ -39,7 +39,7 @@ export const Setup = () => {
               lg
               text={t('nominate.cancel')}
               onClick={() => {
-                setOnNominatorSetup(0);
+                setOnNominatorSetup(false);
                 setActiveAccountSetup('stake', defaultStakeSetup);
               }}
             />

--- a/src/pages/Overview/StakeStatus/Item.tsx
+++ b/src/pages/Overview/StakeStatus/Item.tsx
@@ -5,17 +5,30 @@ import { faChevronRight, faCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ButtonInvertRounded } from '@rossbulat/polkadot-dashboard-ui';
 import { useTheme } from 'contexts/Themes';
+import { useLayoutEffect, useRef } from 'react';
 import { defaultThemes } from 'theme/default';
 import { ItemProps } from './types';
 import { StatusRowWrapper } from './Wrappers';
 
 export const Item = ({ text, ctaText, onClick, leftIcon }: ItemProps) => {
   const { mode } = useTheme();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const subjectRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (containerRef.current && subjectRef.current) {
+      containerRef.current.style.paddingRight = `${
+        subjectRef.current.offsetWidth + 7
+      }px`;
+    }
+  }, [containerRef, subjectRef]);
+
   return (
     <StatusRowWrapper leftIcon={leftIcon?.show}>
       <div>
         <div className="content">
-          <div className="text">
+          <div className="text" ref={containerRef}>
             {leftIcon ? (
               leftIcon.show ? (
                 <FontAwesomeIcon
@@ -35,7 +48,7 @@ export const Item = ({ text, ctaText, onClick, leftIcon }: ItemProps) => {
               ) : null
             ) : null}
             {text}
-            <span className="cta">
+            <span className="cta" ref={subjectRef}>
               {ctaText ? (
                 <ButtonInvertRounded
                   text={ctaText}

--- a/src/pages/Overview/StakeStatus/Item.tsx
+++ b/src/pages/Overview/StakeStatus/Item.tsx
@@ -8,6 +8,7 @@ import { useTheme } from 'contexts/Themes';
 import { useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { defaultThemes } from 'theme/default';
+import { remToUnit } from 'Utils';
 import { ItemProps } from './types';
 import { StatusRowWrapper } from './Wrappers';
 
@@ -20,7 +21,7 @@ export const Item = ({ text, ctaText, onClick, leftIcon }: ItemProps) => {
   useLayoutEffect(() => {
     if (containerRef.current && subjectRef.current) {
       containerRef.current.style.paddingRight = `${
-        subjectRef.current.offsetWidth + 7
+        subjectRef.current.offsetWidth + remToUnit('1rem')
       }px`;
     }
   }, [containerRef, subjectRef, i18n.resolvedLanguage]);

--- a/src/pages/Overview/StakeStatus/Item.tsx
+++ b/src/pages/Overview/StakeStatus/Item.tsx
@@ -6,13 +6,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ButtonInvertRounded } from '@rossbulat/polkadot-dashboard-ui';
 import { useTheme } from 'contexts/Themes';
 import { useLayoutEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { defaultThemes } from 'theme/default';
 import { ItemProps } from './types';
 import { StatusRowWrapper } from './Wrappers';
 
 export const Item = ({ text, ctaText, onClick, leftIcon }: ItemProps) => {
   const { mode } = useTheme();
-
+  const { i18n } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const subjectRef = useRef<HTMLDivElement>(null);
 
@@ -22,7 +23,7 @@ export const Item = ({ text, ctaText, onClick, leftIcon }: ItemProps) => {
         subjectRef.current.offsetWidth + 7
       }px`;
     }
-  }, [containerRef, subjectRef]);
+  }, [containerRef, subjectRef, i18n.resolvedLanguage]);
 
   return (
     <StatusRowWrapper leftIcon={leftIcon?.show}>

--- a/src/pages/Overview/StakeStatus/Wrappers.tsx
+++ b/src/pages/Overview/StakeStatus/Wrappers.tsx
@@ -68,7 +68,7 @@ export const StatusRowWrapper = styled.div<{ leftIcon?: boolean }>`
       height: 2rem;
       max-width: 100%;
       padding: ${(props) =>
-        props.leftIcon ? '0.15rem 8.5rem 0 1.85rem' : '0.15rem 8.5rem 0 0'};
+        props.leftIcon ? '0.15rem 0 0 1.85rem' : '0.15rem 0 0 0'};
       text-align: left;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/pages/Overview/StakeStatus/index.tsx
+++ b/src/pages/Overview/StakeStatus/index.tsx
@@ -139,6 +139,10 @@ export const StakeStatus = () => {
                       <Item
                         leftIcon={{ show: true, status: 'off' }}
                         text={t('overview.notStaking')}
+                        ctaText="Start"
+                        onClick={() =>
+                          openModalWith('StartStaking', {}, 'small')
+                        }
                       />
                     ) : (
                       <>

--- a/src/pages/Pools/Create/index.tsx
+++ b/src/pages/Pools/Create/index.tsx
@@ -31,7 +31,7 @@ export const Create = () => {
               text={t('pools.back')}
               iconLeft={faChevronLeft}
               iconTransform="shrink-3"
-              onClick={() => setOnPoolSetup(0)}
+              onClick={() => setOnPoolSetup(false)}
             />
           </span>
           <span>
@@ -39,7 +39,7 @@ export const Create = () => {
               lg
               text={t('pools.cancel')}
               onClick={() => {
-                setOnPoolSetup(0);
+                setOnPoolSetup(false);
                 setActiveAccountSetup('pool', defaultPoolSetup);
               }}
             />

--- a/src/pages/Pools/Create/index.tsx
+++ b/src/pages/Pools/Create/index.tsx
@@ -17,8 +17,8 @@ import { PoolRoles } from './PoolRoles';
 import { Summary } from './Summary';
 
 export const Create = () => {
-  const { setOnPoolSetup, setActiveAccountSetup } = useSetup();
   const { t } = useTranslation('pages');
+  const { setOnPoolSetup, setActiveAccountSetup } = useSetup();
 
   return (
     <>

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -38,7 +38,7 @@ export const ClosurePrompts = () => {
   const depositorCanClose =
     !poolsSyncing &&
     isDepositor() &&
-    state === 'destroying' &&
+    state === 'Destroying' &&
     memberCounter === '1';
 
   // depositor needs to unbond funds

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -49,7 +49,7 @@ export const ManageBond = () => {
               poolsSyncing ||
               !isBonding() ||
               !isMember() ||
-              state === 'destroying'
+              state === 'Destroying'
             }
             marginRight
             onClick={() => openModalWith('Bond', { bondFor: 'pool' }, 'small')}
@@ -60,7 +60,7 @@ export const ManageBond = () => {
               poolsSyncing ||
               !isBonding() ||
               !isMember() ||
-              state === 'destroying'
+              state === 'Destroying'
             }
             marginRight
             onClick={() =>
@@ -69,7 +69,7 @@ export const ManageBond = () => {
             text="-"
           />
           <ButtonPrimary
-            disabled={poolsSyncing || !isMember() || state === 'destroying'}
+            disabled={poolsSyncing || !isMember() || state === 'Destroying'}
             iconLeft={faLockOpen}
             onClick={() =>
               openModalWith('UnlockChunks', { bondFor: 'pool' }, 'small')

--- a/src/pages/Pools/Home/ManagePool/index.tsx
+++ b/src/pages/Pools/Home/ManagePool/index.tsx
@@ -39,7 +39,7 @@ export const ManagePool = () => {
       <CardWrapper>
         {isSyncing ? (
           <Nominations bondFor="pool" nominator={activeAccount} />
-        ) : canNominate && !isNominating && state !== 'destroying' ? (
+        ) : canNominate && !isNominating && state !== 'Destroying' ? (
           <>
             <CardHeaderWrapper withAction>
               <h3>

--- a/src/pages/Pools/Home/Members.tsx
+++ b/src/pages/Pools/Home/Members.tsx
@@ -28,7 +28,7 @@ export const Members = () => {
   const annuncementBorderColor = networkColorsSecondary[mode];
 
   const showBlockedPrompt =
-    selectedActivePool?.bondedPool?.state === 'blocked' &&
+    selectedActivePool?.bondedPool?.state === 'Blocked' &&
     (isOwner() || isStateToggler());
 
   return (
@@ -52,7 +52,7 @@ export const Members = () => {
       )}
 
       {/* Pool in Destroying state: allow anyone to unbond & withdraw members */}
-      {selectedActivePool?.bondedPool?.state === 'destroying' && (
+      {selectedActivePool?.bondedPool?.state === 'Destroying' && (
         <PageRowWrapper className="page-padding" noVerticalSpacer>
           <CardWrapper
             style={{ border: `1px solid ${annuncementBorderColor}` }}

--- a/src/pages/Pools/Home/MembersList/Member.tsx
+++ b/src/pages/Pools/Home/MembersList/Member.tsx
@@ -41,11 +41,11 @@ export const Member = (props: any) => {
   const { who, batchKey, batchIndex } = props;
 
   const canUnbondBlocked =
-    state === 'blocked' &&
+    state === 'Blocked' &&
     (isOwner() || isStateToggler()) &&
     ![root, stateToggler].includes(who);
 
-  const canUnbondDestroying = state === 'destroying' && who !== depositor;
+  const canUnbondDestroying = state === 'Destroying' && who !== depositor;
 
   const poolMembers = meta[batchKey]?.poolMembers ?? [];
   const member = poolMembers[batchIndex] ?? null;

--- a/src/pages/Pools/Home/PoolStats/Header.tsx
+++ b/src/pages/Pools/Home/PoolStats/Header.tsx
@@ -35,10 +35,10 @@ export const Header = () => {
 
   let stateDisplay;
   switch (state) {
-    case 'blocked':
+    case 'Blocked':
       stateDisplay = t('pools.locked');
       break;
-    case 'destroying':
+    case 'Destroying':
       stateDisplay = t('pools.destroying');
       break;
     default:

--- a/src/pages/Pools/Home/Status/index.tsx
+++ b/src/pages/Pools/Home/Status/index.tsx
@@ -69,7 +69,7 @@ export const Status = ({ height }: { height: number }) => {
           disabled:
             !isReady ||
             isReadOnlyAccount(activeAccount) ||
-            poolState === 'destroying',
+            poolState === 'Destroying',
           small: true,
           onClick: () =>
             openModalWith('ClaimReward', { claimType: 'bond' }, 'small'),
@@ -79,10 +79,10 @@ export const Status = ({ height }: { height: number }) => {
 
   let poolStateIcon;
   switch (poolState) {
-    case 'blocked':
+    case 'Blocked':
       poolStateIcon = faLock;
       break;
-    case 'destroying':
+    case 'Destroying':
       poolStateIcon = faExclamationTriangle;
       break;
     default:
@@ -91,9 +91,9 @@ export const Status = ({ height }: { height: number }) => {
 
   // determine pool status - left side
   const poolStatusLeft =
-    poolState === 'blocked'
+    poolState === 'Blocked'
       ? `${t('pools.locked')} / `
-      : poolState === 'destroying'
+      : poolState === 'Destroying'
       ? `${t('pools.destroying')} / `
       : '';
 

--- a/src/pages/Pools/Home/Status/useStatusButtons.tsx
+++ b/src/pages/Pools/Home/Status/useStatusButtons.tsx
@@ -43,7 +43,7 @@ export const useStatusButtons = () => {
       !activeAccount ||
       stats.maxPools.toNumber() === 0 ||
       bondedPools.length === stats.maxPools.toNumber(),
-    onClick: () => setOnPoolSetup(1),
+    onClick: () => setOnPoolSetup(true),
   };
 
   const joinPoolBtn = {

--- a/src/pages/Pools/Home/Status/useStatusButtons.tsx
+++ b/src/pages/Pools/Home/Status/useStatusButtons.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { usePoolsTabs } from '../context';
 
 export const useStatusButtons = () => {
+  const { t } = useTranslation('pages');
   const { isReady } = useApi();
   const { setOnPoolSetup, getPoolSetupProgressPercent } = useSetup();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -23,7 +24,6 @@ export const useStatusButtons = () => {
   const { bondedPools } = useBondedPools();
   const { isOwner } = useActivePools();
   const { getTransferOptions } = useTransferOptions();
-  const { t } = useTranslation('pages');
 
   const { active } = getTransferOptions(activeAccount).pool;
   const poolSetupPercent = getPoolSetupProgressPercent(activeAccount);

--- a/src/pages/Pools/Home/context.tsx
+++ b/src/pages/Pools/Home/context.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
+import { extractUrlValue } from 'Utils';
 import { PoolsTabsContextInterface } from '../types';
 
 export const PoolsTabsContext: React.Context<PoolsTabsContextInterface> =
@@ -18,7 +19,12 @@ export const PoolsTabsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [activeTab, _setActiveTab] = useState<number>(0);
+  const tabFromUrl = extractUrlValue('t');
+  const initialActiveTab = [0, 1, 2, 3].includes(Number(tabFromUrl))
+    ? Number(tabFromUrl)
+    : 0;
+
+  const [activeTab, _setActiveTab] = useState<number>(initialActiveTab);
 
   const setActiveTab = (t: number) => {
     _setActiveTab(t);

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -32,12 +32,12 @@ import PoolMembershipBox from './Stats/PoolMembership';
 import { Status } from './Status';
 
 export const HomeInner = () => {
+  const { t } = useTranslation('pages');
   const { activeAccount } = useConnect();
   const { bondedPools, getAccountPools } = useBondedPools();
   const { getPoolRoles, selectedActivePool } = useActivePools();
   const { activeTab, setActiveTab } = usePoolsTabs();
   const { openModalWith } = useModal();
-  const { t } = useTranslation('pages');
 
   const accountPools = getAccountPools(activeAccount);
   const totalAccountPools = Object.entries(accountPools).length;


### PR DESCRIPTION
This PR adds new functionality to the dashboard and expands CTA support.

- [x] Uses `useLayoutEffect` to dynamically adjust a container's `paddingRight` property, based on a button width, to make room for the button. Useful in absolute positioning / ellipsis text cutting container combos.
- [x] Introduces a `t` URL variable to automatically switch to a pool tab on the page visit.
- [x] Adds a Start Staking CTA on overview and introduces a modal that provides quick links to the nominator setup screen / all pools tab.
- [x] Fixes an issue with `PoolState`. 