### PR TITLE
Fix `bond`, `setController` for Kusama 0.9.43

### DIFF
--- a/src/modals/UpdateController/index.tsx
+++ b/src/modals/UpdateController/index.tsx
@@ -35,7 +35,7 @@ export const UpdateController = () => {
     const controllerToSubmit = {
       Id: activeAccount ?? '',
     };
-    tx = ['westend'].includes(network.name)
+    tx = ['westend', 'kusama'].includes(network.name)
       ? api.tx.staking.setController()
       : api.tx.staking.setController(controllerToSubmit);
     return tx;

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -58,7 +58,7 @@ export const Summary = ({ section }: SetupStepProps) => {
     const bondAsString = bondToSubmit.isNaN() ? '0' : bondToSubmit.toString();
 
     const txs = [
-      ['westend'].includes(name)
+      ['westend', 'kusama'].includes(name)
         ? api.tx.staking.bond(bondAsString, payeeToSubmit)
         : api.tx.staking.bond(controllerToSubmit, bondAsString, payeeToSubmit),
       api.tx.staking.nominate(targetsToSubmit),


### PR DESCRIPTION
Fixes the removal of controller arguments for Kusama 0.9.43.