### PR TITLE
[Fix] Bond / Unbond modal resize on feedback error length change

### DIFF
--- a/src/library/Form/Bond/BondFeedback.tsx
+++ b/src/library/Form/Bond/BondFeedback.tsx
@@ -161,7 +161,7 @@ export const BondFeedback = ({
 
     const bondValid = !newErrors.length && bond.bond !== '';
     setBondDisabled(disabled);
-    listenIsValid(bondValid);
+    listenIsValid(bondValid, newErrors);
     setErrors(newErrors);
   };
 

--- a/src/library/Form/Unbond/UnbondFeedback.tsx
+++ b/src/library/Form/Unbond/UnbondFeedback.tsx
@@ -139,7 +139,7 @@ export const UnbondFeedback = ({
       newErrors.push(err);
     }
 
-    listenIsValid(!newErrors.length && bond.bond !== '');
+    listenIsValid(!newErrors.length && bond.bond !== '', newErrors);
     setErrors(newErrors);
   };
 

--- a/src/library/Form/types.ts
+++ b/src/library/Form/types.ts
@@ -38,7 +38,7 @@ export interface BondFeedbackProps {
   defaultBond: number | null;
   inSetup?: boolean;
   joiningPool?: boolean;
-  listenIsValid: { (v: boolean): void } | { (): void };
+  listenIsValid: { (valid: boolean, errors: string[]): void } | { (): void };
   parentErrors?: string[];
   disableTxFeeUpdate?: boolean;
   setLocalResize?: () => void;
@@ -61,7 +61,7 @@ export interface UnbondFeedbackProps {
   bondFor: BondFor;
   defaultBond?: number;
   inSetup?: boolean;
-  listenIsValid: { (v: boolean): void } | { (): void };
+  listenIsValid: { (valid: boolean, errors: string[]): void } | { (): void };
   parentErrors?: string[];
   setLocalResize?: () => void;
   txFees: BigNumber;

--- a/src/locale/cn/modals.json
+++ b/src/locale/cn/modals.json
@@ -131,7 +131,6 @@
     "noEnough": "您没有足够的可使用余额做快速解除抵押。快速解除抵押需要余额",
     "noFavoritesAvailable": "无收藏夹",
     "noFavoritesSelected": "无选中收藏夹",
-    "noFreeToBond": "您没有可用的 {{unit}} 可质押",
     "noNominationsSet": "没有提名任何人",
     "noNominatorRole": "您未参与任何提名池活动",
     "noProxyAccountsDeclared": "尚未添加任何代理帐户",

--- a/src/locale/en/modals.json
+++ b/src/locale/en/modals.json
@@ -139,7 +139,6 @@
     "noEnough": "You do not have enough free balance to register for fast unstake. Fast unstake requires a deposit of",
     "noFavoritesAvailable": "No Favorites Available.",
     "noFavoritesSelected": "No Favorites Selected",
-    "noFreeToBond": "You have no free {{unit}} to bond.",
     "noNominationsSet": "You have no nominations set.",
     "noNominatorRole": "You do not have a nominator role in any pools.",
     "noProxyAccountsDeclared": "No proxy accounts have been declared.",

--- a/src/modals/Bond/index.tsx
+++ b/src/modals/Bond/index.tsx
@@ -54,6 +54,9 @@ export const Bond = () => {
   // bond valid.
   const [bondValid, setBondValid] = useState<boolean>(false);
 
+  // feedback errors to trigger modal resize
+  const [feedbackErrors, setFeedbackErrors] = useState<string[]>([]);
+
   // bond minus tx fees.
   const enoughToCoverTxFees: boolean = freeBalance
     .minus(bond.bond)
@@ -126,7 +129,7 @@ export const Bond = () => {
   // modal resize on form update
   useEffect(() => {
     setResize();
-  }, [bond, warnings.length]);
+  }, [bond, bondValid, feedbackErrors.length, warnings.length]);
 
   return (
     <>
@@ -145,7 +148,10 @@ export const Bond = () => {
         <BondFeedback
           syncing={largestTxFee.isZero()}
           bondFor={bondFor}
-          listenIsValid={setBondValid}
+          listenIsValid={(valid, errors) => {
+            setBondValid(valid);
+            setFeedbackErrors(errors);
+          }}
           defaultBond={null}
           setters={[
             {

--- a/src/modals/JoinPool/index.tsx
+++ b/src/modals/JoinPool/index.tsx
@@ -59,10 +59,13 @@ export const JoinPool = () => {
   // bond valid
   const [bondValid, setBondValid] = useState<boolean>(false);
 
+  // feedback errors to trigger modal resize
+  const [feedbackErrors, setFeedbackErrors] = useState<string[]>([]);
+
   // modal resize on form update
   useEffect(() => {
     setResize();
-  }, [bond]);
+  }, [bond, feedbackErrors.length]);
 
   // tx to submit
   const getTx = () => {
@@ -119,7 +122,10 @@ export const JoinPool = () => {
           syncing={largestTxFee.isZero()}
           joiningPool
           bondFor="pool"
-          listenIsValid={setBondValid}
+          listenIsValid={(valid, errors) => {
+            setBondValid(valid);
+            setFeedbackErrors(errors);
+          }}
           defaultBond={null}
           setters={[
             {

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -84,6 +84,9 @@ export const Unbond = () => {
   // bond valid
   const [bondValid, setBondValid] = useState<boolean>(false);
 
+  // feedback errors to trigger modal resize
+  const [feedbackErrors, setFeedbackErrors] = useState<string[]>([]);
+
   // get the max amount available to unbond
   const unbondToMin = isPooling
     ? isDepositor()
@@ -171,7 +174,7 @@ export const Unbond = () => {
   // modal resize on form update
   useEffect(() => {
     setResize();
-  }, [bond, warnings.length]);
+  }, [bond, feedbackErrors.length, warnings.length]);
 
   return (
     <>
@@ -187,7 +190,10 @@ export const Unbond = () => {
         ) : null}
         <UnbondFeedback
           bondFor={bondFor}
-          listenIsValid={setBondValid}
+          listenIsValid={(valid, errors) => {
+            setBondValid(valid);
+            setFeedbackErrors(errors);
+          }}
           setters={[
             {
               set: setBond,

--- a/src/pages/Nominate/Setup/Bond/index.tsx
+++ b/src/pages/Nominate/Setup/Bond/index.tsx
@@ -70,7 +70,7 @@ export const Bond = ({ section }: SetupStepProps) => {
           syncing={txFees.isZero()}
           bondFor="nominator"
           inSetup
-          listenIsValid={setBondValid}
+          listenIsValid={(valid) => setBondValid(valid)}
           defaultBond={initialBondValue}
           setters={[
             {

--- a/src/pages/Pools/Create/Bond/index.tsx
+++ b/src/pages/Pools/Create/Bond/index.tsx
@@ -70,7 +70,7 @@ export const Bond = ({ section }: SetupStepProps) => {
           syncing={txFees.isZero()}
           bondFor="pool"
           inSetup
-          listenIsValid={setBondValid}
+          listenIsValid={(valid) => setBondValid(valid)}
           defaultBond={initialBondValue}
           setters={[
             {


### PR DESCRIPTION
Fixes an issue where the bond / unbond modals would not resize if bond was not valid & error length changed.