### PR TITLE
Fix Invalid Payee Account

### DIFF
--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { isValidAddress } from 'Utils';
 import { useBalances } from 'contexts/Accounts/Balances';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
@@ -45,7 +46,12 @@ export const UpdatePayee = () => {
 
   // update setup progress with payee config.
   const handleChangeDestination = (destination: PayeeOptions) => {
-    setSelected({ destination, account });
+    const val = {
+      destination,
+      account: isValidAddress(account || '') ? account : null,
+    };
+
+    setSelected(val);
   };
 
   // update setup progress with payee account.
@@ -108,9 +114,6 @@ export const UpdatePayee = () => {
         : DefaultSelected
     );
   }, []);
-
-  // Ensure selected item is valid on change.
-  useEffect(() => {}, [selected]);
 
   return (
     <>

--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -46,12 +46,10 @@ export const UpdatePayee = () => {
 
   // update setup progress with payee config.
   const handleChangeDestination = (destination: PayeeOptions) => {
-    const val = {
+    setSelected({
       destination,
       account: isValidAddress(account || '') ? account : null,
-    };
-
-    setSelected(val);
+    });
   };
 
   // update setup progress with payee account.


### PR DESCRIPTION
Fixes an issue that caused an error in `UpdatePayee` when an invalid address was input into `PayeeInput` and the user toggled between options and landed back on the account option.