### PR TITLE
1.0.8 Pre-Release Fixes & Optimisations

### DIFF
--- a/src/library/Hooks/useBatchCall/index.tsx
+++ b/src/library/Hooks/useBatchCall/index.tsx
@@ -12,7 +12,7 @@ export const useBatchCall = () => {
   const { isProxySupported } = useProxySupported();
 
   const newBatchCall = (txs: AnyApi[], from: MaybeAccount) => {
-    if (!api) return null;
+    if (!api) return undefined;
 
     from = from || '';
 

--- a/src/library/Hooks/useBatchCall/index.tsx
+++ b/src/library/Hooks/useBatchCall/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useApi } from 'contexts/Api';
+import type { AnyApi } from 'types';
+
+export const useBatchCall = () => {
+  const { api } = useApi();
+  // TODO: wrap calls in proxy.proxy if there is an active proxy and proxy is supported.
+
+  // const { activeProxy } = useConnect();
+  // const { isProxySupported } = useProxySupported();
+
+  const newBatchCall = (txs: AnyApi[]) => {
+    if (!api) return null;
+
+    return api?.tx.utility.batch(txs);
+  };
+
+  return {
+    newBatchCall,
+  };
+};

--- a/src/library/Hooks/useBatchCall/index.tsx
+++ b/src/library/Hooks/useBatchCall/index.tsx
@@ -14,6 +14,8 @@ export const useBatchCall = () => {
   const newBatchCall = (txs: AnyApi[], from: MaybeAccount) => {
     if (!api) return null;
 
+    from = from || '';
+
     if (activeProxy && isProxySupported(api.tx.utility.batch(txs), from)) {
       return api?.tx.utility.batch(
         txs.map((tx) =>

--- a/src/library/Hooks/useBatchCall/index.tsx
+++ b/src/library/Hooks/useBatchCall/index.tsx
@@ -19,7 +19,7 @@ export const useBatchCall = () => {
         txs.map((tx) =>
           api.tx.proxy.proxy(
             {
-              id: activeProxy,
+              id: from,
             },
             null,
             tx

--- a/src/library/Hooks/useBuildPayload/index.tsx
+++ b/src/library/Hooks/useBuildPayload/index.tsx
@@ -1,0 +1,64 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useApi } from 'contexts/Api';
+import { useBalances } from 'contexts/Balances';
+import { useTxMeta } from 'contexts/TxMeta';
+import type { AnyApi } from 'types';
+
+export const useBuildPayload = () => {
+  const { api } = useApi();
+  const { getNonce } = useBalances();
+  const { setTxPayload } = useTxMeta();
+
+  // Build and set payload of the transaction and store it in TxMetaContext.
+  const buildPayload = async (tx: AnyApi, from: string, uid: number) => {
+    if (api && tx) {
+      const lastHeader = await api.rpc.chain.getHeader();
+      const blockNumber = api.registry.createType(
+        'BlockNumber',
+        lastHeader.number.toNumber()
+      );
+      const method = api.createType('Call', tx);
+      const era = api.registry.createType('ExtrinsicEra', {
+        current: lastHeader.number.toNumber(),
+        period: 64,
+      });
+
+      const accountNonce = getNonce(from);
+      const nonce = api.registry.createType('Compact<Index>', accountNonce);
+
+      const payload = {
+        specVersion: api.runtimeVersion.specVersion.toHex(),
+        transactionVersion: api.runtimeVersion.transactionVersion.toHex(),
+        address: from,
+        blockHash: lastHeader.hash.toHex(),
+        blockNumber: blockNumber.toHex(),
+        era: era.toHex(),
+        genesisHash: api.genesisHash.toHex(),
+        method: method.toHex(),
+        nonce: nonce.toHex(),
+        signedExtensions: [
+          'CheckNonZeroSender',
+          'CheckSpecVersion',
+          'CheckTxVersion',
+          'CheckGenesis',
+          'CheckMortality',
+          'CheckNonce',
+          'CheckWeight',
+          'ChargeTransactionPayment',
+        ],
+        tip: api.registry.createType('Compact<Balance>', 0).toHex(),
+        version: tx.version,
+      };
+      const raw = api.registry.createType('ExtrinsicPayload', payload, {
+        version: payload.version,
+      });
+      setTxPayload(raw, uid);
+    }
+  };
+
+  return {
+    buildPayload,
+  };
+};

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -1,0 +1,68 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  UnsupportedIfUniqueController,
+  isSupportedProxyCall,
+} from 'config/proxies';
+import { useBonded } from 'contexts/Bonded';
+import { useConnect } from 'contexts/Connect';
+import { useProxies } from 'contexts/Proxies';
+import type { AnyApi, AnyJson, MaybeAccount } from 'types';
+
+export const useProxySupported = (from: MaybeAccount) => {
+  const { getAccount, activeProxy } = useConnect();
+  const { getBondedAccount } = useBonded();
+  const { getProxyDelegate } = useProxies();
+  const controller = getBondedAccount(from);
+
+  // If call is from controller, & controller is different from stash, then proxy is not
+  // supported.
+  const controllerNotSupported = (c: string) =>
+    UnsupportedIfUniqueController.includes(c) && controller !== from;
+
+  // Determine whether the provided tx is proxy sypported.
+  const isProxySupported = (tx: AnyApi) => {
+    // if already wrapped, return.
+    if (
+      tx?.method.toHuman().section === 'proxy' &&
+      tx?.method.toHuman().method === 'proxy'
+    ) {
+      return true;
+    }
+    // Ledger devices do not support nesting on `proxy.proxy` calls.
+    if (getAccount(activeProxy)?.source === 'ledger') {
+      return false;
+    }
+
+    const proxyDelegate = getProxyDelegate(from, activeProxy);
+    const proxyType = proxyDelegate?.proxyType || '';
+    const pallet = tx?.method.toHuman().section;
+    const method = tx?.method.toHuman().method;
+    const call = `${pallet}.${method}`;
+
+    // If a batch call, test if every inner call is a supported proxy call.
+    if (call === 'utility.batch') {
+      return (tx?.method?.toHuman()?.args?.calls || [])
+        .map((c: AnyJson) => ({
+          pallet: c.section,
+          method: c.method,
+        }))
+        .every(
+          (c: AnyJson) =>
+            isSupportedProxyCall(proxyType, c.pallet, c.method) &&
+            !controllerNotSupported(`${pallet}.${method}`)
+        );
+    }
+
+    // Check if the current call is a supported proxy call.
+    return (
+      isSupportedProxyCall(proxyType, pallet, method) &&
+      !controllerNotSupported(call)
+    );
+  };
+
+  return {
+    isProxySupported,
+  };
+};

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -11,7 +11,7 @@ import { useProxies } from 'contexts/Proxies';
 import type { AnyApi, AnyJson, MaybeAccount } from 'types';
 
 export const useProxySupported = () => {
-  const { getAccount, activeProxy } = useConnect();
+  const { activeProxy } = useConnect();
   const { getBondedAccount } = useBonded();
   const { getProxyDelegate } = useProxies();
 
@@ -28,10 +28,6 @@ export const useProxySupported = () => {
       tx?.method.toHuman().method === 'proxy'
     ) {
       return true;
-    }
-    // Ledger devices do not support nesting on `proxy.proxy` calls.
-    if (getAccount(activeProxy)?.source === 'ledger') {
-      return false;
     }
 
     const proxyDelegate = getProxyDelegate(delegator, activeProxy);

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -49,7 +49,8 @@ export const useProxySupported = () => {
         }))
         .every(
           (c: AnyJson) =>
-            isSupportedProxyCall(proxyType, c.pallet, c.method) &&
+            (isSupportedProxyCall(proxyType, c.pallet, c.method) ||
+              (c.pallet === 'proxy' && c.method === 'proxy')) &&
             !controllerNotSupported(`${pallet}.${method}`, delegator)
         );
     }

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -10,19 +10,18 @@ import { useConnect } from 'contexts/Connect';
 import { useProxies } from 'contexts/Proxies';
 import type { AnyApi, AnyJson, MaybeAccount } from 'types';
 
-export const useProxySupported = (from: MaybeAccount) => {
+export const useProxySupported = () => {
   const { getAccount, activeProxy } = useConnect();
   const { getBondedAccount } = useBonded();
   const { getProxyDelegate } = useProxies();
-  const controller = getBondedAccount(from);
 
   // If call is from controller, & controller is different from stash, then proxy is not
   // supported.
-  const controllerNotSupported = (c: string) =>
-    UnsupportedIfUniqueController.includes(c) && controller !== from;
+  const controllerNotSupported = (c: string, f: MaybeAccount) =>
+    UnsupportedIfUniqueController.includes(c) && getBondedAccount(f) !== f;
 
   // Determine whether the provided tx is proxy supported.
-  const isProxySupported = (tx: AnyApi) => {
+  const isProxySupported = (tx: AnyApi, from: MaybeAccount) => {
     // if already wrapped, return.
     if (
       tx?.method.toHuman().section === 'proxy' &&
@@ -51,14 +50,14 @@ export const useProxySupported = (from: MaybeAccount) => {
         .every(
           (c: AnyJson) =>
             isSupportedProxyCall(proxyType, c.pallet, c.method) &&
-            !controllerNotSupported(`${pallet}.${method}`)
+            !controllerNotSupported(`${pallet}.${method}`, from)
         );
     }
 
     // Check if the current call is a supported proxy call.
     return (
       isSupportedProxyCall(proxyType, pallet, method) &&
-      !controllerNotSupported(call)
+      !controllerNotSupported(call, from)
     );
   };
 

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -21,7 +21,7 @@ export const useProxySupported = (from: MaybeAccount) => {
   const controllerNotSupported = (c: string) =>
     UnsupportedIfUniqueController.includes(c) && controller !== from;
 
-  // Determine whether the provided tx is proxy sypported.
+  // Determine whether the provided tx is proxy supported.
   const isProxySupported = (tx: AnyApi) => {
     // if already wrapped, return.
     if (

--- a/src/library/Hooks/useProxySupported/index.tsx
+++ b/src/library/Hooks/useProxySupported/index.tsx
@@ -21,7 +21,7 @@ export const useProxySupported = () => {
     UnsupportedIfUniqueController.includes(c) && getBondedAccount(f) !== f;
 
   // Determine whether the provided tx is proxy supported.
-  const isProxySupported = (tx: AnyApi, from: MaybeAccount) => {
+  const isProxySupported = (tx: AnyApi, delegator: MaybeAccount) => {
     // if already wrapped, return.
     if (
       tx?.method.toHuman().section === 'proxy' &&
@@ -34,7 +34,7 @@ export const useProxySupported = () => {
       return false;
     }
 
-    const proxyDelegate = getProxyDelegate(from, activeProxy);
+    const proxyDelegate = getProxyDelegate(delegator, activeProxy);
     const proxyType = proxyDelegate?.proxyType || '';
     const pallet = tx?.method.toHuman().section;
     const method = tx?.method.toHuman().method;
@@ -50,14 +50,14 @@ export const useProxySupported = () => {
         .every(
           (c: AnyJson) =>
             isSupportedProxyCall(proxyType, c.pallet, c.method) &&
-            !controllerNotSupported(`${pallet}.${method}`, from)
+            !controllerNotSupported(`${pallet}.${method}`, delegator)
         );
     }
 
     // Check if the current call is a supported proxy call.
     return (
       isSupportedProxyCall(proxyType, pallet, method) &&
-      !controllerNotSupported(call, from)
+      !controllerNotSupported(call, delegator)
     );
   };
 

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -104,7 +104,7 @@ export const useSubmitExtrinsic = ({
     }
   };
 
-  // Refresh tx state upon tx updates.
+  // Refresh state upon `tx` updates.
   useEffect(() => {
     // update txRef to latest tx.
     txRef.current = tx;

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -29,7 +29,7 @@ export const useSubmitExtrinsic = ({
   const { api } = useApi();
   const { extensions } = useExtensions();
   const { addNotification } = useNotifications();
-  const { isProxySupported } = useProxySupported(from);
+  const { isProxySupported } = useProxySupported();
   const { addPending, removePending } = useExtrinsics();
   const { buildPayload } = useBuildPayload();
   const { getAccount, requiresManualSign, activeProxy } = useConnect();
@@ -60,7 +60,7 @@ export const useSubmitExtrinsic = ({
 
   // Store whether this tx is proxy supported.
   const [proxySupported, setProxySupported] = useState<boolean>(
-    isProxySupported(txRef.current)
+    isProxySupported(txRef.current, submitAddress)
   );
 
   // Track for one-shot transaction reset after submission.
@@ -113,7 +113,7 @@ export const useSubmitExtrinsic = ({
     // ensure sender is up to date.
     setSender(submitAddress);
     // update proxy supported status.
-    setProxySupported(isProxySupported(txRef.current));
+    setProxySupported(isProxySupported(txRef.current, submitAddress));
     // wrap tx in proxy call if active proxy & proxy supported.
     wrapTxIfActiveProxy();
     // re-calculate estimated tx fee.

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -119,9 +119,11 @@ export const useSubmitExtrinsic = ({
     }
   };
 
-  // submit extrinsic
+  // Extrinsic submission handler.
   const onSubmit = async () => {
+    const account = getAccount(submitAddress);
     if (
+      account === null ||
       submitting ||
       !shouldSubmit ||
       !api ||
@@ -130,12 +132,7 @@ export const useSubmitExtrinsic = ({
       return;
     }
 
-    const account = getAccount(submitAddress);
-    if (account === null) {
-      return;
-    }
-
-    const accountNonce = (
+    const nonce = (
       await api.rpc.system.accountNextIndex(submitAddress)
     ).toHuman();
 
@@ -153,7 +150,7 @@ export const useSubmitExtrinsic = ({
     }
 
     const onReady = () => {
-      addPending(accountNonce);
+      addPending(nonce);
       addNotification({
         title: t('pending'),
         subtitle: t('transactionInitiated'),
@@ -163,7 +160,7 @@ export const useSubmitExtrinsic = ({
 
     const onInBlock = () => {
       setSubmitting(false);
-      removePending(accountNonce);
+      removePending(nonce);
       addNotification({
         title: t('inBlock'),
         subtitle: t('transactionInBlock'),
@@ -183,7 +180,7 @@ export const useSubmitExtrinsic = ({
           subtitle: t('errorWithTransaction'),
         });
         setSubmitting(false);
-        removePending(accountNonce);
+        removePending(nonce);
       }
     };
 
@@ -208,7 +205,7 @@ export const useSubmitExtrinsic = ({
       if (type === 'ledger') {
         resetLedgerTx();
       }
-      removePending(accountNonce);
+      removePending(nonce);
       addNotification({
         title: t('cancelled'),
         subtitle: t('transactionCancelled'),

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -76,9 +76,12 @@ export const useSubmitExtrinsic = ({
       return;
     }
 
-    // If batch transaction, wrap each call in proxy. Else, just wrap in proxy.
+    // Handle proxy supported.
     if (api && activeProxy && txRef.current && proxySupported) {
+      // update submit address to active proxy account.
       submitAddress = activeProxy;
+
+      // TODO: If batch transaction, wrap each call in proxy. Else, just wrap in proxy.
       txRef.current = api.tx.proxy.proxy(
         {
           id: from,
@@ -111,8 +114,6 @@ export const useSubmitExtrinsic = ({
     // ensure sender is up to date.
     setSender(submitAddress);
     // update proxy supported status.
-    setProxySupported(isProxySupported(txRef.current));
-    // update whether tx is proxy supported.
     setProxySupported(isProxySupported(txRef.current));
     // wrap tx in proxy call if active proxy & proxy supported.
     wrapTxIfActiveProxy();

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -89,6 +89,21 @@ export const useSubmitExtrinsic = ({
     }
   };
 
+  // Calculate the estimated tx fee of the transaction.
+  const calculateEstimatedFee = async () => {
+    if (txRef.current === null) {
+      return;
+    }
+    // get payment info
+    const { partialFee } = await txRef.current.paymentInfo(submitAddress);
+    const partialFeeBn = new BigNumber(partialFee.toString());
+
+    // give tx fees to global useTxMeta context
+    if (partialFeeBn.toString() !== txFees.toString()) {
+      setTxFees(partialFeeBn);
+    }
+  };
+
   // Refresh tx state upon tx updates.
   useEffect(() => {
     // update txRef to latest tx.
@@ -106,20 +121,6 @@ export const useSubmitExtrinsic = ({
     // rebuild tx payload.
     buildPayload(txRef.current, submitAddress, uid);
   }, [tx?.toString(), tx?.method?.args?.calls?.toString(), from]);
-
-  const calculateEstimatedFee = async () => {
-    if (txRef.current === null) {
-      return;
-    }
-    // get payment info
-    const { partialFee } = await txRef.current.paymentInfo(submitAddress);
-    const partialFeeBn = new BigNumber(partialFee.toString());
-
-    // give tx fees to global useTxMeta context
-    if (partialFeeBn.toString() !== txFees.toString()) {
-      setTxFees(partialFeeBn);
-    }
-  };
 
   // Extrinsic submission handler.
   const onSubmit = async () => {

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -125,12 +125,12 @@ export const useSubmitExtrinsic = ({
     txRef.current = tx;
     // update submit address to latest from.
     fromRef.current = from || '';
-    // ensure sender is up to date.
-    setSender(fromRef.current);
     // update proxy supported status.
     setProxySupported(isProxySupported(txRef.current, fromRef.current));
     // wrap tx in proxy call if active proxy & proxy supported.
     wrapTxIfActiveProxy();
+    // ensure sender is up to date.
+    setSender(fromRef.current);
     // re-calculate estimated tx fee.
     calculateEstimatedFee();
     // rebuild tx payload.

--- a/src/library/Hooks/useSubmitExtrinsic/index.tsx
+++ b/src/library/Hooks/useSubmitExtrinsic/index.tsx
@@ -80,8 +80,7 @@ export const useSubmitExtrinsic = ({
     if (api && activeProxy && txRef.current && proxySupported) {
       // update submit address to active proxy account.
       submitAddress = activeProxy;
-
-      // TODO: If batch transaction, wrap each call in proxy. Else, just wrap in proxy.
+      // wrap tx in proxy call.
       txRef.current = api.tx.proxy.proxy(
         {
           id: from,

--- a/src/library/Import/Wrappers.ts
+++ b/src/library/Import/Wrappers.ts
@@ -155,19 +155,11 @@ export const QRViewerWrapper = styled.div`
     padding: 0 1rem;
     width: 100%;
 
-    .address {
-      display: flex;
-      margin-top: 0.5rem;
-      margin-bottom: 1.25rem;
-
-      svg {
-        margin-right: 0.6rem;
-      }
-    }
     > div {
       display: flex;
-      width: 100%;
       justify-content: center;
+      margin-top: 1rem;
+      width: 100%;
     }
   }
 `;

--- a/src/library/SubmitTx/ManualSign/index.tsx
+++ b/src/library/SubmitTx/ManualSign/index.tsx
@@ -11,9 +11,9 @@ import { Vault } from './Vault';
 export const ManualSign = (
   props: SubmitProps & { buttons?: React.ReactNode[] }
 ) => {
-  const { activeAccount, getAccount } = useConnect();
-  const { getTxSignature } = useTxMeta();
-  const accountMeta = getAccount(activeAccount);
+  const { getAccount } = useConnect();
+  const { getTxSignature, sender } = useTxMeta();
+  const accountMeta = getAccount(sender);
   const source = accountMeta?.source;
 
   const { onSubmit } = props;

--- a/src/modals/BalanceTest/index.tsx
+++ b/src/modals/BalanceTest/index.tsx
@@ -1,0 +1,66 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ModalPadding } from '@polkadotcloud/core-ui';
+import { unitToPlanck } from '@polkadotcloud/utils';
+import { useApi } from 'contexts/Api';
+import { useConnect } from 'contexts/Connect';
+import { useModal } from 'contexts/Modal';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
+import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
+import { Close } from 'library/Modal/Close';
+import { SubmitTx } from 'library/SubmitTx';
+
+export const BalanceTest = () => {
+  const { newBatchCall } = useBatchCall();
+  const { api, network } = useApi();
+  const { activeAccount } = useConnect();
+  const { setStatus: setModalStatus } = useModal();
+  const { units } = network;
+
+  // tx to submit
+  const getTx = () => {
+    const tx = null;
+    if (!api || !activeAccount) {
+      return tx;
+    }
+
+    const txs = [
+      api.tx.balances.transfer(
+        {
+          id: '1554u1a67ApEt5xmjbZwjgDNaVckbzB6cjRHWAQ1SpNkNxTd',
+        },
+        unitToPlanck('0.1', units).toString()
+      ),
+      api.tx.balances.transfer(
+        {
+          id: '1554u1a67ApEt5xmjbZwjgDNaVckbzB6cjRHWAQ1SpNkNxTd',
+        },
+        unitToPlanck('0.05', units).toString()
+      ),
+    ];
+    const batch = newBatchCall(txs, activeAccount);
+
+    return batch;
+  };
+
+  const submitExtrinsic = useSubmitExtrinsic({
+    tx: getTx(),
+    from: activeAccount,
+    shouldSubmit: true,
+    callbackSubmit: () => {
+      setModalStatus(2);
+    },
+    callbackInBlock: () => {},
+  });
+
+  return (
+    <>
+      <Close />
+      <ModalPadding>
+        <h2 className="title unbounded">Balance Test</h2>
+      </ModalPadding>
+      <SubmitTx valid {...submitExtrinsic} />
+    </>
+  );
+};

--- a/src/modals/JoinPool/index.tsx
+++ b/src/modals/JoinPool/index.tsx
@@ -15,6 +15,7 @@ import { useTransferOptions } from 'contexts/TransferOptions';
 import { useTxMeta } from 'contexts/TxMeta';
 import { BondFeedback } from 'library/Form/Bond/BondFeedback';
 import { ClaimPermissionInput } from 'library/Form/ClaimPermissionInput';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
 import { useBondGreatestFee } from 'library/Hooks/useBondGreatestFee';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
@@ -26,15 +27,16 @@ import { useTranslation } from 'react-i18next';
 export const JoinPool = () => {
   const { t } = useTranslation('modals');
   const { api, network } = useApi();
-  const { units } = network;
+  const { txFees } = useTxMeta();
+  const { activeAccount } = useConnect();
+  const { newBatchCall } = useBatchCall();
+  const { setActiveAccountSetup } = useSetup();
+  const { getSignerWarnings } = useSignerWarnings();
+  const { getTransferOptions } = useTransferOptions();
+  const { queryPoolMember, addToPoolMembers } = usePoolMembers();
   const { setStatus: setModalStatus, config, setResize } = useModal();
   const { id: poolId, setActiveTab } = config;
-  const { activeAccount } = useConnect();
-  const { queryPoolMember, addToPoolMembers } = usePoolMembers();
-  const { setActiveAccountSetup } = useSetup();
-  const { getTransferOptions } = useTransferOptions();
-  const { getSignerWarnings } = useSignerWarnings();
-  const { txFees } = useTxMeta();
+  const { units } = network;
 
   const { totalPossibleBond, totalAdditionalBond } =
     getTransferOptions(activeAccount).pool;
@@ -84,7 +86,7 @@ export const JoinPool = () => {
       return txs[0];
     }
 
-    return api.tx.utility.batch(txs);
+    return newBatchCall(txs);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/JoinPool/index.tsx
+++ b/src/modals/JoinPool/index.tsx
@@ -86,7 +86,7 @@ export const JoinPool = () => {
       return txs[0];
     }
 
-    return newBatchCall(txs);
+    return newBatchCall(txs, activeAccount);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/ManagePool/Forms/Commission.tsx
+++ b/src/modals/ManagePool/Forms/Commission.tsx
@@ -304,7 +304,7 @@ export const Commission = ({ setSection, incrementCalculateHeight }: any) => {
     if (txs.length === 1) {
       return txs[0];
     }
-    return newBatchCall(txs);
+    return newBatchCall(txs, activeAccount);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/ManagePool/Forms/Commission.tsx
+++ b/src/modals/ManagePool/Forms/Commission.tsx
@@ -20,6 +20,7 @@ import { intervalToDuration } from 'date-fns';
 import { AccountInput } from 'library/AccountInput';
 import { MinDelayInput } from 'library/Form/MinDelayInput';
 import { Warning } from 'library/Form/Warning';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { SubmitTx } from 'library/SubmitTx';
@@ -33,14 +34,15 @@ import type { ChangeRateInput } from './types';
 
 export const Commission = ({ setSection, incrementCalculateHeight }: any) => {
   const { t } = useTranslation('modals');
-  const { api, consts } = useApi();
-  const { setStatus: setModalStatus } = useModal();
-  const { activeAccount } = useConnect();
-  const { getBondedPool, updateBondedPools } = useBondedPools();
-  const { isOwner, selectedActivePool } = useActivePools();
-  const { getSignerWarnings } = useSignerWarnings();
-  const { globalMaxCommission } = usePoolsConfig();
   const { openHelp } = useHelp();
+  const { api, consts } = useApi();
+  const { activeAccount } = useConnect();
+  const { newBatchCall } = useBatchCall();
+  const { globalMaxCommission } = usePoolsConfig();
+  const { setStatus: setModalStatus } = useModal();
+  const { getSignerWarnings } = useSignerWarnings();
+  const { isOwner, selectedActivePool } = useActivePools();
+  const { getBondedPool, updateBondedPools } = useBondedPools();
   const { expectedBlockTime } = consts;
 
   const poolId = selectedActivePool?.id || 0;
@@ -302,7 +304,7 @@ export const Commission = ({ setSection, incrementCalculateHeight }: any) => {
     if (txs.length === 1) {
       return txs[0];
     }
-    return api.tx.utility.batch(txs);
+    return newBatchCall(txs);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/Unstake/index.tsx
+++ b/src/modals/Unstake/index.tsx
@@ -18,6 +18,7 @@ import { useModal } from 'contexts/Modal';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { getUnixTime } from 'date-fns';
 import { Warning } from 'library/Form/Warning';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
@@ -30,14 +31,15 @@ import { useTranslation } from 'react-i18next';
 
 export const Unstake = () => {
   const { t } = useTranslation('modals');
+  const { newBatchCall } = useBatchCall();
   const { api, network, consts } = useApi();
-  const { units } = network;
-  const { setStatus: setModalStatus, setResize } = useModal();
   const { activeAccount } = useConnect();
-  const { getBondedAccount, getAccountNominations } = useBonded();
-  const { getTransferOptions } = useTransferOptions();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
+  const { getTransferOptions } = useTransferOptions();
+  const { setStatus: setModalStatus, setResize } = useModal();
+  const { getBondedAccount, getAccountNominations } = useBonded();
+  const { units } = network;
 
   const controller = getBondedAccount(activeAccount);
   const nominations = getAccountNominations(activeAccount);
@@ -94,7 +96,7 @@ export const Unstake = () => {
       return api.tx.staking.chill();
     }
     const txs = [api.tx.staking.chill(), api.tx.staking.unbond(bondAsString)];
-    return api.tx.utility.batch(txs);
+    return newBatchCall(txs);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/Unstake/index.tsx
+++ b/src/modals/Unstake/index.tsx
@@ -96,7 +96,7 @@ export const Unstake = () => {
       return api.tx.staking.chill();
     }
     const txs = [api.tx.staking.chill(), api.tx.staking.unbond(bondAsString)];
-    return newBatchCall(txs);
+    return newBatchCall(txs, controller);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/modals/UpdateReserve/index.tsx
+++ b/src/modals/UpdateReserve/index.tsx
@@ -103,15 +103,19 @@ export const UpdateReserve = () => {
                 />
               </h4>
               <h2>
-                {minReserve.isZero()
-                  ? t('none')
-                  : `${minReserve.decimalPlaces(4).toString()} ${unit}`}
-                <ButtonHelp
-                  onClick={() =>
-                    openHelp('Reserve Balance For Existential Deposit')
-                  }
-                  style={{ marginLeft: '0.65rem' }}
-                />
+                {minReserve.isZero() ? (
+                  <>
+                    {t('none')}
+                    <ButtonHelp
+                      onClick={() =>
+                        openHelp('Reserve Balance For Existential Deposit')
+                      }
+                      style={{ marginLeft: '0.65rem' }}
+                    />
+                  </>
+                ) : (
+                  `${minReserve.decimalPlaces(4).toString()} ${unit}`
+                )}
               </h2>
             </CardHeaderWrapper>
 

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -9,6 +9,7 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useSetup } from 'contexts/Setup';
 import { Warning } from 'library/Form/Warning';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
 import { usePayeeConfig } from 'library/Hooks/usePayeeConfig';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Header } from 'library/SetupSteps/Header';
@@ -20,11 +21,14 @@ import { SummaryWrapper } from './Wrapper';
 
 export const Summary = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
-  const { api, network } = useApi();
-  const { activeAccount, activeProxy, accountHasSigner } = useConnect();
-  const { getSetupProgress, removeSetupProgress } = useSetup();
+  const {
+    api,
+    network: { units, unit, name },
+  } = useApi();
+  const { newBatchCall } = useBatchCall();
   const { getPayeeItems } = usePayeeConfig();
-  const { units } = network;
+  const { getSetupProgress, removeSetupProgress } = useSetup();
+  const { activeAccount, activeProxy, accountHasSigner } = useConnect();
 
   const setup = getSetupProgress('nominator', activeAccount);
   const { progress } = setup;
@@ -54,12 +58,12 @@ export const Summary = ({ section }: SetupStepProps) => {
     const bondAsString = bondToSubmit.isNaN() ? '0' : bondToSubmit.toString();
 
     const txs = [
-      ['westend'].includes(network.name)
+      ['westend'].includes(name)
         ? api.tx.staking.bond(bondAsString, payeeToSubmit)
         : api.tx.staking.bond(controllerToSubmit, bondAsString, payeeToSubmit),
       api.tx.staking.nominate(targetsToSubmit),
     ];
-    return api.tx.utility.batch(txs);
+    return newBatchCall(txs);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({
@@ -113,7 +117,7 @@ export const Summary = ({ section }: SetupStepProps) => {
               {t('nominate.bondAmount')}:
             </div>
             <div>
-              {new BigNumber(bond).toFormat()} {network.unit}
+              {new BigNumber(bond).toFormat()} {unit}
             </div>
           </section>
         </SummaryWrapper>

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -63,7 +63,7 @@ export const Summary = ({ section }: SetupStepProps) => {
         : api.tx.staking.bond(controllerToSubmit, bondAsString, payeeToSubmit),
       api.tx.staking.nominate(targetsToSubmit),
     ];
-    return newBatchCall(txs);
+    return newBatchCall(txs, activeAccount);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({

--- a/src/pages/Pools/Create/Summary/index.tsx
+++ b/src/pages/Pools/Create/Summary/index.tsx
@@ -12,6 +12,7 @@ import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useSetup } from 'contexts/Setup';
 import { Warning } from 'library/Form/Warning';
+import { useBatchCall } from 'library/Hooks/useBatchCall';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
@@ -22,13 +23,16 @@ import { SummaryWrapper } from './Wrapper';
 
 export const Summary = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
-  const { api, network } = useApi();
-  const { units } = network;
-  const { activeAccount, activeProxy, accountHasSigner } = useConnect();
-  const { getSetupProgress, removeSetupProgress } = useSetup();
+  const {
+    api,
+    network: { units, unit },
+  } = useApi();
   const { stats } = usePoolsConfig();
+  const { newBatchCall } = useBatchCall();
+  const { getSetupProgress, removeSetupProgress } = useSetup();
   const { queryPoolMember, addToPoolMembers } = usePoolMembers();
   const { queryBondedPool, addToBondedPools } = useBondedPools();
+  const { activeAccount, activeProxy, accountHasSigner } = useConnect();
 
   const { lastPoolId } = stats;
   const poolId = lastPoolId.plus(1);
@@ -58,7 +62,7 @@ export const Summary = ({ section }: SetupStepProps) => {
       api.tx.nominationPools.nominate(poolId.toString(), targetsToSubmit),
       api.tx.nominationPools.setMetadata(poolId.toString(), metadata),
     ];
-    return api.tx.utility.batch(txs);
+    return newBatchCall(txs);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({
@@ -106,7 +110,7 @@ export const Summary = ({ section }: SetupStepProps) => {
               {t('pools.bondAmount')}:
             </div>
             <div>
-              {new BigNumber(bond).toFormat()} {network.unit}
+              {new BigNumber(bond).toFormat()} {unit}
             </div>
           </section>
           <section>

--- a/src/pages/Pools/Create/Summary/index.tsx
+++ b/src/pages/Pools/Create/Summary/index.tsx
@@ -62,7 +62,7 @@ export const Summary = ({ section }: SetupStepProps) => {
       api.tx.nominationPools.nominate(poolId.toString(), targetsToSubmit),
       api.tx.nominationPools.setMetadata(poolId.toString(), metadata),
     ];
-    return newBatchCall(txs);
+    return newBatchCall(txs, activeAccount);
   };
 
   const submitExtrinsic = useSubmitExtrinsic({


### PR DESCRIPTION
Polishing for 1.0.8 release.

- [x] Remove `ButtonHelp` from UpdateReserve ED if ED is not None.
- [x] Automatically import Polkadot Vault addresses if they are valid from QR.
- [x] Move `getProxySupported` from `useSubmitExtrinsic` into a new `useProxySupported` hook.
- [x] Move `buildPayload` from `useSubmitExtrinsic` into a new `useBuildPayload` hook.
- [x] Make `tx` a ref in `useSubmitExtrinsic` and unify `useEffect` updates upon changes to `tx` prop.
- [x] `proxy.proxy` to wrap each batch call when there is an active proxy account.
- [x] Activate Ledger support for batch calls.