### PR TITLE
Add `useEffectIgnoreInitial` hook 

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -30,6 +30,7 @@ import type {
 } from 'contexts/Api/types';
 import React, { useEffect, useState } from 'react';
 import type { AnyApi, NetworkName } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 
 export const APIProvider = ({ children }: { children: React.ReactNode }) => {
@@ -138,7 +139,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   // Dynamically load `Sc` when user opts to use light client.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isLightClient) {
       setApiStatus('connecting');
       const { promise: ScPromise, cancel } = makeCancelable(
@@ -154,7 +155,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   }, [isLightClient, network.name]);
 
   // Initialise provider event handlers when provider is set.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (provider) {
       provider.on('connected', () => {
         setApiStatus('connected');

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -12,8 +12,9 @@ import {
 import BigNumber from 'bignumber.js';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { getLedger } from './Utils';
 import * as defaults from './defaults';
 import type {
@@ -173,14 +174,14 @@ export const BalancesProvider = ({
   };
 
   // fetch account balances & ledgers. Remove or add subscriptions
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       handleSyncAccounts();
     }
   }, [accounts, network, isReady]);
 
   // Unsubscribe from subscriptions on network change & unmount.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     unsubAll();
     return () => unsubAll();
   }, [network]);

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -12,6 +12,7 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import React, { useEffect, useRef, useState } from 'react';
 import type { AnyApi, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 import type { BondedAccount, BondedContextInterface } from './types';
 
@@ -61,19 +62,20 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   // Handle accounts sync on connected accounts change.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       handleSyncAccounts();
     }
   }, [accounts, network, isReady]);
 
   // Unsubscribe from subscriptions on unmount.
-  useEffect(() => {
-    return () =>
+  useEffect(
+    () => () =>
       Object.values(unsubs.current).forEach((unsub) => {
         unsub();
-      });
-  }, []);
+      }),
+    []
+  );
 
   // Subscribe to account, get controller and nominations.
   const subscribeToBondedAccount = async (address: string) => {

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -27,6 +27,7 @@ import {
 } from 'contexts/Hardware/Utils';
 import React, { useEffect, useRef, useState } from 'react';
 import type { AnyApi, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useImportExtension } from './Hooks/useImportExtension';
 import {
   extensionIsLocal,
@@ -139,7 +140,7 @@ export const ConnectProvider = ({
 
   // once initialised extensions equal total extensions present in
   // `injectedWeb3`, mark extensions as fetched
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (!checkingInjectedWeb3) {
       if (extensionsInitialisedRef.current.length === extensions?.length || 0) {
         setExtensionsFetched(true);
@@ -149,7 +150,7 @@ export const ConnectProvider = ({
 
   // once extensions are fully initialised, fetch any external accounts present
   // in localStorage.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (extensionsFetched) {
       importVaultAccounts();
       importLedgerAccounts();
@@ -160,7 +161,7 @@ export const ConnectProvider = ({
   }, [extensionsFetched]);
 
   // account fetching complete, mark accounts as initialised.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (extensionsFetched && hardwareInitialisedRef.current === true) {
       accountsInitialisedRef.current = true;
     }

--- a/src/contexts/FastUnstake/index.tsx
+++ b/src/contexts/FastUnstake/index.tsx
@@ -12,9 +12,10 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useNetworkMetrics } from 'contexts/Network';
 import { useStaking } from 'contexts/Staking';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyJson, MaybeAccount } from 'types';
 import Worker from 'workers/stakers?worker';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { defaultFastUnstakeContext, defaultMeta } from './defaults';
 import type {
   FastUnstakeContextInterface,
@@ -71,7 +72,7 @@ export const FastUnstakeProvider = ({
   const checkToEra = activeEra.index.minus(bondDuration);
 
   // initiate fast unstake check for accounts that are nominating but not active.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (
       isReady &&
       activeAccount &&

--- a/src/contexts/Help/index.tsx
+++ b/src/contexts/Help/index.tsx
@@ -1,8 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { MaybeString } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 import type {
   HelpContextInterface,
@@ -18,7 +19,7 @@ export const HelpProvider = ({ children }: HelpContextProps) => {
   });
 
   // when fade out completes, reset active definiton
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (state.status === 0) {
       setState({
         ...state,

--- a/src/contexts/Migrate/index.tsx
+++ b/src/contexts/Migrate/index.tsx
@@ -6,7 +6,8 @@ import { AppVersion } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useUi } from 'contexts/UI';
-import React, { useEffect, useState } from 'react';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
+import React, { useState } from 'react';
 
 export const MigrateProvider = ({
   children,
@@ -43,7 +44,7 @@ export const MigrateProvider = ({
       localStorage.removeItem(`${n.name}_active_proxy`);
     });
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady && !isNetworkSyncing && !done) {
       // Carry out migrations if local version is different to current version.
       if (localAppVersion !== AppVersion) {

--- a/src/contexts/Modal/index.tsx
+++ b/src/contexts/Modal/index.tsx
@@ -3,7 +3,8 @@
 
 import { setStateWithRef } from '@polkadotcloud/utils';
 import { useTxMeta } from 'contexts/TxMeta';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { defaultModalContext } from './defaults';
 import type { ModalConfig, ModalContextInterface, ModalOptions } from './types';
 
@@ -28,7 +29,7 @@ export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
   // Store the modal's resize counter.
   const [resize, setModalResize] = useState<number>(0);
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setResize();
   }, [statusRef.current, notEnoughFunds]);
 

--- a/src/contexts/Network/index.tsx
+++ b/src/contexts/Network/index.tsx
@@ -3,8 +3,9 @@
 
 import { setStateWithRef } from '@polkadotcloud/utils';
 import BigNumber from 'bignumber.js';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyJson } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import * as defaults from './defaults';
 import type {
@@ -121,7 +122,7 @@ export const NetworkMetricsProvider = ({
   };
 
   // manage unsubscribe
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     initialiseSubscriptions();
     return () => {
       unsubscribe();
@@ -129,7 +130,7 @@ export const NetworkMetricsProvider = ({
   }, [isReady]);
 
   // Reset active era and metrics on network change.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     handleResetMetrics();
   }, [network]);
 

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -72,25 +72,6 @@ export const ActivePoolsProvider = ({
   // Should default to the membership pool (if present).
   const [selectedPoolId, setSelectedPoolId] = useState<string | null>(null);
 
-  // re-sync when number of accountRoles change.
-  // this can happen when bondedPools sync, when roles
-  // are edited within the dashboard, or when pool
-  // membership changes.
-  useEffect(() => {
-    unsubscribeActivePools();
-    unsubscribePoolNominations();
-
-    setStateWithRef('unsynced', setSynced, syncedRef);
-  }, [activeAccount, accountPools.length]);
-
-  // subscribe to pool that the active account is a member of.
-  useEffect(() => {
-    if (isReady && syncedRef.current === 'unsynced') {
-      setStateWithRef('syncing', setSynced, syncedRef);
-      handlePoolSubscriptions();
-    }
-  }, [network, isReady, syncedRef.current]);
-
   const getActivePoolMembership = () =>
     // get the activePool that the active account
     activePoolsRef.current.find((a) => {
@@ -460,6 +441,24 @@ export const ActivePoolsProvider = ({
       getActivePoolMembership()?.id || 0
     );
   };
+
+  // re-sync when number of accountRoles change.
+  // this can happen when bondedPools sync, when roles
+  // are edited within the dashboard, or when pool
+  // membership changes.
+  useEffectIgnoreInitial(() => {
+    unsubscribeActivePools();
+    unsubscribePoolNominations();
+    setStateWithRef('unsynced', setSynced, syncedRef);
+  }, [activeAccount, accountPools.length]);
+
+  // subscribe to pool that the active account is a member of.
+  useEffectIgnoreInitial(() => {
+    if (isReady && syncedRef.current === 'unsynced') {
+      setStateWithRef('syncing', setSynced, syncedRef);
+      handlePoolSubscriptions();
+    }
+  }, [network, isReady, syncedRef.current]);
 
   // unsubscribe all on component unmount
   useEffect(

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -11,6 +11,7 @@ import type {
 import { useStaking } from 'contexts/Staking';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { AnyApi, AnyJson, Sync } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import { useBondedPools } from '../BondedPools';
@@ -470,7 +471,7 @@ export const ActivePoolsProvider = ({
   );
 
   // re-calculate pending rewards when membership changes
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     updatePendingRewards();
   }, [
     network,
@@ -482,7 +483,7 @@ export const ActivePoolsProvider = ({
 
   // when we are subscribed to all active pools, syncing is considered
   // completed.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (unsubNominations.current.length === accountPools.length) {
       setStateWithRef('synced', setSynced, syncedRef);
     }

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -10,8 +10,9 @@ import type {
   NominationStatuses,
 } from 'contexts/Pools/types';
 import { useStaking } from 'contexts/Staking';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyMetaBatch, Fn, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../../Api';
 import { usePoolsConfig } from '../PoolsConfig';
 import { defaultBondedPoolsContext } from './defaults';
@@ -37,13 +38,13 @@ export const BondedPoolsProvider = ({
   const [bondedPools, setBondedPools] = useState<BondedPool[]>([]);
 
   // clear existing state for network refresh
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setBondedPools([]);
     setStateWithRef({}, setPoolMetaBatch, poolMetaBatchesRef);
   }, [network]);
 
   // initial setup for fetching bonded pools
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       // fetch bonded pools
       fetchBondedPools();
@@ -54,7 +55,7 @@ export const BondedPoolsProvider = ({
   }, [network, isReady, lastPoolId]);
 
   // after bonded pools have synced, fetch metabatch
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (bondedPools.length) {
       fetchPoolsMetaBatch('bonded_pools', bondedPools, true);
     }

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -5,8 +5,9 @@ import { setStateWithRef } from '@polkadotcloud/utils';
 import { useConnect } from 'contexts/Connect';
 import { usePlugins } from 'contexts/Plugins';
 import type { PoolMember, PoolMemberContext } from 'contexts/Pools/types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyMetaBatch, Fn, MaybeAccount, Sync } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../../Api';
 import { defaultPoolMembers } from './defaults';
 
@@ -42,19 +43,19 @@ export const PoolMembersProvider = ({
   };
 
   // Clear existing state for network refresh
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setPoolMembersNode([]);
     unsubscribeAndResetMeta();
   }, [network]);
 
   // Clear meta state when activeAccount changes
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     unsubscribeAndResetMeta();
   }, [activeAccount]);
 
   // Initial setup for fetching members if Subscan is not enabled. Ensure poolMembers are reset if
   // subscan is disabled.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (!pluginEnabled('subscan')) {
       if (isReady) fetchPoolMembers();
     } else {

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -11,6 +11,7 @@ import type {
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AnyApi, Fn } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import * as defaults from './defaults';
@@ -31,7 +32,7 @@ export const PoolMembershipsProvider = ({
   // stores pool subscription objects
   const poolMembershipUnsubs = useRef<AnyApi[]>([]);
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       (() => {
         setStateWithRef([], setPoolMemberships, poolMembershipsRef);

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -10,8 +10,9 @@ import type {
   PoolConfigState,
   PoolsConfigContextState,
 } from 'contexts/Pools/types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../../Api';
 import * as defaults from './defaults';
 
@@ -41,7 +42,7 @@ export const PoolsConfigProvider = ({
   // stores the user's favorite pools
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites());
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       subscribeToPoolConfig();
     }

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -15,8 +15,9 @@ import BigNumber from 'bignumber.js';
 import { isSupportedProxy } from 'config/proxies';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 import type {
   Delegates,
@@ -166,7 +167,7 @@ export const ProxiesProvider = ({
       ?.delegates.find((d) => d.delegate === delegate) ?? null;
 
   // Subscribe new accounts to proxies, and remove accounts that are no longer imported.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       handleSyncAccounts();
     }
@@ -174,7 +175,7 @@ export const ProxiesProvider = ({
 
   // If active proxy has not yet been set, check local storage `activeProxy` & set it as active
   // proxy if it is the delegate of `activeAccount`.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     const localActiveProxy = localStorageOrDefault(
       `${network.name}_active_proxy`,
       null
@@ -211,7 +212,7 @@ export const ProxiesProvider = ({
   }, [accounts, activeAccount, proxiesRef.current, network]);
 
   // Reset active proxy state, unsubscribe from subscriptions on network change & unmount.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setActiveProxy(null, false);
     unsubAll();
     return () => unsubAll();
@@ -225,7 +226,7 @@ export const ProxiesProvider = ({
   };
 
   // Listens to `proxies` state updates and reformats the data into a list of delegates.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     // Reformat proxiesRef.current into a list of delegates.
     const newDelegates: Delegates = {};
     for (const proxy of proxiesRef.current) {

--- a/src/contexts/Setup/index.tsx
+++ b/src/contexts/Setup/index.tsx
@@ -7,8 +7,9 @@ import {
   unitToPlanck,
 } from '@polkadotcloud/utils';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { BondFor, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
 import { useStaking } from '../Staking';
@@ -206,7 +207,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   // Move away from setup pages on completion / network change.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (!inSetup()) {
       setOnNominatorSetup(false);
     }
@@ -215,8 +216,8 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, [inSetup(), network, poolMembership]);
 
-  // update setup state when activeAccount changes
-  useEffect(() => {
+  // Update setup state when activeAccount changes
+  useEffectIgnoreInitial(() => {
     if (accounts.length) refreshSetups();
   }, [activeAccount, network, accounts]);
 

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -20,10 +20,11 @@ import type {
   StakingMetrics,
   StakingTargets,
 } from 'contexts/Staking/types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyJson, MaybeAccount } from 'types';
 import Worker from 'workers/stakers?worker';
 import type { ResponseInitialiseExposures } from 'workers/types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import { useBonded } from '../Bonded';
 import { useConnect } from '../Connect';
@@ -79,7 +80,7 @@ export const StakingProvider = ({
     ) as StakingTargets
   );
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (apiStatus === 'connecting') {
       setStateWithRef(defaultEraStakers, setEraStakers, eraStakersRef);
       setStakingMetrics(stakingMetrics);
@@ -87,7 +88,7 @@ export const StakingProvider = ({
   }, [apiStatus]);
 
   // handle staking metrics subscription
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       unsubscribeMetrics();
       subscribeToStakingkMetrics();
@@ -106,13 +107,13 @@ export const StakingProvider = ({
   };
 
   // handle syncing with eraStakers
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       fetchEraStakers();
     }
   }, [isReady, activeEra.index, activeAccount]);
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (activeAccount) {
       // set account's targets
       setTargetsState(

--- a/src/contexts/Subscan/index.tsx
+++ b/src/contexts/Subscan/index.tsx
@@ -13,9 +13,10 @@ import { format, fromUnixTime } from 'date-fns';
 import { sortNonZeroPayouts } from 'library/Graphs/Utils';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
 import { locales } from 'locale';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AnyApi, AnySubscan } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
 import { usePlugins } from '../Plugins';
@@ -73,26 +74,26 @@ export const SubscanProvider = ({
   };
 
   // Fetch payouts on plugins toggle.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
   }, [plugins, activeEra]);
 
   // Reset payouts on network switch.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     resetPayouts();
   }, [network]);
 
   // Fetch payouts as soon as network is ready.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady && isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
   }, [isReady, network, activeAccount, activeEra]);
 
   // Store start and end date of fetched payouts.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     const filteredPayouts = sortNonZeroPayouts(payouts, poolClaims, true);
     if (filteredPayouts.length) {
       setPayoutsFromDate(

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -9,8 +9,9 @@ import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useNetworkMetrics } from 'contexts/Network';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 import type { TransferOptions, TransferOptionsContextInterface } from './types';
 
@@ -47,7 +48,7 @@ export const TransferOptionsProvider = ({
   );
 
   // Update an account's reserve amount on account or network change.
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setFeeReserve(getFeeReserveLocalStorage(activeAccount));
   }, [activeAccount, name]);
 

--- a/src/contexts/TxMeta/index.tsx
+++ b/src/contexts/TxMeta/index.tsx
@@ -7,8 +7,9 @@ import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { AnyJson, MaybeAccount } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import * as defaults from './defaults';
 import type { TxMetaContextInterface } from './types';
 
@@ -41,7 +42,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   const [txSignature, setTxSignatureState] = useState<AnyJson>(null);
   const txSignatureRef = React.useRef(txSignature);
 
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     const { freeBalance } = getTransferOptions(sender);
     setNotEnoughFunds(freeBalance.minus(txFees).isLessThan(0));
   }, [txFees, sender]);

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -8,6 +8,7 @@ import { useBalances } from 'contexts/Balances';
 import type { ImportedAccount } from 'contexts/Connect/types';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import React, { useEffect, useRef, useState } from 'react';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
 import { useNetworkMetrics } from '../Network';
@@ -117,7 +118,7 @@ export const UIProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   // re-configure minimised on user change
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     resizeCallback();
   }, [userSideMenuMinimised]);
 

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -17,8 +17,9 @@ import type {
   ValidatorAddresses,
   ValidatorsContextInterface,
 } from 'contexts/Validators/types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import type { AnyApi, AnyMetaBatch, Fn } from 'types';
+import { useEffectIgnoreInitial } from 'library/Hooks/useEffectIgnoreInitial';
 import { useApi } from '../Api';
 import { useBonded } from '../Bonded';
 import { useConnect } from '../Connect';
@@ -96,7 +97,7 @@ export const ValidatorsProvider = ({
   const [validatorCommunity] = useState<any>([...shuffle(ValidatorCommunity)]);
 
   // reset validators list on network change
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setFetchedValidators(0);
     setSessionValidators(defaultSessionValidators);
     setSessionParachainValidators(defaultSessionParachainValidators);
@@ -106,7 +107,7 @@ export const ValidatorsProvider = ({
   }, [network]);
 
   // fetch validators and session validators when activeEra ready
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       fetchValidators();
       subscribeSessionValidators();
@@ -120,22 +121,22 @@ export const ValidatorsProvider = ({
     };
   }, [isReady, activeEra]);
 
-  // fetch parachain session validators when earliestStoredSession ready
-  useEffect(() => {
+  // fetch parachain session validators when `earliestStoredSession` ready
+  useEffectIgnoreInitial(() => {
     if (isReady && greaterThanZero(earliestStoredSession)) {
       subscribeParachainValidators();
     }
   }, [isReady, earliestStoredSession]);
 
   // pre-populating validator meta batches. Needed for generating nominations
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (validators.length > 0) {
       fetchValidatorMetaBatch('validators_browse', validators, true);
     }
   }, [isReady, validators]);
 
   // fetch active account's nominations in validator list format
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady && activeAccount) {
       fetchNominatedList();
     }
@@ -162,7 +163,7 @@ export const ValidatorsProvider = ({
   };
 
   // fetch active account's pool nominations in validator list format
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady && poolNominations) {
       fetchPoolNominatedList();
     }
@@ -183,12 +184,12 @@ export const ValidatorsProvider = ({
   };
 
   // re-fetch favorites on network change
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     setFavorites(getFavorites());
   }, [network]);
 
   // fetch favorites in validator list format
-  useEffect(() => {
+  useEffectIgnoreInitial(() => {
     if (isReady) {
       fetchFavoriteList();
     }

--- a/src/library/Hooks/useEffectIgnoreInitial/index.tsx
+++ b/src/library/Hooks/useEffectIgnoreInitial/index.tsx
@@ -1,0 +1,19 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useRef } from 'react';
+import type { AnyApi, AnyFunction } from 'types';
+
+export const useEffectIgnoreInitial = (fn: AnyFunction, deps: AnyApi[]) => {
+  const isInitial = useRef<boolean>(true);
+
+  useEffect(
+    () => {
+      if (!isInitial.current) {
+        fn();
+      }
+      isInitial.current = false;
+    },
+    deps ? [...deps] : undefined
+  );
+};


### PR DESCRIPTION
Addresses #1204.

Introduces a hook that ignores `useEffect` logic on the first render.

Cuts down on logic being executed when it is guaranteed to fail (due to API state not yet being synced).