### PR TITLE
Dim modal on help open

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@polkadot/util": "^12.1.1",
     "@polkadot/util-crypto": "12.3.2",
     "@polkadotcloud/community": "0.1.2",
-    "@polkadotcloud/core-ui": "^0.3.66",
+    "@polkadotcloud/core-ui": "^0.3.69",
     "@polkadotcloud/react-odometer": "^0.1.17",
     "@polkadotcloud/themes": "^0.1.2",
     "@polkadotcloud/utils": "^0.2.22",

--- a/src/library/Overlay/index.tsx
+++ b/src/library/Overlay/index.tsx
@@ -24,9 +24,10 @@ export const Overlay = () => {
     if (modalStatus === 2) onFadeOut();
   }, [modalStatus]);
 
+  // Do not fade in/out if help is open. (help can be opened in a modal).
   useEffect(() => {
-    if (helpStatus === 1) onFadeIn();
-    if (helpStatus === 2) onFadeOut();
+    if (helpStatus === 1 && modalStatus !== 1) onFadeIn();
+    if (helpStatus === 2 && modalStatus !== 1) onFadeOut();
   }, [helpStatus]);
 
   if (modalStatus === 0 && helpStatus === 0) {

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorFallbackModal } from 'library/ErrorBoundary';
 import { useModal } from 'contexts/Modal';
+import { useHelp } from 'contexts/Help';
 import { AccountPoolRoles } from './AccountPoolRoles';
 import { Accounts } from './Accounts';
 import { Bio } from './Bio';
@@ -53,6 +54,7 @@ export const Modal = () => {
   } = useModal();
   const controls = useAnimation();
   const maxHeight = modalMaxHeight();
+  const { status: helpStatus } = useHelp();
   const modalRef = useRef<HTMLDivElement>(null);
 
   const onFadeIn = async () => {
@@ -139,7 +141,10 @@ export const Modal = () => {
                     : 'hidden',
               }}
             >
-              <ModalCard ref={modalRef}>
+              <ModalCard
+                ref={modalRef}
+                className={helpStatus === 1 ? 'dimmed' : undefined}
+              >
                 <ErrorBoundary FallbackComponent={ErrorFallbackModal}>
                   {modal === 'AccountPoolRoles' && <AccountPoolRoles />}
                   {modal === 'Bio' && <Bio />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,10 +1832,10 @@
   resolved "https://registry.npmjs.org/@polkadotcloud/community/-/community-0.1.2.tgz#d693b89d42ba4ac70abf1c61cfb6b0667ad8130f"
   integrity sha512-vKJXcCTonXolrd3tN8lbta4Qp69XR6yzU/BM1FOMfiA6C2Q2oGDVYBiTL2BOi8XLXWzsu3SaagG4WulO9ZlPSg==
 
-"@polkadotcloud/core-ui@^0.3.66":
-  version "0.3.66"
-  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.3.66.tgz#92e76fec47c19d5c9342ba241cf47402db6d036b"
-  integrity sha512-3loXbVgZEfvxLI4eGBbZhVfsUbCie3mFQy7ZjBwAja+t6TgIaeXCFMKjbunvXaHfxyq9kuNJpcOfsT9DcGdA+w==
+"@polkadotcloud/core-ui@^0.3.69":
+  version "0.3.69"
+  resolved "https://registry.npmjs.org/@polkadotcloud/core-ui/-/core-ui-0.3.69.tgz#27f2c1b3946a04253decc2601273fb746aaa6ef4"
+  integrity sha512-1GeK3Vzkvpbulqj61DctJNCCJUw4b4OjXncLyRvEcsnbZ286HkdJBcGMgx/X4ts6FycZXVOMqfKH17Tkn2FD9g==
 
 "@polkadotcloud/react-odometer@^0.1.17":
   version "0.1.17"


### PR DESCRIPTION
The modal and help canvas now use the same overlay background, so now there is no separate background to overlay an open modal when help is open, causing display issues.

This PR fixes this by transitioning an open model's opacity to 0.1 when help is invoked in a modal.