### PR TITLE
Re-org some Modal wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@polkadot/util": "^12.1.1",
     "@polkadot/util-crypto": "12.3.2",
     "@polkadotcloud/community": "0.1.2",
-    "@polkadotcloud/core-ui": "^0.3.59",
+    "@polkadotcloud/core-ui": "^0.3.60",
     "@polkadotcloud/react-odometer": "^0.1.17",
     "@polkadotcloud/themes": "^0.1.2",
     "@polkadotcloud/utils": "^0.2.22",

--- a/src/library/Help/Wrappers.ts
+++ b/src/library/Help/Wrappers.ts
@@ -4,87 +4,6 @@
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
-// Blurred background modal wrapper
-export const Wrapper = styled(motion.div)`
-  background: var(--modal-background-color);
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  z-index: 10;
-  backdrop-filter: blur(14px);
-
-  > div {
-    height: 100%;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: center;
-    align-items: center;
-    padding: 0 2rem;
-
-    /* click anywhere behind modal content to close */
-    .close {
-      position: fixed;
-      width: 100%;
-      height: 100%;
-      z-index: 8;
-      cursor: default;
-    }
-  }
-`;
-
-export const HeightWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  max-width: 800px;
-  z-index: 9;
-  position: relative;
-  overflow: scroll;
-
-  /* Hide scrollbar for Chrome, Safari and Opera */
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`;
-
-export const ContentWrapper = styled.div`
-  width: 100%;
-  height: auto;
-  overflow: hidden;
-  position: relative;
-  padding: 5rem 0;
-
-  > .buttons {
-    width: 100%;
-    display: flex;
-    flex-flow: row wrap;
-    margin-bottom: 2rem;
-    position: relative;
-
-    > button {
-      > svg {
-        margin-right: 0.5rem;
-      }
-      color: var(--network-color-primary);
-      border: 1px solid var(--network-color-primary);
-      border-radius: 1.5rem;
-      padding: 0.4rem 0.8rem;
-      margin-right: 1.25rem;
-      margin-left: 0;
-    }
-  }
-
-  h1 {
-    font-family: 'Unbounded', 'sans-serif', sans-serif;
-    margin-bottom: 1.75rem;
-  }
-
-  h3 {
-    margin: 2rem 0.5rem 1rem 0.5rem;
-  }
-`;
-
 export const ListWrapper = styled(motion.div)`
   display: flex;
   flex-flow: row wrap;
@@ -118,16 +37,17 @@ export const ListWrapper = styled(motion.div)`
 
 export const DefinitionWrapper = styled(motion.div)`
   background: var(--background-floating-card);
-  width: 100%;
-  display: flex;
   border-radius: 1.5rem;
-  margin-bottom: 1.25rem;
-  padding: 1.5rem 1.5rem 0 1.5rem;
+  display: flex;
   flex-flow: row wrap;
   align-items: center;
+  flex: 1;
   position: relative;
   overflow: hidden;
-  flex: 1;
+  margin-bottom: 1.25rem;
+  padding: 1.5rem 1.5rem 0 1.5rem;
+  transition: all 0.2s;
+  width: 100%;
 
   button {
     padding: 0;
@@ -147,7 +67,8 @@ export const DefinitionWrapper = styled(motion.div)`
   }
 
   h4 {
-    margin-bottom: 1.25rem;
+    font-family: InterSemiBold, sans-serif;
+    margin-bottom: 1.15rem;
   }
 
   p {
@@ -178,15 +99,15 @@ export const ItemWrapper = styled(motion.div)<any>`
     margin-bottom: 1.5rem;
     position: relative;
 
+    > h2 {
+      color: var(--text-color-primary);
+      text-align: left;
+    }
     > h4 {
       color: var(--text-color-primary);
       margin: 0.65rem 0;
       text-transform: uppercase;
       font-size: 0.7rem;
-    }
-    > h2 {
-      color: var(--text-color-primary);
-      text-align: left;
     }
 
     > p {

--- a/src/library/Help/index.tsx
+++ b/src/library/Help/index.tsx
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { faChevronLeft, faTimes } from '@fortawesome/free-solid-svg-icons';
-import { ButtonPrimaryInvert } from '@polkadotcloud/core-ui';
+import {
+  ButtonPrimaryInvert,
+  ModalCanvas,
+  ModalContent,
+  ModalScroll,
+} from '@polkadotcloud/core-ui';
 import { camelize } from '@polkadotcloud/utils';
 import { HelpConfig } from 'config/help';
 import { DefaultLocale } from 'consts';
@@ -18,7 +23,6 @@ import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Definition } from './Items/Definition';
 import { External } from './Items/External';
-import { ContentWrapper, HeightWrapper, Wrapper } from './Wrappers';
 
 export const Help = () => {
   const { t, i18n } = useTranslation('help');
@@ -140,7 +144,7 @@ export const Help = () => {
   });
 
   return (
-    <Wrapper
+    <ModalCanvas
       initial={{
         opacity: 0,
       }}
@@ -150,9 +154,9 @@ export const Help = () => {
       }}
       variants={variants}
     >
-      <div>
-        <HeightWrapper>
-          <ContentWrapper>
+      <div className="inner">
+        <ModalScroll>
+          <ModalContent>
             <div className="buttons">
               {definition && (
                 <ButtonPrimaryInvert
@@ -217,8 +221,8 @@ export const Help = () => {
                 ))}
               </>
             )}
-          </ContentWrapper>
-        </HeightWrapper>
+          </ModalContent>
+        </ModalScroll>
         <button
           type="button"
           className="close"
@@ -229,6 +233,6 @@ export const Help = () => {
           &nbsp;
         </button>
       </div>
-    </Wrapper>
+    </ModalCanvas>
   );
 };

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -4,7 +4,7 @@
 import {
   ModalBackground,
   ModalContainer,
-  ModalContent,
+  ModalCard,
   ModalHeight,
 } from '@polkadotcloud/core-ui';
 import { useModal } from 'contexts/Modal';
@@ -153,7 +153,7 @@ export const Modal = () => {
                     : 'hidden',
               }}
             >
-              <ModalContent ref={modalRef}>
+              <ModalCard ref={modalRef}>
                 <ErrorBoundary FallbackComponent={ErrorFallbackModal}>
                   {modal === 'AccountPoolRoles' && <AccountPoolRoles />}
                   {modal === 'Bio' && <Bio />}
@@ -189,7 +189,7 @@ export const Modal = () => {
                   {modal === 'UpdateReserve' && <UpdateReserve />}
                   {modal === 'WithdrawPoolMember' && <WithdrawPoolMember />}
                 </ErrorBoundary>
-              </ModalContent>
+              </ModalCard>
             </ModalHeight>
             <button
               type="button"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,10 +1832,10 @@
   resolved "https://registry.npmjs.org/@polkadotcloud/community/-/community-0.1.2.tgz#d693b89d42ba4ac70abf1c61cfb6b0667ad8130f"
   integrity sha512-vKJXcCTonXolrd3tN8lbta4Qp69XR6yzU/BM1FOMfiA6C2Q2oGDVYBiTL2BOi8XLXWzsu3SaagG4WulO9ZlPSg==
 
-"@polkadotcloud/core-ui@^0.3.59":
-  version "0.3.59"
-  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.3.59.tgz#3791d0af45326692aa13012543b08e1778235bbb"
-  integrity sha512-tNaYTRWlKPISpsq51WPvm/DFpgwC1DRPH13U6BTWUC0b13fgepYvO/doBfg3AzmroOe7Q/eytrZAMY+dYuFQ8w==
+"@polkadotcloud/core-ui@^0.3.60":
+  version "0.3.60"
+  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.3.60.tgz#e0cd0e7f527a819cabbe2acbd60feebd9ced519e"
+  integrity sha512-pJgK/gUmT+LSQgYBRT7yd7aZO3bUCTK6e8ji0RWdj/P+YtKNYkSqXKUJogHgk4a9YRjGhCeylniLAreHg4FyRQ==
 
 "@polkadotcloud/react-odometer@^0.1.17":
   version "0.1.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,7 +1834,7 @@
 
 "@polkadotcloud/core-ui@^0.3.59":
   version "0.3.59"
-  resolved "https://registry.yarnpkg.com/@polkadotcloud/core-ui/-/core-ui-0.3.59.tgz#3791d0af45326692aa13012543b08e1778235bbb"
+  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.3.59.tgz#3791d0af45326692aa13012543b08e1778235bbb"
   integrity sha512-tNaYTRWlKPISpsq51WPvm/DFpgwC1DRPH13U6BTWUC0b13fgepYvO/doBfg3AzmroOe7Q/eytrZAMY+dYuFQ8w==
 
 "@polkadotcloud/react-odometer@^0.1.17":


### PR DESCRIPTION
Refactors some modal wrappers, renaming the non-card modals to canvases.

This is being merged concurrently with https://github.com/paritytech/polkadot-cloud/pull/316.