### PR TITLE
Introduce `forceReserved`

### DIFF
--- a/src/contexts/Balances/defaults.ts
+++ b/src/contexts/Balances/defaults.ts
@@ -30,5 +30,4 @@ export const defaultBalance: Balance = {
   reserved: new BigNumber(0),
   miscFrozen: new BigNumber(0),
   feeFrozen: new BigNumber(0),
-  freeAfterReserve: new BigNumber(0),
 };

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -32,8 +32,7 @@ export const BalancesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, isReady, network, consts } = useApi();
-  const { existentialDeposit } = consts;
+  const { api, isReady, network } = useApi();
   const { accounts, addExternalAccount, getAccount } = useConnect();
 
   const [balances, setBalances] = useState<Balances[]>([]);

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -142,10 +142,6 @@ export const BalancesProvider = ({
               reserved: new BigNumber(accountData.reserved.toString()),
               miscFrozen: new BigNumber(accountData.miscFrozen.toString()),
               feeFrozen: new BigNumber(accountData.feeFrozen.toString()),
-              freeAfterReserve: BigNumber.max(
-                free.minus(existentialDeposit),
-                0
-              ),
             },
             locks: locks.toHuman().map((l: AnyApi) => ({
               ...l,

--- a/src/contexts/Balances/types.ts
+++ b/src/contexts/Balances/types.ts
@@ -25,7 +25,6 @@ export interface Balance {
   reserved: BigNumber;
   miscFrozen: BigNumber;
   feeFrozen: BigNumber;
-  freeAfterReserve: BigNumber;
 }
 
 export interface UnlockChunkRaw {

--- a/src/contexts/TransferOptions/defaults.ts
+++ b/src/contexts/TransferOptions/defaults.ts
@@ -11,6 +11,7 @@ export const defaultBondedContext: TransferOptionsContextInterface = {
 
 export const transferOptions: TransferOptions = {
   freeBalance: new BigNumber(0),
+  forceReserved: new BigNumber(0),
   nominate: {
     active: new BigNumber(0),
     totalUnlocking: new BigNumber(0),

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -75,7 +75,7 @@ export const TransferOptionsProvider = ({
       }
     }
 
-    // free balance after `forceReserve` amount.
+    // free balance after `total` ledger amount.
     const freeBalance = BigNumber.max(freeMinusReserve.minus(total), 0);
 
     const nominateOptions = () => {

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -36,9 +36,20 @@ export const TransferOptionsProvider = ({
 
     const { free } = balance;
     const { active, total, unlocking } = ledger;
+    const totalLocked =
+      locks?.reduce(
+        (prev, { amount }) => prev.plus(amount),
+        new BigNumber(0)
+      ) || new BigNumber(0);
 
-    // TODO: refer to a new `reserveAmount` figure and deduct instead of `existentialDeposit`.
-    const freeMinusReserve = BigNumber.max(free.minus(existentialDeposit), 0);
+    // Calculate a forced amount of free balance that needs to be reserved to keep the account
+    // alive. Deducts `locks` from free balance reserve needed.
+    const forceReserved = BigNumber.max(
+      existentialDeposit.minus(totalLocked),
+      0
+    );
+    // Total free balance after `forceReserved` is subtracted.
+    const freeMinusReserve = BigNumber.max(free.minus(forceReserved), 0);
 
     // calculate total balance locked
     const maxLockBalance =
@@ -64,7 +75,7 @@ export const TransferOptionsProvider = ({
       }
     }
 
-    // free balance after reserve. Does not consider locks other than staking.
+    // free balance after `forceReserve` amount.
     const freeBalance = BigNumber.max(freeMinusReserve.minus(total), 0);
 
     const nominateOptions = () => {

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -132,6 +132,7 @@ export const TransferOptionsProvider = ({
 
     return {
       freeBalance,
+      forceReserved,
       nominate: nominateOptions(),
       pool: poolOptions(),
     };

--- a/src/contexts/TransferOptions/types.ts
+++ b/src/contexts/TransferOptions/types.ts
@@ -10,6 +10,7 @@ export interface TransferOptionsContextInterface {
 
 export interface TransferOptions {
   freeBalance: BigNumber;
+  forceReserved: BigNumber;
   nominate: {
     active: BigNumber;
     totalUnlocking: BigNumber;

--- a/src/pages/Overview/BalanceChart.tsx
+++ b/src/pages/Overview/BalanceChart.tsx
@@ -20,7 +20,6 @@ export const BalanceChart = () => {
   const { t } = useTranslation('pages');
   const {
     network: { units, unit },
-    consts,
   } = useApi();
   const prices = usePrices();
   const { plugins } = usePlugins();
@@ -28,9 +27,9 @@ export const BalanceChart = () => {
   const { activeAccount } = useConnect();
   const { getBalance, getLocks } = useBalances();
   const { getTransferOptions } = useTransferOptions();
-  const { existentialDeposit } = consts;
   const balance = getBalance(activeAccount);
   const allTransferOptions = getTransferOptions(activeAccount);
+  const { forceReserved } = allTransferOptions;
   const poolBondOpions = allTransferOptions.pool;
   const unlockingPools = poolBondOpions.totalUnlocking.plus(
     poolBondOpions.totalUnlocked
@@ -89,7 +88,7 @@ export const BalanceChart = () => {
 
   // available balance data
   const fundsLocked = planckToUnit(miscFrozen.minus(lockStakingAmount), units);
-  let fundsReserved = planckToUnit(existentialDeposit, units);
+  let fundsReserved = planckToUnit(forceReserved, units);
   const fundsFree = planckToUnit(allTransferOptions.freeBalance, units).minus(
     fundsLocked
   );


### PR DESCRIPTION
Addresses #1000.

- [x] Deprecate `freeAfterReserve` from `Balances` context.
- [x] Seems like this value needs a new `BigNumber` value entirely. `forceReserved` may be a good name for this state object that lives in `TransferOptions` context.
- [x] Also deduct this new value from `freeBalance` in `TransferOptions`.
- [x] `const fundsReserved` in `BalanceChart` needs to reflect this new value, rather than directly using `existentialDeposit`.