### PR TITLE
Convert points to balance for `PoolMemberships`

### DIFF
--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -76,7 +76,10 @@ export const PoolMembershipsProvider = ({
       }
     );
 
-    const handleMembership = (poolMember: AnyApi, claimPermission?: AnyApi) => {
+    const handleMembership = async (
+      poolMember: AnyApi,
+      claimPermission?: AnyApi
+    ) => {
       let membership = poolMember?.unwrapOr(undefined)?.toHuman();
 
       if (membership) {
@@ -92,8 +95,18 @@ export const PoolMembershipsProvider = ({
         membership.points = membership.points
           ? rmCommas(membership.points)
           : '0';
+
+        const balance =
+          (
+            await api.call.nominationPoolsApi.pointsToBalance(
+              membership.poolId,
+              membership.points
+            )
+          )?.toString() || '0';
+
         membership = {
           ...membership,
+          balance: new BigNumber(balance),
           address,
           unlocking,
           claimPermission: claimPermission?.toString() || 'Permissioned',

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -25,18 +25,18 @@ export const PoolMembershipsProvider = ({
   const { api, network, isReady } = useApi();
   const { accounts: connectAccounts, activeAccount } = useConnect();
 
-  // stores pool membership
+  // Stores pool memberships for the imported accounts.
   const [poolMemberships, setPoolMemberships] = useState<PoolMembership[]>([]);
   const poolMembershipsRef = useRef(poolMemberships);
 
-  // stores pool subscription objects
-  const poolMembershipUnsubs = useRef<AnyApi[]>([]);
+  // Stores pool membership unsubs.
+  const unsubs = useRef<AnyApi[]>([]);
 
   useEffectIgnoreInitial(() => {
     if (isReady) {
       (() => {
         setStateWithRef([], setPoolMemberships, poolMembershipsRef);
-        unsubscribeAll();
+        unsubAll();
         getPoolMemberships();
       })();
     }
@@ -45,21 +45,21 @@ export const PoolMembershipsProvider = ({
   // subscribe to account pool memberships
   const getPoolMemberships = async () => {
     Promise.all(
-      connectAccounts.map((a) => subscribeToPoolMembership(a.address))
+      connectAccounts.map(({ address }) => subscribeToPoolMembership(address))
     );
   };
 
   // unsubscribe from pool memberships on unmount
   useEffect(
     () => () => {
-      unsubscribeAll();
+      unsubAll();
     },
     []
   );
 
   // unsubscribe from all pool memberships
-  const unsubscribeAll = () => {
-    Object.values(poolMembershipUnsubs.current).forEach((v: Fn) => v());
+  const unsubAll = () => {
+    Object.values(unsubs.current).forEach((v: Fn) => v());
   };
 
   // subscribe to an account's pool membership
@@ -132,7 +132,7 @@ export const PoolMembershipsProvider = ({
       }
     };
 
-    poolMembershipUnsubs.current = poolMembershipUnsubs.current.concat(unsub);
+    unsubs.current = unsubs.current.concat(unsub);
     return unsub;
   };
 

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -48,6 +48,7 @@ export interface PoolMembership {
   address: string;
   poolId: number;
   points: string;
+  balance: BigNumber;
   lastRecordedRewardCounter: string;
   unbondingEras: Record<number, string>;
   claimPermission: ClaimPermission;

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -87,8 +87,8 @@ export const TransferOptionsProvider = ({
         { amount: new BigNumber(0) }
       )?.amount || new BigNumber(0);
 
-    const points = membership?.points;
-    const activePool = points ? new BigNumber(points) : new BigNumber(0);
+    const poolBalance = membership?.balance;
+    const activePool = poolBalance || new BigNumber(0);
 
     // total amount actively unlocking
     let totalUnlocking = new BigNumber(0);

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -19,13 +19,13 @@ export const ManageBond = () => {
   const { t } = useTranslation('pages');
 
   const { network } = useApi();
-  const { units } = network;
-  const { openModal } = useOverlay().modal;
-  const { activeAccount, isReadOnlyAccount } = useConnect();
-  const { isPoolSyncing } = useUi();
-  const { isBonding, isMember, selectedActivePool } = useActivePools();
-  const { getTransferOptions } = useTransferOptions();
   const { openHelp } = useHelp();
+  const { isPoolSyncing } = useUi();
+  const { openModal } = useOverlay().modal;
+  const { getTransferOptions } = useTransferOptions();
+  const { activeAccount, isReadOnlyAccount } = useConnect();
+  const { isBonding, isMember, selectedActivePool } = useActivePools();
+  const { units } = network;
 
   const allTransferOptions = getTransferOptions(activeAccount);
   const {


### PR DESCRIPTION
This PR fetches the real balance of a pool, and displays in in the `ManageBond` card on the pools page.

There are other areas where pool points are being treated as balances, this should be explored in another PR to ensure balances are being fetched efficiently in large lists.