### PR TITLE
Fetch initial chain meta, store in API

### DIFF
--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -24,11 +24,7 @@ export const consts: APIConstants = {
   poolsPalletId: stringToU8a('0'),
 };
 
-export const chainState: APIChainState = {
-  chain: undefined,
-  version: undefined,
-  ss58Prefix: undefined,
-};
+export const chainState: APIChainState = undefined;
 
 export const defaultApiContext: APIContextInterface = {
   // eslint-disable-next-line

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -4,7 +4,11 @@
 import { stringToU8a } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { NetworkList } from 'config/networks';
-import type { APIConstants, APIContextInterface } from 'contexts/Api/types';
+import type {
+  APIChainState,
+  APIConstants,
+  APIContextInterface,
+} from 'contexts/Api/types';
 
 export const consts: APIConstants = {
   bondDuration: new BigNumber(0),
@@ -20,6 +24,11 @@ export const consts: APIConstants = {
   poolsPalletId: stringToU8a('0'),
 };
 
+export const chainState: APIChainState = {
+  chain: undefined,
+  version: undefined,
+};
+
 export const defaultApiContext: APIContextInterface = {
   // eslint-disable-next-line
   switchNetwork: async (n, lc) => {
@@ -27,6 +36,7 @@ export const defaultApiContext: APIContextInterface = {
   },
   api: null,
   consts,
+  chainState,
   isLightClient: false,
   isReady: false,
   apiStatus: 'disconnected',

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -27,6 +27,7 @@ export const consts: APIConstants = {
 export const chainState: APIChainState = {
   chain: undefined,
   version: undefined,
+  ss58Prefix: undefined,
 };
 
 export const defaultApiContext: APIContextInterface = {

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -4,11 +4,7 @@
 import { stringToU8a } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { NetworkList } from 'config/networks';
-import type {
-  APIChainState,
-  APIConstants,
-  APIContextInterface,
-} from 'contexts/Api/types';
+import type { APIConstants, APIContextInterface } from 'contexts/Api/types';
 
 export const consts: APIConstants = {
   bondDuration: new BigNumber(0),
@@ -24,8 +20,6 @@ export const consts: APIConstants = {
   poolsPalletId: stringToU8a('0'),
 };
 
-export const chainState: APIChainState = undefined;
-
 export const defaultApiContext: APIContextInterface = {
   // eslint-disable-next-line
   switchNetwork: async (n, lc) => {
@@ -33,7 +27,7 @@ export const defaultApiContext: APIContextInterface = {
   },
   api: null,
   consts,
-  chainState,
+  chainState: undefined,
   isLightClient: false,
   isReady: false,
   apiStatus: 'disconnected',

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -98,9 +98,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   );
 
   // Store chain state.
-  const [chainState, setchainState] = useState<APIChainState>(
-    defaults.chainState
-  );
+  const [chainState, setchainState] = useState<APIChainState>(undefined);
 
   // Store whether in light client mode.
   const [isLightClient, setIsLightClient] = useState<boolean>(

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -179,19 +179,29 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     setApiStatus('connected');
 
     const newChainState = await Promise.all([
-      newApi.rpc.system.chain(),
-      newApi.rpc.system.version(),
+      newApi.query.system.chain(),
+      newApi.query.system.version(),
+      newApi.query.system.ss58Prefix(),
     ]);
 
-    const chain = newChainState[0].toHuman();
-    const version = newChainState[1].toHuman();
+    // check that chain values have been fetched before committing to state.
+    // could be expanded to check supported chains.
+    if (
+      newChainState.every((c) => {
+        return !!c?.toHuman();
+      })
+    ) {
+      const chain = newChainState[0]?.toString();
+      const version = newChainState[1]?.toString();
+      const ss58Prefix = Number(newChainState[1]?.toString());
+
+      // set fetched chain state in storage.
+      setchainState({ chain, version, ss58Prefix });
+    }
 
     // store active network in localStorage.
     // NOTE: this should ideally refer to above `chain` value.
     localStorage.setItem('network', String(network.name));
-
-    // set fetched chain state in storage.
-    setchainState({ chain, version });
 
     // Assume chain state is correct and bootstrap network consts.
     connectedCallback(newApi);

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -179,9 +179,9 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     setApiStatus('connected');
 
     const newChainState = await Promise.all([
-      newApi.query.system.chain(),
-      newApi.query.system.version(),
-      newApi.query.system.ss58Prefix(),
+      newApi.rpc.system.chain(),
+      newApi.rpc.system.version(),
+      newApi.consts.system.ss58Prefix,
     ]);
 
     // check that chain values have been fetched before committing to state.
@@ -193,7 +193,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     ) {
       const chain = newChainState[0]?.toString();
       const version = newChainState[1]?.toString();
-      const ss58Prefix = Number(newChainState[1]?.toString());
+      const ss58Prefix = Number(newChainState[2]?.toString());
 
       // set fetched chain state in storage.
       setchainState({ chain, version, ss58Prefix });

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -26,10 +26,16 @@ export interface APIConstants {
   poolsPalletId: U8aLike;
 }
 
+export interface APIChainState {
+  chain: string | undefined;
+  version: string | undefined;
+}
+
 export interface APIContextInterface {
   switchNetwork: (n: NetworkName, l: boolean) => Promise<void>;
   api: ApiPromise | null;
   consts: APIConstants;
+  chainState: APIChainState;
   isReady: boolean;
   isLightClient: boolean;
   apiStatus: ApiStatus;

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -26,11 +26,13 @@ export interface APIConstants {
   poolsPalletId: U8aLike;
 }
 
-export interface APIChainState {
-  chain: string | undefined;
-  version: string | undefined;
-  ss58Prefix: number | undefined;
-}
+export type APIChainState =
+  | {
+      chain: string;
+      version: string;
+      ss58Prefix: number;
+    }
+  | undefined;
 
 export interface APIContextInterface {
   switchNetwork: (n: NetworkName, l: boolean) => Promise<void>;

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -29,6 +29,7 @@ export interface APIConstants {
 export interface APIChainState {
   chain: string | undefined;
   version: string | undefined;
+  ss58Prefix: number | undefined;
 }
 
 export interface APIContextInterface {


### PR DESCRIPTION
Continues what #1185 started.

Stores `chain`, `version` and `ss58Prefix` in chain state.