### PR TITLE
Deprecate getNominationsStatus, improve useNominationStatus hook

### DIFF
--- a/.github/workflows/gh-publish.yml
+++ b/.github/workflows/gh-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
 
-jobs:      
+jobs:
   gh-deploy:
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +15,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: yarn install
       - name: Build
-        working-directory: "."
+        working-directory: '.'
         run: yarn build:pages
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { stringToU8a } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
@@ -21,7 +22,6 @@ export const consts: APIConstants = {
 };
 
 export const defaultApiContext: APIContextInterface = {
-  // eslint-disable-next-line
   switchNetwork: async (n, lc) => {
     await new Promise((resolve) => resolve(null));
   },

--- a/src/contexts/Balances/defaults.ts
+++ b/src/contexts/Balances/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
 import type { Balance, BalancesContextInterface, Ledger } from './types';
@@ -7,13 +8,9 @@ import type { Balance, BalancesContextInterface, Ledger } from './types';
 export const defaultBalancesContext: BalancesContextInterface = {
   ledgers: [],
   balances: [],
-  // eslint-disable-next-line
   getStashLedger: (address) => defaultLedger,
-  // eslint-disable-next-line
   getBalance: (address) => defaultBalance,
-  // eslint-disable-next-line
   getLocks: (address) => [],
-  // eslint-disable-next-line
   getNonce: (address) => 0,
 };
 

--- a/src/contexts/Bonded/defaults.ts
+++ b/src/contexts/Bonded/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type {
   BondedContextInterface,
@@ -12,13 +13,9 @@ export const nominations: Nominations = {
 };
 
 export const defaultBondedContext: BondedContextInterface = {
-  // eslint-disable-next-line
   getAccount: (address) => null,
-  // eslint-disable-next-line
   getBondedAccount: (address) => null,
-  // eslint-disable-next-line
   getAccountNominations: (address) => [],
-  // eslint-disable-next-line
   isController: (address) => false,
   bondedAccounts: [],
 };

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -23,6 +23,7 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
   // Balance accounts state.
   const [bondedAccounts, setBondedAccounts] = useState<BondedAccount[]>([]);
   const bondedAccountsRef = useRef(bondedAccounts);
+
   const unsubs = useRef<Record<string, VoidFn>>({});
 
   // Handle the syncing of accounts on accounts change.

--- a/src/contexts/Canvas/defaults.ts
+++ b/src/contexts/Canvas/defaults.ts
@@ -1,13 +1,12 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { CanvasContextInterface } from './types';
 
 export const defaultCanvasContext: CanvasContextInterface = {
-  // eslint-disable-next-line
   openCanvas: () => {},
   closeCanvas: () => {},
-  // eslint-disable-next-line
   setStatus: (s) => {},
   status: 0,
 };

--- a/src/contexts/Connect/defaults.ts
+++ b/src/contexts/Connect/defaults.ts
@@ -1,35 +1,24 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ConnectContextInterface } from 'contexts/Connect/types';
 
 export const defaultConnectContext: ConnectContextInterface = {
-  // eslint-disable-next-line
   formatAccountSs58: (a: string) => null,
-  // eslint-disable-next-line
   connectExtensionAccounts: async (e) =>
     new Promise((resolve) => resolve(false)),
-  // eslint-disable-next-line
   getAccount: (a) => null,
-  // eslint-disable-next-line
   connectToAccount: (a) => {},
   disconnectFromAccount: () => {},
-  // eslint-disable-next-line
   addExternalAccount: (a, b) => {},
   getActiveAccount: () => null,
-  // eslint-disable-next-line
   accountHasSigner: (a) => false,
-  // eslint-disable-next-line
   requiresManualSign: (a) => false,
-  // eslint-disable-next-line
   isReadOnlyAccount: (a) => false,
-  // eslint-disable-next-line
   addToAccounts: (a) => {},
-  // eslint-disable-next-line
   forgetAccounts: (a) => {},
-  // eslint-disable-next-line
   setActiveProxy: (p, l) => {},
-  // eslint-disable-next-line
   renameImportedAccount: (a, n) => {},
   accounts: [],
   activeAccount: null,

--- a/src/contexts/Extensions/defaults.ts
+++ b/src/contexts/Extensions/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ExtensionsContextInterface } from './types';
 
@@ -8,10 +9,7 @@ export const defaultExtensionsContext: ExtensionsContextInterface = {
   extensionsStatus: {},
   extensionsFetched: false,
   checkingInjectedWeb3: false,
-  // eslint-disable-next-line
   setExtensionStatus: (id, s) => {},
-  // eslint-disable-next-line
   setExtensionsFetched: (s) => {},
-  // eslint-disable-next-line
   setExtensions: (s) => {},
 };

--- a/src/contexts/Extrinsics/defaults.ts
+++ b/src/contexts/Extrinsics/defaults.ts
@@ -1,12 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ExtrinsicsContextInterface } from './types';
 
 export const defaultExtrinsicsContext: ExtrinsicsContextInterface = {
-  // eslint-disable-next-line
   addPending: (t) => {},
-  // eslint-disable-next-line
   removePending: (t) => {},
   pending: [],
 };

--- a/src/contexts/FastUnstake/defaults.ts
+++ b/src/contexts/FastUnstake/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { FastUnstakeContextInterface, MetaInterface } from './types';
 
@@ -8,7 +9,6 @@ export const defaultMeta: MetaInterface = {
 };
 
 export const defaultFastUnstakeContext: FastUnstakeContextInterface = {
-  // eslint-disable-next-line
   getLocalkey: (a) => '',
   checking: false,
   meta: defaultMeta,

--- a/src/contexts/Filters/defaults.ts
+++ b/src/contexts/Filters/defaults.ts
@@ -1,31 +1,20 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { FiltersContextInterface } from './types';
 
 export const defaultFiltersInterface: FiltersContextInterface = {
-  // eslint-disable-next-line
   getFilters: (t, g) => [],
-  // eslint-disable-next-line
   toggleFilter: (t, g, f) => {},
-  // eslint-disable-next-line
   setMultiFilters: (t, g, fs, r) => {},
-  // eslint-disable-next-line
   getOrder: (g) => 'default',
-  // eslint-disable-next-line
   setOrder: (g, o) => {},
-  // eslint-disable-next-line
   getSearchTerm: (g) => null,
-  // eslint-disable-next-line
   setSearchTerm: (g, t) => {},
-  // eslint-disable-next-line
   resetFilters: (t, g) => {},
-  // eslint-disable-next-line
   resetOrder: (g) => {},
-  // eslint-disable-next-line
   clearSearchTerm: (g) => {},
-  // eslint-disable-next-line
   applyFilters: (t, g, l, f) => {},
-  // eslint-disable-next-line
   applyOrder: (g, l, f) => {},
 };

--- a/src/contexts/Hardware/defaults.ts
+++ b/src/contexts/Hardware/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type {
   LedgerHardwareContextInterface,
@@ -19,47 +20,32 @@ export const defaultFeedback = {
 export const defaultLedgerHardwareContext: LedgerHardwareContextInterface = {
   transportResponse: null,
   pairDevice: async () => new Promise((resolve) => resolve(false)),
-  // eslint-disable-next-line
   executeLedgerLoop: async (a, s, o) => new Promise((resolve) => resolve()),
-  // eslint-disable-next-line
   setIsPaired: (v) => {},
-  // eslint-disable-next-line
   handleNewStatusCode: (a, s) => {},
-  // eslint-disable-next-line
   setIsExecuting: (b) => {},
   resetStatusCodes: () => {},
   getIsExecuting: () => false,
   getStatusCodes: () => [],
   getTransport: () => null,
-  // eslint-disable-next-line
   ledgerAccountExists: (a) => false,
-  // eslint-disable-next-line
   addLedgerAccount: (a, i) => null,
-  // eslint-disable-next-line
   removeLedgerAccount: (a) => {},
-  // eslint-disable-next-line
   renameLedgerAccount: (a, n) => {},
-  // eslint-disable-next-line
   getLedgerAccount: (a) => null,
   isPaired: 'unknown',
   ledgerAccounts: [],
   getFeedback: () => defaultFeedback,
-  // eslint-disable-next-line
   setFeedback: (s, h) => {},
   resetFeedback: () => {},
   handleUnmount: () => {},
 };
 
 export const defaultVaultHardwareContext: VaultHardwareContextInterface = {
-  // eslint-disable-next-line
   vaultAccountExists: (a) => false,
-  // eslint-disable-next-line
   addVaultAccount: (a, i) => null,
-  // eslint-disable-next-line
   removeVaultAccount: (a) => {},
-  // eslint-disable-next-line
   renameVaultAccount: (a, n) => {},
-  // eslint-disable-next-line
   getVaultAccount: (a) => null,
   vaultAccounts: [],
 };

--- a/src/contexts/Help/defaults.ts
+++ b/src/contexts/Help/defaults.ts
@@ -1,15 +1,13 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { HelpContextInterface } from './types';
 
 export const defaultHelpContext: HelpContextInterface = {
-  // eslint-disable-next-line
   openHelp: (key) => {},
   closeHelp: () => {},
-  // eslint-disable-next-line
   setStatus: (status) => {},
-  // eslint-disable-next-line
   setDefinition: (definition) => {},
   status: 0,
   definition: null,

--- a/src/contexts/Identities/defaults.ts
+++ b/src/contexts/Identities/defaults.ts
@@ -1,10 +1,10 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { IdentitiesContextInterface } from './types';
 
 export const defaultIdentitiesContext: IdentitiesContextInterface = {
-  // eslint-disable-next-line
   fetchIdentitiesMetaBatch: (k, v, r) => {},
   meta: {},
 };

--- a/src/contexts/Menu/defaults.ts
+++ b/src/contexts/Menu/defaults.ts
@@ -1,16 +1,14 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { MenuContextInterface } from './types';
 
 export const defaultMenuContext: MenuContextInterface = {
   openMenu: () => {},
   closeMenu: () => {},
-  // eslint-disable-next-line
   setMenuPosition: (r) => {},
-  // eslint-disable-next-line
   checkMenuPosition: (r) => {},
-  // eslint-disable-next-line
   setMenuItems: (items) => {},
   open: 0,
   show: 0,

--- a/src/contexts/Modal/defaults.ts
+++ b/src/contexts/Modal/defaults.ts
@@ -1,21 +1,16 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ModalContextInterface } from './types';
 
 export const defaultModalContext: ModalContextInterface = {
   status: 'closed',
-  // eslint-disable-next-line
   setStatus: (status) => {},
-  // eslint-disable-next-line
   openModalWith: (m, c, s) => {},
-  // eslint-disable-next-line
   replaceModalWith: (m, c, s) => {},
-  // eslint-disable-next-line
   setModalHeight: (v) => {},
-  // eslint-disable-next-line
   setModalRef: (v) => {},
-  // eslint-disable-next-line
   setHeightRef: (v) => {},
   setResize: () => {},
   modalMaxHeight: () => 0,

--- a/src/contexts/Notifications/defaults.ts
+++ b/src/contexts/Notifications/defaults.ts
@@ -1,12 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { NotificationsContextInterface } from './types';
 
 export const defaultNotificationsContext: NotificationsContextInterface = {
-  // eslint-disable-next-line
   addNotification: (n) => {},
-  // eslint-disable-next-line
   removeNotification: (n) => {},
   notifications: [],
 };

--- a/src/contexts/Plugins/defaults.ts
+++ b/src/contexts/Plugins/defaults.ts
@@ -1,12 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { PluginsContextInterface } from './types';
 
 export const defaultPluginsContext: PluginsContextInterface = {
-  // eslint-disable-next-line
   togglePlugin: (k) => {},
-  // eslint-disable-next-line
   pluginEnabled: (k) => false,
   plugins: [],
 };

--- a/src/contexts/Pools/ActivePools/defaults.ts
+++ b/src/contexts/Pools/ActivePools/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
 import type { ActivePool, ActivePoolsContextState } from '../types';
@@ -57,10 +58,8 @@ export const defaultActivePoolContext: ActivePoolsContextState = {
   getPoolBondedAccount: () => null,
   getPoolUnlocking: () => [],
   getPoolRoles: () => poolRoles,
-  // eslint-disable-next-line
   setTargets: (t) => {},
   getNominationsStatus: () => nominationStatus,
-  // eslint-disable-next-line
   setSelectedPoolId: (p) => {},
   selectedActivePool,
   targets,

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -1,32 +1,21 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { BondedPoolsContextState } from '../types';
 
 export const defaultBondedPoolsContext: BondedPoolsContextState = {
-  // eslint-disable-next-line
   fetchPoolsMetaBatch: (k, v: [], r) => {},
-  // eslint-disable-next-line
   queryBondedPool: (p) => {},
-  // eslint-disable-next-line
   getBondedPool: (p) => null,
-  // eslint-disable-next-line
   updateBondedPools: (p) => {},
-  // eslint-disable-next-line
   addToBondedPools: (p) => {},
-  // eslint-disable-next-line
   removeFromBondedPools: (p) => {},
-  // eslint-disable-next-line
   getPoolNominationStatus: (n, o) => {},
-  // eslint-disable-next-line
   getPoolNominationStatusCode: (t) => '',
-  // eslint-disable-next-line
   getAccountRoles: (w) => null,
-  // eslint-disable-next-line
   getAccountPools: (w) => null,
-  // eslint-disable-next-line
   replacePoolRoles: (p, e) => {},
-  // eslint-disable-next-line
   poolSearchFilter: (l, k, v) => {},
   bondedPools: [],
   meta: {},

--- a/src/contexts/Pools/PoolMembers/defaults.ts
+++ b/src/contexts/Pools/PoolMembers/defaults.ts
@@ -1,27 +1,20 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { PoolMemberContext } from '../types';
 
 export const defaultPoolMembers: PoolMemberContext = {
-  // eslint-disable-next-line
   fetchPoolMembersMetaBatch: (k, v, r) => {},
-  // eslint-disable-next-line
   queryPoolMember: (w) => {},
-  // eslint-disable-next-line
   getMembersOfPoolFromNode: (p) => {},
-  // eslint-disable-next-line
   addToPoolMembers: (m) => {},
-  // eslint-disable-next-line
   removePoolMember: (w) => {},
-  // eslint-disable-next-line
   getPoolMemberCount: (p) => 0,
   poolMembersApi: [],
-  // eslint-disable-next-line
   setPoolMembersApi: (p) => {},
   poolMembersNode: [],
   meta: {},
   fetchedPoolMembersApi: 'unsynced',
-  // eslint-disable-next-line
   setFetchedPoolMembersApi: (s) => {},
 };

--- a/src/contexts/Prompt/defaults.tsx
+++ b/src/contexts/Prompt/defaults.tsx
@@ -1,15 +1,13 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { PromptContextInterface } from './types';
 
 export const defaultPromptContext: PromptContextInterface = {
-  // eslint-disable-next-line
   openPromptWith: (o, s) => {},
   closePrompt: () => {},
-  // eslint-disable-next-line
   setStatus: (s) => {},
-  // eslint-disable-next-line
   setPrompt: (d) => {},
   size: 'small',
   status: 0,

--- a/src/contexts/Proxies/defaults.ts
+++ b/src/contexts/Proxies/defaults.ts
@@ -1,16 +1,13 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ProxiesContextInterface } from './type';
 
 export const defaultProxiesContext: ProxiesContextInterface = {
-  // eslint-disable-next-line
   getDelegates: (a) => undefined,
-  // eslint-disable-next-line
   getProxyDelegate: (x, y) => null,
-  // eslint-disable-next-line
   getProxiedAccounts: (a) => [],
-  // eslint-disable-next-line
   handleDeclareDelegate: (a) => new Promise((resolve) => resolve([])),
   proxies: [],
   delegates: {},

--- a/src/contexts/Setup/defaults.ts
+++ b/src/contexts/Setup/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type {
   NominatorProgress,
@@ -24,24 +25,16 @@ export const defaultPoolProgress: PoolProgress = {
 };
 
 export const defaultSetupContext: SetupContextInterface = {
-  // eslint-disable-next-line
   getSetupProgress: (a, b) => ({
     section: 1,
     progress: defaultNominatorProgress,
   }),
-  // eslint-disable-next-line
   removeSetupProgress: (a, b) => {},
-  // eslint-disable-next-line
   getNominatorSetupPercent: (a) => 0,
-  // eslint-disable-next-line
   getPoolSetupPercent: (a) => 0,
-  // eslint-disable-next-line
   setActiveAccountSetup: (t, p) => {},
-  // eslint-disable-next-line
   setActiveAccountSetupSection: (t, s) => {},
-  // eslint-disable-next-line
   setOnNominatorSetup: (v) => {},
-  // eslint-disable-next-line
   setOnPoolSetup: (v) => {},
   onNominatorSetup: false,
   onPoolSetup: false,

--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
 import type {
@@ -40,14 +41,10 @@ export const defaultTargets: StakingTargets = {
 export const defaultNominationStatus: NominationStatuses = {};
 
 export const defaultStakingContext: StakingContextInterface = {
-  // eslint-disable-next-line
   getNominationsStatusFromTargets: (w, t) => defaultNominationStatus,
-  // eslint-disable-next-line
   setTargets: (t) => {},
   hasController: () => false,
-  // eslint-disable-next-line
   getControllerNotImported: (a) => null,
-  // eslint-disable-next-line
   addressDifferentToStash: (a) => false,
   isBonding: () => false,
   isNominating: () => false,

--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -40,7 +40,6 @@ export const defaultTargets: StakingTargets = {
 export const defaultNominationStatus: NominationStatuses = {};
 
 export const defaultStakingContext: StakingContextInterface = {
-  getNominationsStatus: () => defaultNominationStatus,
   // eslint-disable-next-line
   getNominationsStatusFromTargets: (w, t) => defaultNominationStatus,
   // eslint-disable-next-line

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -16,7 +16,6 @@ import type { PayeeConfig, PayeeOptions } from 'contexts/Setup/types';
 import type {
   EraStakers,
   Exposure,
-  NominationStatuses,
   StakingContextInterface,
   StakingMetrics,
   StakingTargets,
@@ -31,7 +30,6 @@ import { useConnect } from '../Connect';
 import { useNetworkMetrics } from '../Network';
 import {
   defaultEraStakers,
-  defaultNominationStatus,
   defaultStakingContext,
   defaultStakingMetrics,
   defaultTargets,
@@ -253,33 +251,6 @@ export const StakingProvider = ({
     });
   };
 
-  /*
-   * Get the status of nominations.
-   * Possible statuses: waiting, inactive, active.
-   */
-  const getNominationsStatus = () => {
-    if (inSetup() || !activeAccount) {
-      return defaultNominationStatus;
-    }
-    const statuses: NominationStatuses = {};
-    for (const nomination of getAccountNominations(activeAccount)) {
-      const s = eraStakersRef.current.stakers.find(
-        ({ address }) => address === nomination
-      );
-
-      if (s === undefined) {
-        statuses[nomination] = 'waiting';
-        continue;
-      }
-      if (!(s.others ?? []).find(({ who }: any) => who === activeAccount)) {
-        statuses[nomination] = 'inactive';
-        continue;
-      }
-      statuses[nomination] = 'active';
-    }
-    return statuses;
-  };
-
   /* Sets an account's stored target validators */
   const setTargets = (value: StakingTargets) => {
     localStorage.setItem(`${activeAccount}_targets`, JSON.stringify(value));
@@ -394,7 +365,6 @@ export const StakingProvider = ({
   return (
     <StakingContext.Provider
       value={{
-        getNominationsStatus,
         getNominationsStatusFromTargets,
         setTargets,
         hasController,

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -301,7 +301,7 @@ export const StakingProvider = ({
 
     for (const target of fromTargets) {
       const staker = eraStakersRef.current.stakers.find(
-        ({ address }: any) => address === target
+        ({ address }) => address === target
       );
 
       if (staker === undefined) {

--- a/src/contexts/Staking/types.ts
+++ b/src/contexts/Staking/types.ts
@@ -18,7 +18,9 @@ export interface StakingMetrics {
 }
 
 export interface EraStakers {
-  stakers: any[];
+  stakers: (ExposureValue & {
+    address: string;
+  })[];
   nominators: any[] | undefined;
   totalActiveNominators: number;
   activeValidators: number;

--- a/src/contexts/Staking/types.ts
+++ b/src/contexts/Staking/types.ts
@@ -62,7 +62,6 @@ export interface ExposureOther {
 }
 
 export interface StakingContextInterface {
-  getNominationsStatus: () => any;
   getNominationsStatusFromTargets: (w: MaybeAccount, t: any[]) => any;
   setTargets: (t: any) => any;
   hasController: () => boolean;

--- a/src/contexts/Subscan/defaults.ts
+++ b/src/contexts/Subscan/defaults.ts
@@ -1,18 +1,16 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { SubscanContextInterface } from './types';
 
 export const defaultSubscanContext: SubscanContextInterface = {
-  // eslint-disable-next-line
   fetchEraPoints: (v, e) => {},
   payouts: [],
   poolClaims: [],
   unclaimedPayouts: [],
   payoutsFromDate: undefined,
   payoutsToDate: undefined,
-  // eslint-disable-next-line
   fetchPoolDetails: (poolId) => new Promise((resolve) => resolve({})),
-  // eslint-disable-next-line
   fetchPoolMembers: (poolId, page) => new Promise((resolve) => resolve([])),
 };

--- a/src/contexts/Themes/defaults.ts
+++ b/src/contexts/Themes/defaults.ts
@@ -1,10 +1,10 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ThemeContextInterface } from './types';
 
 export const defaultThemeContext: ThemeContextInterface = {
-  // eslint-disable-next-line
   toggleTheme: (str) => {},
   mode: 'light',
 };

--- a/src/contexts/Tooltip/defaults.ts
+++ b/src/contexts/Tooltip/defaults.ts
@@ -1,16 +1,14 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { TooltipContextInterface } from './types';
 
 export const defaultTooltipContext: TooltipContextInterface = {
   openTooltip: () => {},
   closeTooltip: () => {},
-  // eslint-disable-next-line
   setTooltipPosition: (x, y) => {},
-  // eslint-disable-next-line
   showTooltip: () => {},
-  // eslint-disable-next-line
   setTooltipTextAndOpen: (t) => {},
   open: 0,
   show: 0,

--- a/src/contexts/TransferOptions/defaults.ts
+++ b/src/contexts/TransferOptions/defaults.ts
@@ -1,13 +1,12 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
 import type { TransferOptions, TransferOptionsContextInterface } from './types';
 
 export const defaultBondedContext: TransferOptionsContextInterface = {
-  // eslint-disable-next-line
   getTransferOptions: (a) => transferOptions,
-  // eslint-disable-next-line
   setFeeReserveBalance: (r) => {},
   feeReserve: new BigNumber(0),
 };

--- a/src/contexts/TxMeta/defaults.ts
+++ b/src/contexts/TxMeta/defaults.ts
@@ -1,29 +1,24 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
 import type { TxMetaContextInterface } from './types';
 
 export const defaultTxMeta: TxMetaContextInterface = {
-  // eslint-disable-next-line
   controllerSignerAvailable: (a, b) => 'ok',
   txFees: new BigNumber(0),
   notEnoughFunds: false,
-  // eslint-disable-next-line
   setTxFees: (f) => {},
   resetTxFees: () => {},
   sender: null,
-  // eslint-disable-next-line
   setSender: (s) => {},
   txFeesValid: false,
   incrementPayloadUid: () => 0,
   getPayloadUid: () => 0,
   getTxPayload: () => {},
-  // eslint-disable-next-line
   setTxPayload: (p, u) => {},
   getTxSignature: () => null,
-  // eslint-disable-next-line
   resetTxPayloads: () => {},
-  // eslint-disable-next-line
   setTxSignature: (s) => {},
 };

--- a/src/contexts/UI/defaults.ts
+++ b/src/contexts/UI/defaults.ts
@@ -1,14 +1,12 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { UIContextInterface } from './types';
 
 export const defaultUIContext: UIContextInterface = {
-  // eslint-disable-next-line
   setSideMenu: (v) => {},
-  // eslint-disable-next-line
   setUserSideMenuMinimised: (v) => {},
-  // eslint-disable-next-line
   setContainerRefs: (v) => {},
   sideMenuOpen: false,
   userSideMenuMinimised: false,

--- a/src/contexts/Validators/defaults.ts
+++ b/src/contexts/Validators/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ValidatorsContextInterface } from 'contexts/Validators/types';
 
@@ -14,15 +15,10 @@ export const defaultSessionParachainValidators = {
 };
 
 export const defaultValidatorsContext: ValidatorsContextInterface = {
-  // eslint-disable-next-line
   fetchValidatorMetaBatch: (k, v, r) => {},
-  // eslint-disable-next-line
   removeValidatorMetaBatch: (k) => {},
-  // eslint-disable-next-line
   fetchValidatorPrefs: async (v) => null,
-  // eslint-disable-next-line
   addFavorite: (a) => {},
-  // eslint-disable-next-line
   removeFavorite: (a) => {},
   validators: [],
   avgCommission: 0,

--- a/src/contexts/Validators/index.tsx
+++ b/src/contexts/Validators/index.tsx
@@ -397,7 +397,7 @@ export const ValidatorsProvider = ({
       validatorMetaBatchesRef
     );
 
-    const subscribeToIdentities = async (addr: AnyApi) => {
+    const subscribeToIdentities = async (addr: string[]) => {
       const unsub = await api.query.identity.identityOf.multi<AnyApi>(
         addr,
         (result) => {
@@ -425,7 +425,7 @@ export const ValidatorsProvider = ({
       return unsub;
     };
 
-    const subscribeToSuperIdentities = async (addr: AnyApi) => {
+    const subscribeToSuperIdentities = async (addr: string[]) => {
       const unsub = await api.query.identity.superOf.multi<AnyApi>(
         addr,
         async (result) => {

--- a/src/library/Filter/defaults.ts
+++ b/src/library/Filter/defaults.ts
@@ -1,21 +1,16 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ValidatorFilterContextInterface } from './types';
 
 export const defaultContext: ValidatorFilterContextInterface = {
-  // eslint-disable-next-line
   orderValidators: (v) => {},
-  // eslint-disable-next-line
   applyValidatorOrder: (l, o) => {},
-  // eslint-disable-next-line
   applyValidatorFilters: (l, k, f) => {},
-  // eslint-disable-next-line
   toggleFilterValidators: (v) => {},
-  // eslint-disable-next-line
   toggleAllValidatorFilters: (t) => {},
   resetValidatorFilters: () => {},
-  // eslint-disable-next-line
   validatorSearchFilter: (l, k, v) => {},
   validatorFilters: [],
   validatorOrder: 'default',

--- a/src/library/Graphs/Utils.ts
+++ b/src/library/Graphs/Utils.ts
@@ -44,7 +44,7 @@ export const calculateDailyPayouts = (
   fromDate: Date,
   maxDays: number,
   units: number,
-  // eslint-disable-next-line
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   subject: string
 ) => {
   let dailyPayouts: AnySubscan = [];

--- a/src/library/Hooks/useUnstaking/index.tsx
+++ b/src/library/Hooks/useUnstaking/index.tsx
@@ -9,24 +9,23 @@ import { useNetworkMetrics } from 'contexts/Network';
 import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import type { AnyJson } from 'types';
+import { useNominationStatus } from '../useNominationStatus';
 
 export const useUnstaking = () => {
   const { t } = useTranslation('library');
   const { consts } = useApi();
-  const { getTransferOptions } = useTransferOptions();
+  const { inSetup } = useStaking();
   const { activeAccount } = useConnect();
-  const { getNominationsStatus, inSetup } = useStaking();
   const { activeEra } = useNetworkMetrics();
+  const { getTransferOptions } = useTransferOptions();
+  const { getNominationStatus } = useNominationStatus();
   const { checking, head, isExposed, queueDeposit, meta } = useFastUnstake();
   const { bondDuration } = consts;
   const transferOptions = getTransferOptions(activeAccount).nominate;
-  const nominationStatuses = getNominationsStatus();
+  const { nominees } = getNominationStatus(activeAccount, 'nominator');
 
   // determine if user is regular unstaking
   const { active } = transferOptions;
-  const activeNominations = Object.entries(nominationStatuses)
-    .map(([k, v]: any) => (v === 'active' ? k : false))
-    .filter((v) => v !== false);
 
   // determine if user is fast unstaking.
   const inHead =
@@ -58,7 +57,7 @@ export const useUnstaking = () => {
 
   return {
     getFastUnstakeText,
-    isUnstaking: !inSetup() && !activeNominations.length && active.isZero(),
+    isUnstaking: !inSetup() && !nominees.active.length && active.isZero(),
     isFastUnstaking: !!registered,
   };
 };

--- a/src/library/ListItem/Labels/NominationStatus.tsx
+++ b/src/library/ListItem/Labels/NominationStatus.tsx
@@ -8,6 +8,8 @@ import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useStaking } from 'contexts/Staking';
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
+import { useNominationStatus } from 'library/Hooks/useNominationStatus';
+import { useConnect } from 'contexts/Connect';
 import type { NominationStatusProps } from '../types';
 
 export const NominationStatus = ({
@@ -16,11 +18,13 @@ export const NominationStatus = ({
   bondFor,
 }: NominationStatusProps) => {
   const { t } = useTranslation('library');
-  const { getNominationsStatus, eraStakers, erasStakersSyncing } = useStaking();
-  const { getPoolNominationStatus } = useBondedPools();
   const {
     network: { unit, units },
   } = useApi();
+  const { activeAccount } = useConnect();
+  const { getPoolNominationStatus } = useBondedPools();
+  const { getNomineesStatus } = useNominationStatus();
+  const { eraStakers, erasStakersSyncing } = useStaking();
 
   const { activeAccountOwnStake, stakers } = eraStakers;
 
@@ -30,7 +34,7 @@ export const NominationStatus = ({
     nominationStatus = getPoolNominationStatus(nominator, address);
   } else {
     // get all active account's nominations.
-    const nominationStatuses = getNominationsStatus();
+    const nominationStatuses = getNomineesStatus(activeAccount, 'nominator');
     // find the nominator status within the returned nominations.
     nominationStatus = nominationStatuses[address];
   }

--- a/src/library/PoolList/defaults.ts
+++ b/src/library/PoolList/defaults.ts
@@ -1,12 +1,12 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { PoolListContextProps } from './types';
 
 export const defaultListFormat = 'col';
 
 export const defaultPoolList: PoolListContextProps = {
-  // eslint-disable-next-line
   setListFormat: (v) => {},
   listFormat: defaultListFormat,
 };

--- a/src/pages/Community/defaults.ts
+++ b/src/pages/Community/defaults.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 export const item = {
   name: '',
@@ -8,7 +9,6 @@ export const item = {
 };
 
 export const defaultContext = {
-  // eslint-disable-next-line
   setActiveSection: (t: number) => {},
   activeSection: 0,
 };

--- a/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -48,7 +48,7 @@ export const NominationStatus = ({
   // Determine whether to display fast unstake button or regular unstake button.
   const unstakeButton =
     fastUnstakeErasToCheckPerBlock > 0 &&
-    !nominationStatus.activeNominees.length &&
+    !nominationStatus.nominees.active.length &&
     (checking || !isExposed)
       ? {
           disabled: checking || isReadOnlyAccount(controller),

--- a/src/pages/Payouts/PayoutList/context.tsx
+++ b/src/pages/Payouts/PayoutList/context.tsx
@@ -1,12 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
-
 import React, { useState } from 'react';
 import type { PayoutListContextInterface } from 'pages/Pools/types';
 
 export const PayoutListContext =
   React.createContext<PayoutListContextInterface>({
-    // eslint-disable-next-line
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setListFormat: (v: string) => {},
     listFormat: 'col',
   });

--- a/src/pages/Pools/Home/Status/PoolStatus.tsx
+++ b/src/pages/Pools/Home/Status/PoolStatus.tsx
@@ -18,10 +18,10 @@ export const PoolStatus = () => {
   const { selectedActivePool, poolNominations } = useActivePools();
 
   const poolStash = selectedActivePool?.addresses?.stash || '';
-  const { earningRewards, activeNominees } = getNominationStatus(
-    poolStash,
-    'pool'
-  );
+  const {
+    earningRewards,
+    nominees: { active },
+  } = getNominationStatus(poolStash, 'pool');
   const poolState = selectedActivePool?.bondedPool?.state ?? null;
   const poolNominating = !!poolNominations?.targets?.length;
 
@@ -51,7 +51,7 @@ export const PoolStatus = () => {
     ? t('pools.inactivePoolNotNominating')
     : !poolNominating
     ? t('pools.inactivePoolNotNominating')
-    : activeNominees.length
+    : active.length
     ? `${t('pools.nominatingAnd')} ${
         earningRewards
           ? t('pools.earningRewards')

--- a/src/pages/Pools/Home/Status/PoolStatus.tsx
+++ b/src/pages/Pools/Home/Status/PoolStatus.tsx
@@ -18,10 +18,7 @@ export const PoolStatus = () => {
   const { selectedActivePool, poolNominations } = useActivePools();
 
   const poolStash = selectedActivePool?.addresses?.stash || '';
-  const {
-    earningRewards,
-    nominees: { active },
-  } = getNominationStatus(poolStash, 'pool');
+  const { earningRewards, nominees } = getNominationStatus(poolStash, 'pool');
   const poolState = selectedActivePool?.bondedPool?.state ?? null;
   const poolNominating = !!poolNominations?.targets?.length;
 
@@ -51,7 +48,7 @@ export const PoolStatus = () => {
     ? t('pools.inactivePoolNotNominating')
     : !poolNominating
     ? t('pools.inactivePoolNotNominating')
-    : active.length
+    : nominees.active.length
     ? `${t('pools.nominatingAnd')} ${
         earningRewards
           ? t('pools.earningRewards')

--- a/src/pages/Pools/Home/context.tsx
+++ b/src/pages/Pools/Home/context.tsx
@@ -7,7 +7,7 @@ import type { PoolsTabsContextInterface } from '../types';
 
 export const PoolsTabsContext: React.Context<PoolsTabsContextInterface> =
   React.createContext({
-    // eslint-disable-next-line
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setActiveTab: (t: number) => {},
     activeTab: 0,
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,13 +98,13 @@ export type BondFor = 'pool' | 'nominator';
 export type Fn = () => void;
 
 // any types to compress compiler warnings
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyApi = any;
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyJson = any;
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = any;
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyMetaBatch = any;
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnySubscan = any;


### PR DESCRIPTION
This PR has deprecated `getNominationStatus` in favour of `useNominationStatus` hook. Misc syntax improvements also included.

- [x] Test fast unstake.
- [x] Test `useUnstaking`.
- [x] Test nomination status labels for list items.
- [x] Test nomination statuses match with production.