### PR TITLE
Allow app to use extension on Light Client

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -296,7 +296,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     const { endpoints } = NetworkList[name];
     const newProvider = lc || new WsProvider(endpoints.rpc);
     if (lc) {
-      await newProvider.connect({ forceEmbeddedNode: true });
+      await newProvider.connect();
     }
     setProvider(newProvider);
   };


### PR DESCRIPTION
The flag `forceEmbeddedNode` was passed to the provider's connect options;
This flag, makes the client to always use a node embedded within the page and never use the substrate-connect extension. It defaults to `false` thus removing the option will allow the app to connect to the extension