### PR TITLE
Add Dockerfile, script and doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:buster as BUILDER
+
+WORKDIR /app
+COPY . .
+RUN apt update && apt install -y git
+RUN yarn install && yarn build
+
+# --------------------------------------------------
+FROM nginx
+
+COPY --from=BUILDER /app/build /usr/share/nginx/html
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ staking.polkadot.network/#/overview?n=kusama&l=cn
 ## Presentations
 
 - 30/06/2022: [[Video] Polkadot Decoded 2022: Polkadot Staking Dashboard Demo](https://youtu.be/H1WGu6mf1Ls)
+
+## Using containers
+
+You may build a container using:
+```
+./scripts/build-container.sh
+```
+
+then run your container with:
+```
+podman run --d -p 8080:80 localhost/polkadot-staking-dashboard
+```
+and access the **Staking Dashboard** at http://localhost:8080/

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+podman build \
+    -t polkadot-staking-dashboard \
+    -t psd \
+    .


### PR DESCRIPTION
This PR adds a Dockerfile.

I did build the image and pushed it to my account to allow testing.
The end product can be tested with:
```
podman run --name staking-dashboard --rm -it -p 8080:80 docker.io/chevdor/polkadot-staking-dashboard
open http://localhost:8080/
```
