### PR TITLE
Add defaultFeeReserve

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -67,6 +67,7 @@ export const NetworkList: Networks = {
       ...DefaultParams,
       stakeTarget: 0.75,
     },
+    defaultFeeReserve: 0.1,
   },
   kusama: {
     name: 'kusama',
@@ -122,6 +123,7 @@ export const NetworkList: Networks = {
       auctionMax: 60,
       stakeTarget: 0.75,
     },
+    defaultFeeReserve: 0.05,
   },
   westend: {
     name: 'westend',
@@ -175,5 +177,6 @@ export const NetworkList: Networks = {
       ...DefaultParams,
       stakeTarget: 0.75,
     },
+    defaultFeeReserve: 0.1,
   },
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,7 @@ export interface Network {
     priceTicker: string;
   };
   params: Record<string, number>;
+  defaultFeeReserve: number;
 }
 
 export interface PageCategory {


### PR DESCRIPTION
Adds default fee reserves to each network. 0.1 for DOT and WND, 0.05 for KSM, ensuring that accounts will have some funds to pay for tx fees by default.