### PR TITLE
Pre-process X day average prior to graph start item

### DIFF
--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -47,18 +47,20 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
   const { inSetup } = useStaking();
   const { membership } = usePoolMemberships();
   const { payouts, poolClaims, unclaimedPayouts } = useSubscan();
+  const notStaking = !isSyncing && inSetup() && !membership;
 
   // remove slashes from payouts (graph does not support negative values).
   const payoutsNoSlash = payouts.filter(
     (p: AnySubscan) => p.event_id !== 'Slashed'
   );
 
+  // remove slashes from unclaimed payouts.
   const unclaimedPayoutsNoSlash = unclaimedPayouts.filter(
     (p: AnySubscan) => p.event_id !== 'Slashed'
   );
 
-  const notStaking = !isSyncing && inSetup() && !membership;
-  const { payoutsByDay, poolClaimsByDay, unclaimPayoutsByDay } =
+  // get formatted rewards data for graph.
+  const { allPayouts, allPoolClaims, allUnclaimedPayouts } =
     formatRewardsForGraphs(
       days,
       units,
@@ -66,6 +68,10 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
       poolClaims,
       unclaimedPayoutsNoSlash
     );
+
+  const { p: payoutsByDay } = allPayouts;
+  const { p: poolClaimsByDay } = allPoolClaims;
+  const { p: unclaimPayoutsByDay } = allUnclaimedPayouts;
 
   // determine color for payouts
   const colorPayouts = notStaking

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -70,9 +70,9 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
       unclaimedPayoutsNoSlash
     );
 
-  const { p: payoutsByDay } = allPayouts;
-  const { p: poolClaimsByDay } = allPoolClaims;
-  const { p: unclaimPayoutsByDay } = allUnclaimedPayouts;
+  const { p: graphPayouts } = allPayouts;
+  const { p: graphUnclaimedPayouts } = allUnclaimedPayouts;
+  const { p: graphPoolClaims } = allPoolClaims;
 
   // determine color for payouts
   const colorPayouts = notStaking
@@ -85,7 +85,7 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
     : colors.secondary[mode];
 
   const data = {
-    labels: payoutsByDay.map((item: AnySubscan) => {
+    labels: graphPayouts.map((item: AnySubscan) => {
       const dateObj = format(fromUnixTime(item.block_timestamp), 'do MMM', {
         locale: locales[i18n.resolvedLanguage],
       });
@@ -95,7 +95,7 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
       {
         order: 1,
         label: t('payout'),
-        data: payoutsByDay.map((item: AnySubscan) => item.amount),
+        data: graphPayouts.map((item: AnySubscan) => item.amount),
         borderColor: colorPayouts,
         backgroundColor: colorPayouts,
         pointRadius: 0,
@@ -104,7 +104,7 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
       {
         order: 2,
         label: t('poolClaim'),
-        data: poolClaimsByDay.map((item: AnySubscan) => item.amount),
+        data: graphPoolClaims.map((item: AnySubscan) => item.amount),
         borderColor: colorPoolClaims,
         backgroundColor: colorPoolClaims,
         pointRadius: 0,
@@ -112,8 +112,8 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
       },
       {
         order: 3,
+        data: graphUnclaimedPayouts.map((item: AnySubscan) => item.amount),
         label: t('unclaimedPayouts'),
-        data: unclaimPayoutsByDay.map((item: AnySubscan) => item.amount),
         borderColor: colorPayouts,
         backgroundColor: colors.pending[mode],
         pointRadius: 0,

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -62,6 +62,7 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
   // get formatted rewards data for graph.
   const { allPayouts, allPoolClaims, allUnclaimedPayouts } =
     formatRewardsForGraphs(
+      new Date(),
       days,
       units,
       payoutsNoSlash,

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -61,8 +61,11 @@ export const PayoutLine = ({
     (p: AnySubscan) => p.event_id !== 'Slashed'
   );
 
+  // define the most recent date that we will show on the graph.
+  const fromDate = new Date();
+
   const { allPayouts, allPoolClaims } = formatRewardsForGraphs(
-    new Date(),
+    fromDate,
     days,
     units,
     payoutsNoSlash,
@@ -75,9 +78,14 @@ export const PayoutLine = ({
 
   // combine payouts and pool claims into one dataset and calculate averages.
   const combined = combineRewardsByDay(payoutsByDay, poolClaimsByDay);
+  const preCombined = combineRewardsByDay(prePayoutsByDay, prePoolClaimsByDay);
 
-  // TODO: concat pre-payouts with payouts and pass into average function.
-  const combinedPayouts = calculatePayoutAverages(combined, 10, days);
+  const combinedPayouts = calculatePayoutAverages(
+    preCombined.concat(combined),
+    fromDate,
+    days,
+    10
+  );
 
   // determine color for payouts
   const color = notStaking

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -25,7 +25,7 @@ import type { AnySubscan } from 'types';
 import type { PayoutLineProps } from './types';
 import {
   calculatePayoutAverages,
-  combineRewardsByDay,
+  combineRewards,
   formatRewardsForGraphs,
 } from './Utils';
 
@@ -73,12 +73,12 @@ export const PayoutLine = ({
     [] // Note: we are not using `unclaimedPayouts` here.
   );
 
-  const { p: payoutsByDay, a: prePayoutsByDay } = allPayouts;
-  const { p: poolClaimsByDay, a: prePoolClaimsByDay } = allPoolClaims;
+  const { p: graphPayouts, a: graphPrePayouts } = allPayouts;
+  const { p: graphPoolClaims, a: graphPrePoolClaims } = allPoolClaims;
 
   // combine payouts and pool claims into one dataset and calculate averages.
-  const combined = combineRewardsByDay(payoutsByDay, poolClaimsByDay);
-  const preCombined = combineRewardsByDay(prePayoutsByDay, prePoolClaimsByDay);
+  const combined = combineRewards(graphPayouts, graphPoolClaims);
+  const preCombined = combineRewards(graphPrePayouts, graphPrePoolClaims);
 
   const combinedPayouts = calculatePayoutAverages(
     preCombined.concat(combined),

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -61,7 +61,7 @@ export const PayoutLine = ({
     (p: AnySubscan) => p.event_id !== 'Slashed'
   );
 
-  const { payoutsByDay, poolClaimsByDay } = formatRewardsForGraphs(
+  const { allPayouts, allPoolClaims } = formatRewardsForGraphs(
     days,
     units,
     payoutsNoSlash,
@@ -69,9 +69,13 @@ export const PayoutLine = ({
     [] // Note: we are not using `unclaimedPayouts` here.
   );
 
+  const { p: payoutsByDay, a: prePayoutsByDay } = allPayouts;
+  const { p: poolClaimsByDay, a: prePoolClaimsByDay } = allPoolClaims;
+
   // combine payouts and pool claims into one dataset and calculate averages.
   const combined = combineRewardsByDay(payoutsByDay, poolClaimsByDay);
 
+  // TODO: concat pre-payouts with payouts and pass into average function.
   const combinedPayouts = calculatePayoutAverages(combined, 10, days);
 
   // determine color for payouts

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -62,6 +62,7 @@ export const PayoutLine = ({
   );
 
   const { allPayouts, allPoolClaims } = formatRewardsForGraphs(
+    new Date(),
     days,
     units,
     payoutsNoSlash,

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -281,16 +281,17 @@ const processPayouts = (
   return { p, a };
 };
 
-// Get payout average in 10 day period after to `days` threshold
+// Get payout average in `avgDays` day period after to `days` threshold
 //
-// These payouts are used for calculating the 10-day average prior to the start of the payout graph.
+// These payouts are used for calculating the `avgDays`-day average prior to the start of the payout
+// graph.
 const getPreMaxDaysPayouts = (
   payouts: AnySubscan,
   fromDate: Date,
   days: number,
   avgDays: number
 ) => {
-  // remove payouts that are not within 10 `days` pre-graph window.
+  // remove payouts that are not within `avgDays` `days` pre-graph window.
   return payouts.filter(
     (p: AnySubscan) =>
       daysPassed(fromUnixTime(p.block_timestamp), fromDate) > days &&

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -139,16 +139,16 @@ export const calculatePayoutsByDay = (
 
 // Calculate average payouts per day.
 export const calculatePayoutAverages = (
-  payoutsByDay: AnySubscan,
+  payouts: AnySubscan,
   average: number,
   days: number
 ) => {
-  // if we don't need to take an average, just return `payoutsByDay`.
-  if (average <= 1) return payoutsByDay;
+  // if we don't need to take an average, just return `payouts`.
+  if (average <= 1) return payouts;
 
   // create moving average value over `average` past days, if any.
   const payoutsAverages = [];
-  for (let i = 0; i < payoutsByDay.length; i++) {
+  for (let i = 0; i < payouts.length; i++) {
     // average period end.
     const end = Math.max(0, i - average);
 
@@ -158,21 +158,21 @@ export const calculatePayoutAverages = (
     let num = 0;
 
     for (let j = i; j >= end; j--) {
-      if (payoutsByDay[j]) {
-        total += payoutsByDay[j].amount;
+      if (payouts[j]) {
+        total += payouts[j].amount;
       }
       // increase by one to treat non-existent as zero value
       num += 1;
     }
 
     if (total === 0) {
-      total = payoutsByDay[i].amount;
+      total = payouts[i].amount;
     }
 
     payoutsAverages.push({
       amount: total / num,
-      event_id: payoutsByDay[i].event_id,
-      block_timestamp: payoutsByDay[i].block_timestamp,
+      event_id: payouts[i].event_id,
+      block_timestamp: payouts[i].block_timestamp,
     });
   }
 
@@ -265,6 +265,8 @@ const processPayouts = (
   a = a.concat(prefillMissingDays(a, averageFromDate, avgDays));
   // fill in gap days between payouts with zero values.
   a = fillGapDays(a, averageFromDate);
+  // reverse payouts: most recent last.
+  a = a.reverse();
 
   return { p, a };
 };

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -189,9 +189,14 @@ export const formatRewardsForGraphs = (
   unclaimedPayouts: AnySubscan
 ) => {
   // process staking payouts.
-  const payoutsByDay = processPayouts(payouts, days, units, 'staking');
-  const poolClaimsByDay = processPayouts(poolClaims, days, units, 'pools');
-  const unclaimPayoutsByDay = processPayouts(
+  const { p: payoutsByDay } = processPayouts(payouts, days, units, 'staking');
+  const { p: poolClaimsByDay } = processPayouts(
+    poolClaims,
+    days,
+    units,
+    'pools'
+  );
+  const { p: unclaimPayoutsByDay } = processPayouts(
     unclaimedPayouts,
     days,
     units,
@@ -226,7 +231,7 @@ const processPayouts = (
   p = fillGapDays(p);
   // reverse payouts: most recent last.
   p = p.reverse();
-  return p;
+  return { p };
 };
 
 // Combine reward payouts.

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -249,7 +249,22 @@ const processPayouts = (
   p = p.reverse();
 
   // use normalised payouts for calculating the 10-day average prior to the start of the payout graph.
-  const a = getPreMaxDaysPayouts(normalised, fromDate, days);
+  const avgDays = 10;
+  const preNormalised = getPreMaxDaysPayouts(normalised, fromDate, days);
+  // start of average calculation should be the earliest date.
+  const averageFromDate = subDays(fromDate, MaxPayoutDays);
+
+  let a = calculatePayoutsByDay(
+    preNormalised,
+    averageFromDate,
+    avgDays,
+    units,
+    subject
+  );
+  // prefill payouts if we are missing the earlier dates.
+  a = a.concat(prefillMissingDays(a, averageFromDate, avgDays));
+  // fill in gap days between payouts with zero values.
+  a = fillGapDays(a, averageFromDate);
 
   return { p, a };
 };

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -36,6 +36,7 @@ export const Overview = () => {
   const { units } = network;
   const { payouts, poolClaims, unclaimedPayouts } = useSubscan();
   const { lastReward } = formatRewardsForGraphs(
+    new Date(),
     14,
     units,
     payouts,

--- a/tests/graphs.test.ts
+++ b/tests/graphs.test.ts
@@ -55,10 +55,11 @@ test('post fill missing days works', () => {
   //  p0,  p1,  p2,   p3,   p4,  p5,   p6
   //  -    -    x     x     x    0     0
   const payouts = normalisePayouts(mockPayouts);
+  const fromDate = new Date();
   const maxDays = 7;
 
   // post fill the missing days for mock payouts.
-  const missingDays = postFillMissingDays(payouts, maxDays);
+  const missingDays = postFillMissingDays(payouts, fromDate, maxDays);
 
   // amount of missing days returned should be correct.
   expect(missingDays.length).toBe(2);
@@ -89,10 +90,11 @@ test('pre fill missing days works', () => {
   //  p0,  p1,  p2,   p3,   p4,   p5,   p6
   //            x     x     x     -     -
   const payouts = normalisePayouts(mockPayouts);
+  const fromDate = new Date();
   const maxDays = 7;
 
   // post fill the missing days for mock payouts.
-  const missingDays = prefillMissingDays(payouts, maxDays);
+  const missingDays = prefillMissingDays(payouts, fromDate, maxDays);
 
   // expect amount of missing days to be 2
   expect(missingDays.length).toBe(2);
@@ -123,13 +125,14 @@ test('pre fill and post fill missing days work together', () => {
   //  p0,  p1,  p2,   p3,   p4,   p5,   p6,   p7,   p8,   p9
   //  -    -    x     x     x     -     -     -     -     -
   const payouts = normalisePayouts(mockPayouts);
+  const fromDate = new Date();
   const maxDays = 10;
 
   // post fill the missing days for mock payouts.
-  const missingPostDays = postFillMissingDays(payouts, maxDays);
+  const missingPostDays = postFillMissingDays(payouts, fromDate, maxDays);
   expect(missingPostDays.length).toBe(2);
 
-  const missingPreDays = prefillMissingDays(payouts, maxDays);
+  const missingPreDays = prefillMissingDays(payouts, fromDate, maxDays);
   expect(missingPreDays.length).toBe(5);
 
   const finalPayouts = missingPostDays.concat(payouts).concat(missingPreDays);


### PR DESCRIPTION
This PR adds logic to pre-process payouts some time prior to the graph starting - if they exist - so the first payout accurately displays its 10-day average. Prior to this solution, the 10 day average always started at zero.