### PR TITLE
Pre release UX Fixes

### DIFF
--- a/src/contexts/Subscan/defaults.ts
+++ b/src/contexts/Subscan/defaults.ts
@@ -9,4 +9,6 @@ export const defaultSubscanContext: SubscanContextInterface = {
   payouts: [],
   poolClaims: [],
   unclaimedPayouts: [],
+  payoutsFromDate: undefined,
+  payoutsToDate: undefined,
 };

--- a/src/contexts/Subscan/index.tsx
+++ b/src/contexts/Subscan/index.tsx
@@ -4,8 +4,12 @@
 import { isNotZero } from 'Utils';
 import { ApiEndpoints, ApiSubscanKey } from 'consts';
 import { useNetworkMetrics } from 'contexts/Network';
+import { format, fromUnixTime } from 'date-fns';
+import { sortNonZeroPayouts } from 'library/Graphs/Utils';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
+import { locales } from 'locale';
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { AnyApi, AnySubscan } from 'types';
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
@@ -29,6 +33,7 @@ export const SubscanProvider = ({
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
   const { erasToSeconds } = useErasToTimeLeft();
+  const { i18n } = useTranslation();
 
   // store fetched payouts from Subscan
   const [payouts, setPayouts] = useState<AnySubscan>([]);
@@ -38,6 +43,12 @@ export const SubscanProvider = ({
 
   // store fetched unclaimed payouts from Subscan
   const [unclaimedPayouts, setUnclaimedPayouts] = useState<AnyApi>([]);
+
+  // store the start date of fetched payouts and pool claims combined.
+  const [payoutsFromDate, setPayoutsFromDate] = useState<string | undefined>();
+
+  // store the end date of fetched payouts and pool claims combined.
+  const [payoutsToDate, setPayoutsToDate] = useState<string | undefined>();
 
   // handle fetching the various types of payout and set state in one render.
   const handleFetchPayouts = async () => {
@@ -62,24 +73,49 @@ export const SubscanProvider = ({
     setPoolClaims([]);
   };
 
-  // fetch payouts on plugins toggle
+  // Fetch payouts on plugins toggle.
   useEffect(() => {
     if (isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
   }, [plugins, activeEra]);
 
-  // reset payouts on network switch
+  // Reset payouts on network switch.
   useEffect(() => {
     resetPayouts();
   }, [network]);
 
-  // fetch payouts as soon as network is ready
+  // Fetch payouts as soon as network is ready.
   useEffect(() => {
     if (isReady && isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
   }, [isReady, network, activeAccount, activeEra]);
+
+  // Store start and end date of fetched payouts.
+  useEffect(() => {
+    const filteredPayouts = sortNonZeroPayouts(payouts, poolClaims, true);
+    if (filteredPayouts.length) {
+      setPayoutsFromDate(
+        format(
+          fromUnixTime(
+            filteredPayouts[filteredPayouts.length - 1].block_timestamp
+          ),
+          'do MMM',
+          {
+            locale: locales[i18n.resolvedLanguage],
+          }
+        )
+      );
+
+      // latest payout date
+      setPayoutsToDate(
+        format(fromUnixTime(filteredPayouts[0].block_timestamp), 'do MMM', {
+          locale: locales[i18n.resolvedLanguage],
+        })
+      );
+    }
+  }, [payouts, poolClaims, unclaimedPayouts]);
 
   /* fetchPayouts
    * fetches payout history from Subscan.
@@ -246,6 +282,8 @@ export const SubscanProvider = ({
         payouts,
         poolClaims,
         unclaimedPayouts,
+        payoutsFromDate,
+        payoutsToDate,
       }}
     >
       {children}

--- a/src/contexts/Subscan/types.ts
+++ b/src/contexts/Subscan/types.ts
@@ -8,4 +8,6 @@ export interface SubscanContextInterface {
   payouts: AnySubscan;
   poolClaims: AnySubscan;
   unclaimedPayouts: AnySubscan;
+  payoutsFromDate: string | undefined;
+  payoutsToDate: string | undefined;
 }

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -3,6 +3,7 @@
 
 import { greaterThanZero, planckToUnit } from 'Utils';
 import BigNumber from 'bignumber.js';
+import { MaxPayoutDays } from 'consts';
 import {
   addDays,
   differenceInDays,
@@ -14,6 +15,17 @@ import {
 } from 'date-fns';
 import type { AnyApi, AnySubscan } from 'types';
 import type { PayoutDayCursor } from './types';
+
+// Take non-zero rewards in most-recent order.
+export const sortNonZeroPayouts = (
+  payouts: AnySubscan,
+  poolClaims: AnySubscan
+) =>
+  [...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0)]
+    .sort(
+      (a: AnySubscan, b: AnySubscan) => b.block_timestamp - a.block_timestamp
+    )
+    .slice(0, MaxPayoutDays);
 
 // Given payouts, calculate daily income and fill missing days with zero amounts.
 export const calculatePayoutsByDay = (

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -19,13 +19,23 @@ import type { PayoutDayCursor } from './types';
 // Take non-zero rewards in most-recent order.
 export const sortNonZeroPayouts = (
   payouts: AnySubscan,
-  poolClaims: AnySubscan
-) =>
-  [...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0)]
-    .sort(
-      (a: AnySubscan, b: AnySubscan) => b.block_timestamp - a.block_timestamp
-    )
-    .slice(0, MaxPayoutDays);
+  poolClaims: AnySubscan,
+  capMaxDays: boolean
+) => {
+  const list = [
+    ...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0),
+  ].sort(
+    (a: AnySubscan, b: AnySubscan) => b.block_timestamp - a.block_timestamp
+  );
+
+  const fromTimestamp = getUnixTime(subDays(new Date(), MaxPayoutDays));
+
+  if (capMaxDays) {
+    return list.filter((l: AnySubscan) => l.block_timestamp >= fromTimestamp);
+  }
+
+  return list;
+};
 
 // Given payouts, calculate daily income and fill missing days with zero amounts.
 export const calculatePayoutsByDay = (

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -180,6 +180,11 @@ export const PoolListInner = ({
 
   const filterTabsConfig = [
     {
+      label: t('all'),
+      includes: [],
+      excludes: [],
+    },
+    {
       label: t('active'),
       includes: ['active'],
       excludes: ['locked', 'destroying'],
@@ -224,7 +229,7 @@ export const PoolListInner = ({
             placeholder={t('search')}
           />
         )}
-        <Tabs config={filterTabsConfig} activeIndex={0} />
+        <Tabs config={filterTabsConfig} activeIndex={1} />
         {pagination && listPools.length > 0 && (
           <Pagination page={page} total={totalPages} setter={setPage} />
         )}

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -81,7 +81,10 @@ export const PoolListInner = ({
   const pageStart = pageEnd - (ListItemsPerPage - 1);
 
   // render batch
-  const batchEnd = renderIteration * ListItemsPerBatch - 1;
+  const batchEnd = Math.min(
+    renderIteration * ListItemsPerBatch - 1,
+    ListItemsPerPage
+  );
 
   // refetch list when pool list changes
   useEffect(() => {

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -122,7 +122,10 @@ export const ValidatorListInner = ({
   const pageStart = pageEnd - (ListItemsPerPage - 1);
 
   // render batch
-  const batchEnd = renderIteration * ListItemsPerBatch - 1;
+  const batchEnd = Math.min(
+    renderIteration * ListItemsPerBatch - 1,
+    ListItemsPerPage
+  );
 
   // reset list when validator list changes
   useEffect(() => {

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -72,7 +72,10 @@ export const PayoutListInner = ({
   const pageStart = pageEnd - (ListItemsPerPage - 1);
 
   // render batch
-  const batchEnd = renderIteration * ListItemsPerBatch - 1;
+  const batchEnd = Math.min(
+    renderIteration * ListItemsPerBatch - 1,
+    ListItemsPerPage
+  );
 
   // refetch list when list changes
   useEffect(() => {

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -13,7 +13,7 @@ import { useUi } from 'contexts/UI';
 import { format, fromUnixTime } from 'date-fns';
 import { PayoutBar } from 'library/Graphs/PayoutBar';
 import { PayoutLine } from 'library/Graphs/PayoutLine';
-import { formatSize } from 'library/Graphs/Utils';
+import { formatSize, sortNonZeroPayouts } from 'library/Graphs/Utils';
 import {
   CardHeaderWrapper,
   CardWrapper,
@@ -53,13 +53,7 @@ export const Payouts = ({ page }: PageProps) => {
 
   useEffect(() => {
     // take non-zero rewards in most-recent order
-    let pList: AnySubscan = [
-      ...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0),
-    ]
-      .sort(
-        (a: AnySubscan, b: AnySubscan) => b.block_timestamp - a.block_timestamp
-      )
-      .slice(0, MaxPayoutDays);
+    let pList: AnySubscan = sortNonZeroPayouts(payouts, poolClaims);
 
     // re-order rewards based on block timestamp
     pList = pList.sort((a: AnySubscan, b: AnySubscan) => {

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -3,7 +3,6 @@
 
 import { ButtonHelp } from '@polkadotcloud/dashboard-ui';
 import { PageRowWrapper } from 'Wrappers';
-import BigNumber from 'bignumber.js';
 import { MaxPayoutDays } from 'consts';
 import { useHelp } from 'contexts/Help';
 import { usePlugins } from 'contexts/Plugins';
@@ -52,16 +51,8 @@ export const Payouts = ({ page }: PageProps) => {
   const { width, height, minHeight } = formatSize(size, 300);
 
   useEffect(() => {
-    // take non-zero rewards in most-recent order
-    let pList: AnySubscan = sortNonZeroPayouts(payouts, poolClaims);
-
-    // re-order rewards based on block timestamp
-    pList = pList.sort((a: AnySubscan, b: AnySubscan) => {
-      const x = new BigNumber(a.block_timestamp);
-      const y = new BigNumber(b.block_timestamp);
-      return y.minus(x);
-    });
-    setPayoutLists(pList);
+    // filter zero rewards and order via block timestamp, most recent first.
+    setPayoutLists(sortNonZeroPayouts(payouts, poolClaims));
   }, [payouts, poolClaims]);
 
   useEffect(() => {

--- a/src/pages/Pools/Home/MembersList/index.tsx
+++ b/src/pages/Pools/Home/MembersList/index.tsx
@@ -76,7 +76,10 @@ export const MembersListInner = ({
   const pageStart = pageEnd - (ListItemsPerPage - 1);
 
   // render batch
-  const batchEnd = renderIteration * ListItemsPerBatch - 1;
+  const batchEnd = Math.min(
+    renderIteration * ListItemsPerBatch - 1,
+    ListItemsPerPage
+  );
 
   // refetch list when list changes
   useEffect(() => {


### PR DESCRIPTION
Fixes pertaining to the 1.0.6 release of the dashboard.

- [x] Added All pools tab option to view inactive pools.
- [x] Fixed an issue where more list items were being displayed than intended.
- [x] Fixed an issue where payouts were not being capped early enough for larger lists of payouts.
- [x] The Payouts graph title on the Payouts page is now persisted, and does not reinitialise on every page visit.
