### PR TITLE
[Eslint] Activate some eslint rules, fix codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,8 @@
     "unused-imports"
   ],
   "rules": {
+    // NOTE: These rules are being reviewed and comments justifying their deactivation will be
+    // added.
     "react/require-default-props": "off",
     "react/no-access-state-in-setstate": "off",
     "react/destructuring-assignment": "off",
@@ -41,19 +43,21 @@
     "react/static-property-placement": "off",
     "no-unused-vars": "off",
     "no-param-reassign": "off",
-    "no-plusplus": "off",
-    "no-continue": "off",
     "no-restricted-syntax": "off",
     "@typescript-eslint/no-empty-function": "off",
     "no-use-before-define": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "import/prefer-default-export": "off",
-    "consistent-return": "off",
     "no-promise-executor-return": "off",
     "prefer-destructuring": "off",
-    "@typescript-eslint/ban-ts-comment": "off",
     "no-nested-ternary": "off",
-    "no-shadow": "off",
+    // `continue` statements cut down on conditional nesting and improve readability where it is
+    // used in this project. Conditionals would further bloat the code.
+    "no-continue": "off",
+    // Unary operators are not impacting code as semi-colons are currently enforced.
+    "no-plusplus": "off",
+    // Default imports cause naming inconsistencies to imports when component names are changed.
+    "import/prefer-default-export": "off",
+
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/consistent-type-imports": [
       "error",

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -140,18 +140,20 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Dynamically load `Sc` when user opts to use light client.
   useEffectIgnoreInitial(() => {
+    let cancel: () => void | undefined;
+
     if (isLightClient) {
       setApiStatus('connecting');
-      const { promise: ScPromise, cancel } = makeCancelable(
-        import('@substrate/connect')
-      );
-      ScPromise.then((Sc) => {
+
+      const ScPromise = makeCancelable(import('@substrate/connect'));
+      cancel = ScPromise.cancel;
+      ScPromise.promise.then((Sc) => {
         handleLightClientConnection(Sc);
       });
-      return () => {
-        cancel?.();
-      };
     }
+    return () => {
+      cancel?.();
+    };
   }, [isLightClient, network.name]);
 
   // Initialise provider event handlers when provider is set.

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -80,7 +80,7 @@ export const BalancesProvider = ({
   };
 
   const handleSubscriptions = async (address: string) => {
-    if (!api) return;
+    if (!api) return undefined;
 
     const unsub = await api.queryMulti<AnyApi>(
       [

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -79,7 +79,7 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Subscribe to account, get controller and nominations.
   const subscribeToBondedAccount = async (address: string) => {
-    if (!api) return;
+    if (!api) return undefined;
 
     const unsub = await api.queryMulti<AnyApi>(
       [

--- a/src/contexts/Extensions/index.tsx
+++ b/src/contexts/Extensions/index.tsx
@@ -60,20 +60,21 @@ export const ExtensionsProvider = ({
   // sets an interval to listen to `window` until the
   // `injectedWeb3` property is present.
   useEffect(() => {
-    if (intervalInitialisedRef.current) return;
-    intervalInitialisedRef.current = true;
+    if (!intervalInitialisedRef.current) {
+      intervalInitialisedRef.current = true;
 
-    injectedWeb3Interval = setInterval(() => {
-      if (++injectCounter === 10) {
-        handleClearInterval(false);
-      } else {
-        // if injected is present
-        const injectedWeb3 = (window as AnyApi)?.injectedWeb3 || null;
-        if (injectedWeb3 !== null) {
-          handleClearInterval(true);
+      injectedWeb3Interval = setInterval(() => {
+        if (++injectCounter === 10) {
+          handleClearInterval(false);
+        } else {
+          // if injected is present
+          const injectedWeb3 = (window as AnyApi)?.injectedWeb3 || null;
+          if (injectedWeb3 !== null) {
+            handleClearInterval(true);
+          }
         }
-      }
-    }, 500);
+      }, 500);
+    }
     return () => {
       clearInterval(injectedWeb3Interval);
     };

--- a/src/contexts/Extensions/types.ts
+++ b/src/contexts/Extensions/types.ts
@@ -15,7 +15,7 @@ export interface ExtensionInjected extends ExtensionConfig {
 export interface ExtensionInterface {
   accounts: {
     subscribe: {
-      (a: { (a: ExtensionAccount[]): void }): void;
+      (a: { (b: ExtensionAccount[]): void }): void;
     };
   };
   provider: AnyApi;

--- a/src/contexts/Hardware/Ledger.tsx
+++ b/src/contexts/Hardware/Ledger.tsx
@@ -277,6 +277,7 @@ export const LedgerHardwareProvider = ({
         body: [result],
       };
     }
+    return undefined;
   };
 
   // Signs a payload on device.
@@ -328,6 +329,7 @@ export const LedgerHardwareProvider = ({
         },
       };
     }
+    return undefined;
   };
 
   // Handle an incoming new status code and persist to state.

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -64,7 +64,7 @@ export const PoolMembershipsProvider = ({
 
   // subscribe to an account's pool membership
   const subscribeToPoolMembership = async (address: string) => {
-    if (!api) return;
+    if (!api) return undefined;
 
     const unsub = await api.queryMulti<AnyApi>(
       [

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -94,7 +94,7 @@ export const ProxiesProvider = ({
   const delegatesRef = useRef(delegates);
 
   const subscribeToProxies = async (address: string) => {
-    if (!api) return;
+    if (!api) return undefined;
 
     const unsub = await api.queryMulti<AnyApi>(
       [[api.query.proxy.proxies, address]],

--- a/src/library/Hooks/useBlockNumber/index.tsx
+++ b/src/library/Hooks/useBlockNumber/index.tsx
@@ -17,10 +17,9 @@ export const useBlockNumber = () => {
   const unsub = useRef<AnyApi>();
 
   useEffect(() => {
-    if (!isReady) return;
-
-    subscribeBlockNumber();
-
+    if (isReady) {
+      subscribeBlockNumber();
+    }
     return () => {
       if (unsub.current) unsub.current();
     };

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -159,14 +159,15 @@ export const ValidatorListInner = ({
           false
         );
       }
-
-      return () => {
+    }
+    return () => {
+      if (allowFilters) {
         resetFilters('exclude', 'validators');
         resetFilters('include', 'validators');
         resetOrder('validators');
         clearSearchTerm('validators');
-      };
-    }
+      }
+    };
   }, []);
 
   // configure validator list when network is ready to fetch

--- a/src/modals/Networks/index.tsx
+++ b/src/modals/Networks/index.tsx
@@ -11,7 +11,7 @@ import { NetworkList } from 'config/networks';
 import { useApi } from 'contexts/Api';
 import { useModal } from 'contexts/Modal';
 import { Title } from 'library/Modal/Title';
-import type { NetworkName } from 'types';
+import type { AnyJson, NetworkName } from 'types';
 import { ReactComponent as BraveIconSVG } from '../../img/brave-logo.svg';
 import {
   BraveWarning,
@@ -30,8 +30,8 @@ export const Networks = () => {
   const [braveBrowser, setBraveBrowser] = useState<boolean>(false);
 
   useEffect(() => {
-    // @ts-ignore
-    window.navigator?.brave?.isBrave().then(async (isBrave: boolean) => {
+    const navigator: AnyJson = window.navigator;
+    navigator?.brave?.isBrave().then(async (isBrave: boolean) => {
       setBraveBrowser(isBrave);
     });
   });

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -59,7 +59,7 @@ export const HomeInner = () => {
       fetchingMemberCount.current = true;
       const poolDetails = await fetchPoolDetails(selectedActivePool.id);
       fetchingMemberCount.current = false;
-      return setMemberCount(poolDetails?.member_count || 0);
+      setMemberCount(poolDetails?.member_count || 0);
     }
     setMemberCount(
       getMembersOfPoolFromNode(selectedActivePool?.id ?? 0).length


### PR DESCRIPTION
This PR re-activates the `@typescript-eslint/ban-ts-comment`, `consistent-return`, and `no-shadow` eslint rules, and the codebase fixed to reflect them. 

Comments have been added on 3 `off` rules to justify their deactivation, and future PRs will review other `off` rules & either remove them, or keep / justify them.