### PR TITLE
use InterSemiBold, deprecate font-variation-settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@polkadot/react-qr": "^3.4.1",
     "@polkadot/rpc-provider": "^10.7.2",
     "@polkadot/util": "^12.1.1",
-    "@polkadotcloud/core-ui": "^0.2.62",
+    "@polkadotcloud/core-ui": "^0.2.63",
     "@polkadotcloud/react-odometer": "^0.1.17",
     "@polkadotcloud/utils": "^0.2.22",
     "@substrate/connect": "^0.7.26",

--- a/src/library/BarChart/Wrappers.ts
+++ b/src/library/BarChart/Wrappers.ts
@@ -48,10 +48,10 @@ export const Legend = styled.div`
   display: flex;
 
   > h4 {
+    font-family: InterSemiBold, sans-serif;
     display: flex;
     align-items: center;
     padding: 0.5rem 1rem;
-    font-variation-settings: 'wght' 600;
     font-size: 1.1rem;
     margin: 0;
 
@@ -83,12 +83,12 @@ export const Bar = styled.div`
     transition: width 1.5s cubic-bezier(0, 1, 0, 1);
 
     > span {
+      font-family: InterSemiBold, sans-serif;
       position: absolute;
       left: 0;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      font-variation-settings: 'wght' 600;
       padding: 0 0.8rem;
       width: 100%;
       font-size: 1rem;

--- a/src/library/List/index.ts
+++ b/src/library/List/index.ts
@@ -126,7 +126,6 @@ export const List = styled.div<ListProps>`
       border-radius: 1.75rem;
       padding: 0.75rem 1.25rem;
       font-size: 1.15rem;
-      font-variation-settings: 'wght' 500;
       &:focus {
         border-width: 1.75px;
       }

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -157,6 +157,7 @@ export const IdentityWrapper = styled(motion.div)`
   }
   h4 {
     color: var(--text-color-secondary);
+    font-family: InterSemiBold, sans-serif;
     position: absolute;
     top: 0;
     width: 100%;
@@ -167,7 +168,6 @@ export const IdentityWrapper = styled(motion.div)`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-variation-settings: 'wght' 600;
     font-size: 1rem;
 
     > span {

--- a/src/library/Overlay/Wrappers.tsx
+++ b/src/library/Overlay/Wrappers.tsx
@@ -138,7 +138,6 @@ export const FilterListButton = styled.button<{ active: boolean }>`
       props.active
         ? 'var(--network-color-stroke)'
         : 'var(--text-color-secondary)'};
-    font-variation-settings: 'wght' 500;
     transition: color var(--transition-duration);
   }
 

--- a/src/library/PayeeInput/Wrapper.ts
+++ b/src/library/PayeeInput/Wrapper.ts
@@ -48,7 +48,6 @@ export const Wrapper = styled.div<{ activeInput?: boolean }>`
           color: var(--text-color-secondary);
           font-size: 1.25rem;
           z-index: 1;
-          font-variation-settings: 'wght' 500;
           opacity: 1;
 
           &:disabled {
@@ -61,7 +60,6 @@ export const Wrapper = styled.div<{ activeInput?: boolean }>`
           opacity: 0;
           position: absolute;
           top: -999px;
-          font-variation-settings: 'wght' 500;
         }
       }
     }

--- a/src/library/Stat/Wrapper.ts
+++ b/src/library/Stat/Wrapper.ts
@@ -42,6 +42,7 @@ export const Wrapper = styled.div<{ isAddress?: boolean }>`
 
     .text {
       padding-left: ${(props) => (props.isAddress ? '3rem' : 0)};
+      font-family: InterSemiBold, sans-serif;
       color: var(--text-color-primary);
       padding-top: 0.1rem;
       position: absolute;
@@ -50,7 +51,6 @@ export const Wrapper = styled.div<{ isAddress?: boolean }>`
       margin: 0;
       height: 2.4rem;
       font-size: 1.4rem;
-      font-variation-settings: 'wght' 600;
       width: auto;
       max-width: 100%;
       text-align: left;

--- a/src/library/StatBoxList/Wrapper.ts
+++ b/src/library/StatBoxList/Wrapper.ts
@@ -39,7 +39,7 @@ export const StatBoxWrapper = styled(motion.div)`
 
   /* responsive screen sizing */
   h3 {
-    font-variation-settings: 'wght' 600;
+    font-family: InterSemiBold, sans-serif;
     font-size: 1.2rem;
   }
   @media (min-width: 950px) {
@@ -158,7 +158,7 @@ export const TextTitleWrapper = styled.div<{ primary?: boolean }>`
     props.primary === true
       ? 'var(--network-color-primary)'
       : 'var(--text-color-primary)'};
-  font-variation-settings: 'wght' 600;
+  font-family: InterSemiBold, sans-serif;
   display: flex;
   flex-flow: row wrap;
   margin-bottom: 0.45rem;
@@ -187,7 +187,7 @@ export const TimeLeftWrapper = styled.div<{ primary?: boolean }>`
     props.primary === true
       ? 'var(--network-color-primary)'
       : 'var(--text-color-primary)'};
-  font-variation-settings: 'wght' 600;
+  font-family: InterSemiBold, sans-serif;
   display: flex;
   flex-flow: row wrap;
   font-size: 1.2rem;
@@ -199,7 +199,7 @@ export const TimeLeftWrapper = styled.div<{ primary?: boolean }>`
 
   span {
     color: var(--text-color-secondary);
-    font-variation-settings: 'wght' 600;
+    font-family: InterSemiBold, sans-serif;
     font-size: 0.95rem;
     margin-left: 0.3rem;
     margin-top: 0.1rem;

--- a/src/modals/Connect/Wrappers.ts
+++ b/src/modals/Connect/Wrappers.ts
@@ -90,8 +90,8 @@ export const ExtensionInner = styled.div`
   position: relative;
 
   h3 {
+    font-family: InterSemiBold, sans-serif;
     margin: 1rem 0 0 0;
-    font-variation-settings: 'wght' 600;
     > svg {
       margin-right: 0.5rem;
     }
@@ -193,13 +193,13 @@ export const ActionWithButton = styled.div`
       display: flex;
       align-items: center;
       flex-grow: 1;
-      font-variation-settings: 'wght' 650;
+      font-family: InterSemiBold, sans-serif;
       > svg {
         margin-right: 0.5rem;
       }
     }
     &:last-child {
-      font-variation-settings: 'wght' 650;
+      font-family: InterSemiBold, sans-serif;
     }
   }
 `;
@@ -264,7 +264,7 @@ export const ManualAccount = styled.div`
         h4 {
           margin: 0;
           &.title {
-            font-variation-settings: 'wght' 600;
+            font-family: InterSemiBold, sans-serif;
             > svg {
               margin: 0 0.6rem;
             }

--- a/src/pages/Payouts/Wrappers.ts
+++ b/src/pages/Payouts/Wrappers.ts
@@ -48,7 +48,7 @@ export const ItemWrapper = styled(motion.div)`
 
         h4 {
           color: var(--text-color-secondary);
-          font-variation-settings: 'wght' 600;
+          font-family: InterSemiBold, sans-serif;
           &.claim {
             color: var(--network-color-secondary);
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,10 +972,10 @@
     tslib "^2.5.0"
     ws "^8.13.0"
 
-"@polkadotcloud/core-ui@^0.2.62":
-  version "0.2.62"
-  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.2.62.tgz#245b11676354e7fccbb6d9e3dbc7681e4efc880e"
-  integrity sha512-1cmMZ2gklG/0QBPNG1tRigGi2P7UQ4pjOrmBXGQP72HWwUC8cTgpu+lKKAXkcmupKcxTPawuwkAc61asNKbOfQ==
+"@polkadotcloud/core-ui@^0.2.63":
+  version "0.2.63"
+  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.2.63.tgz#0f1613ca4e386f05b67fc2896ed10ecc3687fe8b"
+  integrity sha512-ny9RWuwKmWiJ2n1PmtnqWn45+izonNxCndatJolcC4XdT6Tm8S51SbATPIViGMw5nFx47gfTdBmtSYiNQvrNug==
 
 "@polkadotcloud/react-odometer@^0.1.17":
   version "0.1.17"


### PR DESCRIPTION
This PR uses the latest version of `@polkadotcloud/core-ui`, that replaces the variable `Inter` font with woff2 alternatives.

https://github.com/paritytech/polkadot-dashboard-ui/pull/215