### PR TITLE
Ledger pre-release fixes 2

### DIFF
--- a/src/contexts/Hardware/Ledger.tsx
+++ b/src/contexts/Hardware/Ledger.tsx
@@ -109,7 +109,7 @@ export const LedgerHardwareProvider = ({
       err.startsWith('Error: InvalidStateError')
     ) {
       // occurs when tx was approved outside of active channel.
-      setDefaultMessage('Previous transaction rejected. Please try again.');
+      setDefaultMessage(t('queuedTransactionRejected'));
     } else if (
       err.startsWith('Error: TransportOpenUserCancelled') ||
       err.startsWith('Error: Ledger Device is busy')

--- a/src/contexts/Hardware/Ledger.tsx
+++ b/src/contexts/Hardware/Ledger.tsx
@@ -180,7 +180,6 @@ export const LedgerHardwareProvider = ({
   // all Ledger tasks, along with errors that occur during the process.
   const executeLedgerLoop = async (
     appName: string,
-    transport: AnyJson,
     tasks: Array<LedgerTask>,
     options?: AnyJson
   ) => {
@@ -198,17 +197,13 @@ export const LedgerHardwareProvider = ({
       // tasks at once.
       let result = null;
       if (tasks.includes('get_address')) {
-        result = await handleGetAddress(
-          appName,
-          transport,
-          options?.accountIndex || 0
-        );
+        result = await handleGetAddress(appName, options?.accountIndex || 0);
       } else if (tasks.includes('sign_tx')) {
         const uid = options?.uid || 0;
         const index = options?.accountIndex || 0;
         const payload = options?.payload || '';
 
-        result = await handleSignTx(appName, transport, uid, index, payload);
+        result = await handleSignTx(appName, uid, index, payload);
       }
 
       // a populated result indicates a successful execution. Set the transport response state for
@@ -227,13 +222,9 @@ export const LedgerHardwareProvider = ({
   };
 
   // Gets an app address on device.
-  const handleGetAddress = async (
-    appName: string,
-    transport: AnyJson,
-    index: number
-  ) => {
-    const substrateApp = newSubstrateApp(transport, appName);
-    const { deviceModel } = transport;
+  const handleGetAddress = async (appName: string, index: number) => {
+    const substrateApp = newSubstrateApp(ledgerTransport.current, appName);
+    const { deviceModel } = ledgerTransport.current;
     const { id, productName } = deviceModel;
 
     setDefaultMessage(null);
@@ -277,13 +268,12 @@ export const LedgerHardwareProvider = ({
   // Signs a payload on device.
   const handleSignTx = async (
     appName: string,
-    transport: AnyJson,
     uid: number,
     index: number,
     payload: AnyJson
   ) => {
-    const substrateApp = newSubstrateApp(transport, appName);
-    const { deviceModel } = transport;
+    const substrateApp = newSubstrateApp(ledgerTransport.current, appName);
+    const { deviceModel } = ledgerTransport.current;
     const { id, productName } = deviceModel;
 
     setTransportResponse({

--- a/src/contexts/Hardware/defaults.ts
+++ b/src/contexts/Hardware/defaults.ts
@@ -12,7 +12,7 @@ export const defaultLedgerHardwareContext: LedgerHardwareContextInterface = {
   transportResponse: null,
   pairDevice: async () => new Promise((resolve) => resolve(false)),
   // eslint-disable-next-line
-  executeLedgerLoop: async (a, t, s, o) => new Promise((resolve) => resolve()),
+  executeLedgerLoop: async (a, s, o) => new Promise((resolve) => resolve()),
   // eslint-disable-next-line
   setIsPaired: (v) => {},
   // eslint-disable-next-line

--- a/src/contexts/Hardware/types.ts
+++ b/src/contexts/Hardware/types.ts
@@ -11,7 +11,6 @@ export type LedgerHardwareContextInterface = {
   transportResponse: AnyJson;
   executeLedgerLoop: (
     appName: string,
-    transport: AnyJson,
     tasks: Array<LedgerTask>,
     options?: AnyJson
   ) => Promise<void>;

--- a/src/contexts/TxMeta/defaults.ts
+++ b/src/contexts/TxMeta/defaults.ts
@@ -15,9 +15,8 @@ export const defaultTxMeta: TxMetaContextInterface = {
   setSender: (s) => {},
   txFeesValid: false,
   incrementPayloadUid: () => 0,
-  getActivePayloadUid: () => 0,
-  // eslint-disable-next-line
-  getTxPayload: (u) => {},
+  getPayloadUid: () => 0,
+  getTxPayload: () => {},
   // eslint-disable-next-line
   setTxPayload: (p, u) => {},
   getTxSignature: () => null,

--- a/src/contexts/TxMeta/index.tsx
+++ b/src/contexts/TxMeta/index.tsx
@@ -31,10 +31,11 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   // are calculated asynchronously and extrinsic associated with them may be cancelled. For this
   // reason we give every payload a uid, and check whether this uid matches the active extrinsic
   // before submitting it.
-  const [txPayloads, setTxPayloadsState] = useState<{ [key: string]: AnyJson }>(
-    {}
-  );
-  const txPayloadsRef = React.useRef(txPayloads);
+  const [txPayload, setTxPayloadState] = useState<{
+    payload: AnyJson;
+    uid: number;
+  } | null>(null);
+  const txPayloadRef = React.useRef(txPayload);
 
   // Store an optional signed transaction if extrinsics require manual signing (e.g. Ledger).
   const [txSignature, setTxSignatureState] = useState<AnyJson>(null);
@@ -49,29 +50,31 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
     setTxFees(new BigNumber(0));
   };
 
-  const getActivePayloadUid = () => {
-    return Object.keys(txPayloadsRef.current).length;
+  const getPayloadUid = () => {
+    return txPayloadRef.current?.uid || 1;
   };
 
   const incrementPayloadUid = () => {
-    return Object.keys(txPayloadsRef.current).length + 1;
+    return (txPayloadRef.current?.uid || 0) + 1;
   };
 
-  const getTxPayload = (uid: number) => {
-    return txPayloadsRef.current[`payload${uid}`] || null;
+  const getTxPayload = () => {
+    return txPayloadRef.current?.payload || null;
   };
 
   const setTxPayload = (p: AnyJson, uid: number) => {
-    const key = `payload${uid}`;
     setStateWithRef(
-      { ...txPayloadsRef.current, [key]: p },
-      setTxPayloadsState,
-      txPayloadsRef
+      {
+        payload: p,
+        uid,
+      },
+      setTxPayloadState,
+      txPayloadRef
     );
   };
 
   const resetTxPayloads = () => {
-    setStateWithRef({}, setTxPayloadsState, txPayloadsRef);
+    setStateWithRef(null, setTxPayloadState, txPayloadRef);
   };
 
   const getTxSignature = () => {
@@ -100,7 +103,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         sender,
         setSender,
         incrementPayloadUid,
-        getActivePayloadUid,
+        getPayloadUid,
         getTxPayload,
         setTxPayload,
         resetTxPayloads,

--- a/src/contexts/TxMeta/types.ts
+++ b/src/contexts/TxMeta/types.ts
@@ -13,8 +13,8 @@ export interface TxMetaContextInterface {
   setSender: (s: MaybeAccount) => void;
   txFeesValid: boolean;
   incrementPayloadUid: () => number;
-  getActivePayloadUid: () => number;
-  getTxPayload: (u: number) => AnyJson;
+  getPayloadUid: () => number;
+  getTxPayload: () => AnyJson;
   setTxPayload: (s: AnyJson, u: number) => void;
   resetTxPayloads: () => void;
   getTxSignature: () => AnyJson;

--- a/src/library/Hooks/useLedgerLoop/index.tsx
+++ b/src/library/Hooks/useLedgerLoop/index.tsx
@@ -8,13 +8,8 @@ import { useTxMeta } from 'contexts/TxMeta';
 import type { LederLoopProps } from './types';
 
 export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
-  const {
-    setIsPaired,
-    getTransport,
-    getIsExecuting,
-    getStatusCodes,
-    executeLedgerLoop,
-  } = useLedgerHardware();
+  const { setIsPaired, getIsExecuting, getStatusCodes, executeLedgerLoop } =
+    useLedgerHardware();
   const {
     network: { name },
   } = useApi();
@@ -39,7 +34,7 @@ export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
       const accountIndex = options?.accountIndex ? options.accountIndex() : 0;
       const payload = await getTxPayload();
       if (getIsExecuting()) {
-        await executeLedgerLoop(appName, getTransport(), tasks, {
+        await executeLedgerLoop(appName, tasks, {
           uid,
           accountIndex,
           payload,

--- a/src/library/Hooks/useLedgerLoop/index.tsx
+++ b/src/library/Hooks/useLedgerLoop/index.tsx
@@ -18,7 +18,7 @@ export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
   const {
     network: { name },
   } = useApi();
-  const { getTxPayload, getActivePayloadUid } = useTxMeta();
+  const { getTxPayload, getPayloadUid } = useTxMeta();
   const { appName } = getLedgerApp(name);
 
   // Connect to Ledger device and perform necessary tasks.
@@ -29,17 +29,15 @@ export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
     if (!mounted()) {
       return;
     }
-
     // If the app is not open on-device, or device is not connected, cancel execution.
     // If we are to explore auto looping via an interval, this may wish to use `determineStatusFromCode` instead.
     if (['DeviceNotConnected'].includes(getStatusCodes()[0]?.statusCode)) {
       setIsPaired('unpaired');
     } else {
       // Get task options and execute the loop.
-      const uid = getActivePayloadUid();
+      const uid = getPayloadUid();
       const accountIndex = options?.accountIndex ? options.accountIndex() : 0;
-      const payload = await getTxPayload(uid);
-
+      const payload = await getTxPayload();
       if (getIsExecuting()) {
         await executeLedgerLoop(appName, getTransport(), tasks, {
           uid,

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -237,7 +237,7 @@ export const useSubmitExtrinsic = ({
     // pre-submission state update
     setSubmitting(true);
 
-    const txPayload: AnyJson = getTxPayload(uid);
+    const txPayload: AnyJson = getTxPayload();
     const txSignature: AnyJson = getTxSignature();
 
     // handle signed transaction.

--- a/src/locale/cn/modals.json
+++ b/src/locale/cn/modals.json
@@ -139,6 +139,7 @@
     "poolIsNotNominating": "该提名池未提名任何验证人",
     "poolName": "提名池名称",
     "poolNominations": "池的提名",
+    "queuedTransactionRejected": "上一笔交易己被拒绝.请再试一次",
     "readOnly": "只读帐户无法签署交易.",
     "readOnlyAccount": "{{count}} 个只读帐户",
     "readOnlyAccounts": "只读帐户",

--- a/src/locale/en/modals.json
+++ b/src/locale/en/modals.json
@@ -148,6 +148,7 @@
     "poolIsNotNominating": "Pool is Not Nominating.",
     "poolName": "Pool Name",
     "poolNominations": "Pool Nominations",
+    "queuedTransactionRejected": "Previous transaction rejected. Please try again.",
     "readOnly": "Your account is read only, and cannot sign transactions.",
     "readOnlyAccount_one": "{{count}} Read Only Account",
     "readOnlyAccount_other": "{{count}} Read Only Accounts",


### PR DESCRIPTION
More pre-release fixes dealing with Ledger edge cases and simplification of syntax.

- [x] Deals with an error where there are one or more queued transactions on the Ledger device that are returned when a new transaction is being signed.
- [x] Simplified `txPayload` state to only store one `payload` and `uid`. `uid` is now incremented based on the current one in state, or defaults to `1` otherwise.
- [x] No longer passes `transport` into `executeLedgerLoop`, refers to ref instead.
- [x] Toggles `inProgress` refs to `false` when extrinsic components unmount - important to prevent hanging of future transactions.