### PR TITLE
Bump substrate connect to 0.7.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@polkadot/rpc-provider": "^10.1.4",
     "@polkadot/util": "^11.0.1",
     "@polkadotcloud/dashboard-ui": "0.2.0",
-    "@substrate/connect": "^0.7.21",
+    "@substrate/connect": "^0.7.22",
     "@types/lodash.throttle": "^4.1.7",
     "bignumber.js": "^9.1.1",
     "bn.js": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,10 +987,19 @@
   resolved "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.1.tgz#fa5738039586c648013caa6a0c95c43265dbe77d"
   integrity sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg==
 
-"@substrate/connect@0.7.21", "@substrate/connect@^0.7.21":
+"@substrate/connect@0.7.21":
   version "0.7.21"
   resolved "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.21.tgz#26bba45380d1b6df42a3bdd3843afc99126810ec"
   integrity sha512-mn0SeWpNwvEY+hEoLunIg854cku1wMy6mgktxUGsdEH7m8u86LQ1hXwFC6gHbaRhG0KGMCblzY4askN4yf057w==
+  dependencies:
+    "@substrate/connect-extension-protocol" "^1.0.1"
+    eventemitter3 "^4.0.7"
+    smoldot "1.0.0"
+
+"@substrate/connect@^0.7.22":
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.22.tgz#15a20d734bab082c87f2aaaf75ce012c83881ef7"
+  integrity sha512-g12IYiepPu0OFWcm87ugDbfPr5a9TCGd4HJv1zXB2TRP/ZvYtHCE9+ftA5IvJbJPw6CI6/0XmUbP7Nz19HT/aw==
   dependencies:
     "@substrate/connect-extension-protocol" "^1.0.1"
     eventemitter3 "^4.0.7"


### PR DESCRIPTION
Contains the [fix](https://github.com/paritytech/substrate-connect/pull/1400) that was breaking the build of Vite ("veet");