### PR TITLE
Favorite validators to own context

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -33,7 +33,8 @@ import { TooltipProvider } from 'contexts/Tooltip';
 import { TransferOptionsProvider } from 'contexts/TransferOptions';
 import { TxMetaProvider } from 'contexts/TxMeta';
 import { UIProvider } from 'contexts/UI';
-import { ValidatorsProvider } from 'contexts/Validators';
+import { ValidatorsProvider } from 'contexts/Validators/ValidatorEntries';
+import { FavoriteValidatorsProvider } from 'contexts/Validators/FavoriteValidators';
 import { withProviders } from 'library/Hooks';
 import { PayoutsProvider } from 'contexts/Payouts';
 import { OverlayProvider } from '@polkadot-cloud/react';
@@ -61,6 +62,7 @@ export const Providers = withProviders(
   ActivePoolsProvider,
   TransferOptionsProvider,
   ValidatorsProvider,
+  FavoriteValidatorsProvider,
   FastUnstakeProvider,
   PayoutsProvider,
   UIProvider,

--- a/src/contexts/Validators/FavoriteValidators/defaults.ts
+++ b/src/contexts/Validators/FavoriteValidators/defaults.ts
@@ -1,0 +1,20 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import BigNumber from 'bignumber.js';
+import type { FavoriteValidatorsContextInterface } from '../types';
+
+export const defaultValidatorsData = {
+  entries: [],
+  notFullCommissionCount: 0,
+  totalNonAllCommission: new BigNumber(0),
+};
+
+export const defaultFavoriteValidatorsContext: FavoriteValidatorsContextInterface =
+  {
+    addFavorite: (a) => {},
+    removeFavorite: (a) => {},
+    favorites: [],
+    favoritesList: null,
+  };

--- a/src/contexts/Validators/FavoriteValidators/index.tsx
+++ b/src/contexts/Validators/FavoriteValidators/index.tsx
@@ -1,0 +1,95 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import React, { useState } from 'react';
+import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useApi } from 'contexts/Api';
+import type { Validator, FavoriteValidatorsContextInterface } from '../types';
+import { getLocalFavorites } from '../Utils';
+import { defaultFavoriteValidatorsContext } from './defaults';
+import { useValidators } from '../ValidatorEntries';
+
+export const FavoriteValidatorsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { isReady, network } = useApi();
+  const { fetchValidatorPrefs } = useValidators();
+  const { name } = network;
+
+  // Stores the user's favorite validators.
+  const [favorites, setFavorites] = useState<string[]>(getLocalFavorites(name));
+
+  // Stores the user's favorites validators as list.
+  const [favoritesList, setFavoritesList] = useState<Validator[] | null>(null);
+
+  const fetchFavoriteList = async () => {
+    // fetch preferences
+    const favoritesWithPrefs = await fetchValidatorPrefs(
+      [...favorites].map((address) => ({
+        address,
+      }))
+    );
+    setFavoritesList(favoritesWithPrefs || []);
+  };
+
+  // Adds a favorite validator.
+  const addFavorite = (address: string) => {
+    const newFavorites: any = Object.assign(favorites);
+    if (!newFavorites.includes(address)) {
+      newFavorites.push(address);
+    }
+
+    localStorage.setItem(
+      `${network.name}_favorites`,
+      JSON.stringify(newFavorites)
+    );
+    setFavorites([...newFavorites]);
+  };
+
+  // Removes a favorite validator if they exist.
+  const removeFavorite = (address: string) => {
+    const newFavorites = Object.assign(favorites).filter(
+      (validator: string) => validator !== address
+    );
+    localStorage.setItem(
+      `${network.name}_favorites`,
+      JSON.stringify(newFavorites)
+    );
+    setFavorites([...newFavorites]);
+  };
+
+  // Re-fetch favorites on network change
+  useEffectIgnoreInitial(() => {
+    setFavorites(getLocalFavorites(name));
+  }, [network]);
+
+  // Fetch favorites in validator list format
+  useEffectIgnoreInitial(() => {
+    if (isReady) {
+      fetchFavoriteList();
+    }
+  }, [isReady, favorites]);
+
+  return (
+    <FavoriteValidatorsContext.Provider
+      value={{
+        addFavorite,
+        removeFavorite,
+        favorites,
+        favoritesList,
+      }}
+    >
+      {children}
+    </FavoriteValidatorsContext.Provider>
+  );
+};
+
+export const FavoriteValidatorsContext =
+  React.createContext<FavoriteValidatorsContextInterface>(
+    defaultFavoriteValidatorsContext
+  );
+
+export const useFavoriteValidators = () =>
+  React.useContext(FavoriteValidatorsContext);

--- a/src/contexts/Validators/ValidatorEntries/defaults.ts
+++ b/src/contexts/Validators/ValidatorEntries/defaults.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
-import type { ValidatorsContextInterface } from 'contexts/Validators/types';
+import type { ValidatorsContextInterface } from '../types';
 
 export const defaultValidatorsData = {
   entries: [],
@@ -12,17 +12,14 @@ export const defaultValidatorsData = {
 };
 
 export const defaultValidatorsContext: ValidatorsContextInterface = {
-  addFavorite: (a) => {},
-  removeFavorite: (a) => {},
+  fetchValidatorPrefs: async (a) => new Promise((resolve) => resolve(null)),
   validators: [],
   validatorIdentities: {},
   validatorSupers: {},
   avgCommission: 0,
   sessionValidators: [],
   sessionParaValidators: [],
-  favorites: [],
   nominated: null,
   poolNominated: null,
-  favoritesList: null,
   validatorCommunity: [],
 };

--- a/src/contexts/Validators/types.ts
+++ b/src/contexts/Validators/types.ts
@@ -4,19 +4,23 @@
 import type { AnyJson } from 'types';
 
 export interface ValidatorsContextInterface {
-  addFavorite: (a: string) => void;
-  removeFavorite: (a: string) => void;
+  fetchValidatorPrefs: (a: ValidatorAddresses) => Promise<Validator[] | null>;
   validators: Validator[];
   validatorIdentities: Record<string, Identity>;
   validatorSupers: Record<string, AnyJson>;
   avgCommission: number;
   sessionValidators: string[];
   sessionParaValidators: string[];
-  favorites: string[];
   nominated: Validator[] | null;
   poolNominated: Validator[] | null;
-  favoritesList: Validator[] | null;
   validatorCommunity: any[];
+}
+
+export interface FavoriteValidatorsContextInterface {
+  addFavorite: (a: string) => void;
+  removeFavorite: (a: string) => void;
+  favorites: string[];
+  favoritesList: Validator[] | null;
 }
 
 export interface Identity {

--- a/src/library/GenerateNominations/index.tsx
+++ b/src/library/GenerateNominations/index.tsx
@@ -15,7 +15,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
 import { SelectableWrapper } from 'library/List';
 import { SelectItems } from 'library/SelectItems';
@@ -24,6 +24,7 @@ import { ValidatorList } from 'library/ValidatorList';
 import { Wrapper } from 'pages/Overview/NetworkSats/Wrappers';
 import { useStaking } from 'contexts/Staking';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 import type {
   GenerateNominationsInnerProps,
   Nominations,
@@ -36,11 +37,12 @@ export const GenerateNominations = ({
   batchKey,
 }: GenerateNominationsInnerProps) => {
   const { t } = useTranslation('library');
-  const { openModal } = useOverlay().modal;
   const { isReady, consts } = useApi();
+  const { openModal } = useOverlay().modal;
   const { isFastUnstaking } = useUnstaking();
-  const { activeAccount, isReadOnlyAccount } = useConnect();
   const { stakers } = useStaking().eraStakers;
+  const { favoritesList } = useFavoriteValidators();
+  const { activeAccount, isReadOnlyAccount } = useConnect();
   const { validators, validatorIdentities, validatorSupers } = useValidators();
   const {
     fetch: fetchFromMethod,
@@ -49,10 +51,6 @@ export const GenerateNominations = ({
   } = useFetchMehods();
   const { maxNominations } = consts;
 
-  let { favoritesList } = useValidators();
-  if (favoritesList === null) {
-    favoritesList = [];
-  }
   // store the method of fetching validators
   const [method, setMethod] = useState<string | null>(
     defaultNominations.length ? 'Manual' : null

--- a/src/library/GenerateNominations/useFetchMethods.tsx
+++ b/src/library/GenerateNominations/useFetchMethods.tsx
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { shuffle } from '@polkadot-cloud/utils';
-import { useValidators } from 'contexts/Validators';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { Validator } from 'contexts/Validators/types';
 import { useValidatorFilters } from 'library/Hooks/useValidatorFilters';
 
 export const useFetchMehods = () => {
   const { validators, sessionParaValidators } = useValidators();
   const { applyFilter, applyOrder } = useValidatorFilters();
-  let { favoritesList } = useValidators();
-  if (favoritesList === null) {
-    favoritesList = [];
-  }
+  const { favoritesList } = useFavoriteValidators();
 
   const fetch = (method: string) => {
     let nominations;
@@ -56,7 +54,7 @@ export const useFetchMehods = () => {
       return favs;
     }
 
-    if (favoritesList.length) {
+    if (favoritesList?.length) {
       // take subset of up to 16 favorites
       favs = favoritesList.slice(0, 16);
     }

--- a/src/library/Headers/index.tsx
+++ b/src/library/Headers/index.tsx
@@ -8,7 +8,7 @@ import { usePlugins } from 'contexts/Plugins';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { useUi } from 'contexts/UI';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { usePayouts } from 'contexts/Payouts';
 import { Connect } from './Connect';
 import { Connected } from './Connected';

--- a/src/library/Hooks/useNominationStatus/index.tsx
+++ b/src/library/Hooks/useNominationStatus/index.tsx
@@ -9,7 +9,7 @@ import { useBonded } from 'contexts/Bonded';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { AnyJson, MaybeAccount } from 'types';
 
 export const useNominationStatus = () => {

--- a/src/library/Hooks/useValidatorFilters/index.tsx
+++ b/src/library/Hooks/useValidatorFilters/index.tsx
@@ -3,7 +3,7 @@
 
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
 import { useTranslation } from 'react-i18next';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { AnyFunction, AnyJson } from 'types';
 import { useStaking } from 'contexts/Staking';
 

--- a/src/library/ListItem/Labels/FavoriteValidator.tsx
+++ b/src/library/ListItem/Labels/FavoriteValidator.tsx
@@ -7,15 +7,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { useNotifications } from 'contexts/Notifications';
 import { useTooltip } from 'contexts/Tooltip';
-import { useValidators } from 'contexts/Validators';
 import { TooltipTrigger } from 'library/ListItem/Wrappers';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 import type { FavoriteProps } from '../types';
 
 export const FavoriteValidator = ({ address }: FavoriteProps) => {
   const { t } = useTranslation('library');
-  const { addNotification } = useNotifications();
-  const { favorites, addFavorite, removeFavorite } = useValidators();
   const { setTooltipTextAndOpen } = useTooltip();
+  const { addNotification } = useNotifications();
+  const { favorites, addFavorite, removeFavorite } = useFavoriteValidators();
 
   const isFavorite = favorites.includes(address);
 

--- a/src/library/ListItem/Labels/Identity.tsx
+++ b/src/library/ListItem/Labels/Identity.tsx
@@ -3,7 +3,7 @@
 
 import { clipAddress } from '@polkadot-cloud/utils';
 import { useEffect, useState } from 'react';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { Identicon } from 'library/Identicon';
 import { IdentityWrapper } from 'library/ListItem/Wrappers';
 import { getIdentityDisplay } from '../../ValidatorList/Validator/Utils';

--- a/src/library/ListItem/Labels/ParaValidator.tsx
+++ b/src/library/ListItem/Labels/ParaValidator.tsx
@@ -5,7 +5,7 @@ import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { useTooltip } from 'contexts/Tooltip';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { TooltipTrigger } from 'library/ListItem/Wrappers';
 import type { ParaValidatorProps } from '../types';
 

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -13,7 +13,7 @@ import type { NotificationText } from 'contexts/Notifications/types';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { useUi } from 'contexts/UI';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { usePoolCommission } from 'library/Hooks/usePoolCommission';
 import { FavoritePool } from 'library/ListItem/Labels/FavoritePool';
 import { PoolBonded } from 'library/ListItem/Labels/PoolBonded';

--- a/src/library/ValidatorList/Validator/Default.tsx
+++ b/src/library/ValidatorList/Validator/Default.tsx
@@ -18,7 +18,7 @@ import {
   Wrapper,
 } from 'library/ListItem/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
-import { useValidators } from '../../../contexts/Validators';
+import { useValidators } from '../../../contexts/Validators/ValidatorEntries';
 import { useList } from '../../List/context';
 import { Blocked } from '../../ListItem/Labels/Blocked';
 import { Commission } from '../../ListItem/Labels/Commission';

--- a/src/library/ValidatorList/Validator/Nomination.tsx
+++ b/src/library/ValidatorList/Validator/Nomination.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { ParaValidator } from 'library/ListItem/Labels/ParaValidator';
 import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
 import { useList } from '../../List/context';

--- a/src/modals/NominateFromFavorites/index.tsx
+++ b/src/modals/NominateFromFavorites/index.tsx
@@ -12,7 +12,6 @@ import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useActivePools } from 'contexts/Pools/ActivePools';
-import { useValidators } from 'contexts/Validators';
 import type { Validator } from 'contexts/Validators/types';
 import { Warning } from 'library/Form/Warning';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
@@ -22,6 +21,7 @@ import { SubmitTx } from 'library/SubmitTx';
 import { ValidatorList } from 'library/ValidatorList';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 import { ListWrapper } from './Wrappers';
 
 export const NominateFromFavorites = () => {
@@ -30,7 +30,7 @@ export const NominateFromFavorites = () => {
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
-  const { favoritesList } = useValidators();
+  const { favoritesList } = useFavoriteValidators();
   const { getSignerWarnings } = useSignerWarnings();
   const {
     config: { options },

--- a/src/modals/SelectFavorites/index.tsx
+++ b/src/modals/SelectFavorites/index.tsx
@@ -5,11 +5,11 @@ import { ModalPadding } from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useValidators } from 'contexts/Validators';
 import type { Validator } from 'contexts/Validators/types';
 import { Title } from 'library/Modal/Title';
 import { ValidatorList } from 'library/ValidatorList';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 import { FooterWrapper, ListWrapper } from './Wrappers';
 
 export const SelectFavorites = () => {
@@ -20,7 +20,7 @@ export const SelectFavorites = () => {
     setModalStatus,
     setModalResize,
   } = useOverlay().modal;
-  const { favoritesList } = useValidators();
+  const { favoritesList } = useFavoriteValidators();
   const { maxNominations } = consts;
   const { nominations, callback: generateNominationsCallback } = options;
 

--- a/src/pages/Community/Entity.tsx
+++ b/src/pages/Community/Entity.tsx
@@ -6,7 +6,7 @@ import { ButtonSecondary, PageHeading, PageRow } from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { ValidatorList } from 'library/ValidatorList';
 import { Item } from './Item';

--- a/src/pages/Community/List.tsx
+++ b/src/pages/Community/List.tsx
@@ -4,7 +4,7 @@
 import { PageRow } from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
 import { useApi } from 'contexts/Api';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { Item } from './Item';
 import { ItemsWrapper } from './Wrappers';
 import { useCommunitySections } from './context';

--- a/src/pages/Nominate/Active/Nominations/index.tsx
+++ b/src/pages/Nominate/Active/Nominations/index.tsx
@@ -10,12 +10,13 @@ import { useHelp } from 'contexts/Help';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { CardHeaderWrapper } from 'library/Card/Wrappers';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
 import { ValidatorList } from 'library/ValidatorList';
 import type { MaybeAccount } from 'types';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 import { Wrapper } from './Wrapper';
 
 export const Nominations = ({
@@ -26,18 +27,15 @@ export const Nominations = ({
   nominator: MaybeAccount;
 }) => {
   const { t } = useTranslation('pages');
-  const { openModal } = useOverlay().modal;
-  const { inSetup } = useStaking();
   const { isSyncing } = useUi();
-  const { activeAccount, isReadOnlyAccount } = useConnect();
-  const { getAccountNominations } = useBonded();
-  const { isFastUnstaking } = useUnstaking();
-  const { nominated: stakeNominated, poolNominated } = useValidators();
   const { openHelp } = useHelp();
-  let { favoritesList } = useValidators();
-  if (favoritesList === null) {
-    favoritesList = [];
-  }
+  const { inSetup } = useStaking();
+  const { openModal } = useOverlay().modal;
+  const { isFastUnstaking } = useUnstaking();
+  const { getAccountNominations } = useBonded();
+  const { favoritesList } = useFavoriteValidators();
+  const { activeAccount, isReadOnlyAccount } = useConnect();
+  const { nominated: stakeNominated, poolNominated } = useValidators();
 
   const {
     poolNominations,

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -15,7 +15,7 @@ import { useNetworkMetrics } from 'contexts/Network';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { StakingContext } from 'contexts/Staking';
 import { useTheme } from 'contexts/Themes';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { Header, List, Wrapper as ListWrapper } from 'library/List';
 import { MotionContainer } from 'library/List/MotionContainer';
 import { Pagination } from 'library/List/Pagination';

--- a/src/pages/Validators/AllValidators.tsx
+++ b/src/pages/Validators/AllValidators.tsx
@@ -4,7 +4,7 @@
 import { PageRow } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { StatBoxList } from 'library/StatBoxList';
 import { ValidatorList } from 'library/ValidatorList';

--- a/src/pages/Validators/Favorites.tsx
+++ b/src/pages/Validators/Favorites.tsx
@@ -4,14 +4,14 @@
 import { PageRow } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useValidators } from 'contexts/Validators';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { ValidatorList } from 'library/ValidatorList';
+import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators';
 
 export const ValidatorFavorites = () => {
   const { t } = useTranslation('pages');
   const { isReady } = useApi();
-  const { favoritesList } = useValidators();
+  const { favoritesList } = useFavoriteValidators();
 
   const batchKey = 'favorite_validators';
 

--- a/src/pages/Validators/Stats/AverageCommission.tsx
+++ b/src/pages/Validators/Stats/AverageCommission.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useTranslation } from 'react-i18next';
-import { useValidators } from 'contexts/Validators';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { Text } from 'library/StatBoxList/Text';
 
 export const AverageCommissionStat = () => {


### PR DESCRIPTION
Separates favorite validator management from `useValidators`, with misc syntax improvements.