### PR TITLE
Revert Connectivity to Substrate Connect Extension

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -218,7 +218,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     switch (lc) {
       case true:
         newProvider = new ScProvider(Sc, endpoints.lightClient);
-        await newProvider.connect({ forceEmbeddedNode: true });
+        await newProvider.connect();
         break;
       default:
         newProvider = new WsProvider(endpoints.rpc);


### PR DESCRIPTION
I am not sure why the app was forced to avoid using Substrate Connect Extension, but it seems to me (and have tested it) that the experience (now that extension contains Smoldot v1.0) is identical to RPC  (no hanging connections or non-returned results anymore). 

Would prefer to merge after #774 

Screenshot below shows PSD connected to light client and how all info (especially stats at the bottom of the screen exist):

![image](https://user-images.githubusercontent.com/5408605/226280009-63ec7d36-0690-4362-9014-d70a2d0235b5.png)
