### PR TITLE
Correct the epoch help definition

### DIFF
--- a/src/locale/cn/help.json
+++ b/src/locale/cn/help.json
@@ -84,7 +84,7 @@
       "epoch": [
         "Epoch",
         [
-          "Epoch是{NETWORK_NAME} Session的另一个名称. 在每个Epoch开始时选择一组不同的验证人验证区块.",
+          "Epoch是{NETWORK_NAME} Session的另一个名称. 每个Era分为6个Epoch, 在此期间, 验证人被指定为特定时段或Slots的区块生产者.",
           "1个Epoch在波卡为4小时."
         ]
       ],

--- a/src/locale/en/help.json
+++ b/src/locale/en/help.json
@@ -86,7 +86,7 @@
       "epoch": [
         "Epoch",
         [
-          "An epoch is another name for a session in {NETWORK_NAME}. A different set of validators are selected to validate blocks at the beginning of every epoch.",
+          "An epoch is another name for a session in {NETWORK_NAME}. Each era is divided into 6 epochs during which validators are assigned as block producers to specific time frames or slots.",
           "1 epoch is currently 4 hours in Polkadot."
         ]
       ],


### PR DESCRIPTION
The epoch definition is not correct and conflicts with the era definition, which is confusing. 

Source: https://wiki.polkadot.network/docs/learn-staking#eras-and-sessions