### PR TITLE
Tidy up `CardWrapper` for Cloud and `@container`

### DIFF
--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -75,10 +75,10 @@ export const CardWrapper = styled.div<CardWrapperProps>`
   position: relative;
   overflow: hidden;
   margin-top: 1.4rem;
-  padding: ${(props) => (props.$noPadding ? 0 : '1.5rem')};
+  padding: 1.5rem;
 
   @media (max-width: ${SideMenuStickyThreshold}px) {
-    padding: ${(props) => (props.$noPadding ? '0rem' : '1rem 0.75rem')};
+    padding: 1rem 0.75rem;
   }
 
   &.transparent {
@@ -90,8 +90,9 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     padding: 0;
   }
 
-  ${(props) =>
-    props.$warning ? 'border: 1px solid var(--status-warning-color);' : ''}
+  &.warning {
+    border: 1px solid var(--status-warning-color);
+  }
 
   @media (min-width: ${SideMenuStickyThreshold + 1}px) {
     height: ${(props) => (props.height ? `${props.height}px` : 'inherit')};

--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -121,11 +121,4 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     width: 100%;
     position: relative;
   }
-
-  .option {
-    border-bottom: 1px solid #ddd;
-    padding: 0.75rem 1rem;
-    font-size: 1rem;
-    text-align: left;
-  }
 `;

--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -125,9 +125,4 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     font-size: 1rem;
     text-align: left;
   }
-  h4 {
-    &.withMargin {
-      margin: 0.5rem 0;
-    }
-  }
 `;

--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -77,10 +77,6 @@ export const CardWrapper = styled.div<CardWrapperProps>`
   margin-top: 1.4rem;
   padding: 1.5rem;
 
-  @media (max-width: ${SideMenuStickyThreshold}px) {
-    padding: 1rem 0.75rem;
-  }
-
   &.transparent {
     background: none;
     border: none;
@@ -94,19 +90,26 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     border: 1px solid var(--status-warning-color);
   }
 
+  @media (max-width: ${SideMenuStickyThreshold}px) {
+    padding: 1rem 0.75rem;
+  }
+
   @media (min-width: ${SideMenuStickyThreshold + 1}px) {
     height: ${(props) => (props.height ? `${props.height}px` : 'inherit')};
   }
 
   .content {
     padding: 0 0.5rem;
+
+    h3,
+    h4 {
+      margin-top: 0;
+    }
     h3 {
-      margin-top: 0rem;
       margin-bottom: 0.75rem;
     }
 
     h4 {
-      margin-top: 0;
       margin-bottom: 0;
     }
   }

--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -98,6 +98,14 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     height: ${(props) => (props.height ? `${props.height}px` : 'inherit')};
   }
 
+  .inner {
+    padding: 1rem;
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+    position: relative;
+  }
+
   .content {
     padding: 0 0.5rem;
 
@@ -112,13 +120,5 @@ export const CardWrapper = styled.div<CardWrapperProps>`
     h4 {
       margin-bottom: 0;
     }
-  }
-
-  .inner {
-    padding: 1rem;
-    display: flex;
-    flex-flow: column nowrap;
-    width: 100%;
-    position: relative;
   }
 `;

--- a/src/library/Card/Wrappers.ts
+++ b/src/library/Card/Wrappers.ts
@@ -74,25 +74,20 @@ export const CardWrapper = styled.div<CardWrapperProps>`
   flex: 1;
   position: relative;
   overflow: hidden;
-  margin-top: ${(props) => (props.$transparent ? '0rem' : '1.4rem')};
-  padding: ${(props) =>
-    props.$noPadding ? 0 : props.$transparent ? 0 : '1.5rem'};
-  ${(props) =>
-    props.$transparent &&
-    `
-      border: none;
-      box-shadow: none;
-      background: none;
-      border-radius: 0rem;
-    `}
+  margin-top: 1.4rem;
+  padding: ${(props) => (props.$noPadding ? 0 : '1.5rem')};
 
   @media (max-width: ${SideMenuStickyThreshold}px) {
-    padding: ${(props) =>
-      props.$noPadding
-        ? '0rem'
-        : props.$transparent
-        ? '0rem 0rem'
-        : '1rem 0.75rem'};
+    padding: ${(props) => (props.$noPadding ? '0rem' : '1rem 0.75rem')};
+  }
+
+  &.transparent {
+    background: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    margin-top: 0;
+    padding: 0;
   }
 
   ${(props) =>

--- a/src/library/Graphs/types.ts
+++ b/src/library/Graphs/types.ts
@@ -39,10 +39,6 @@ export interface CardHeaderWrapperProps {
 }
 
 export interface CardWrapperProps {
-  $flex?: boolean;
-  $noPadding?: boolean;
-  $transparent?: boolean;
-  border?: string;
   height?: string | number;
 }
 

--- a/src/library/Graphs/types.ts
+++ b/src/library/Graphs/types.ts
@@ -42,7 +42,6 @@ export interface CardWrapperProps {
   $flex?: boolean;
   $noPadding?: boolean;
   $transparent?: boolean;
-  $warning?: boolean;
   border?: string;
   height?: string | number;
 }

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -114,10 +114,7 @@ export const ValidatorMetrics = () => {
           style={{
             margin: '0 0 0 0.5rem',
             height: 350,
-            border: 'none',
-            boxShadow: 'none',
           }}
-          $flex
         >
           <CardHeaderWrapper>
             <h4>

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -110,6 +110,7 @@ export const ValidatorMetrics = () => {
       >
         <SubscanButton />
         <CardWrapper
+          className="transparent"
           style={{
             margin: '0 0 0 0.5rem',
             height: 350,
@@ -117,7 +118,6 @@ export const ValidatorMetrics = () => {
             boxShadow: 'none',
           }}
           $flex
-          $transparent
         >
           <CardHeaderWrapper>
             <h4>

--- a/src/pages/Nominate/Active/ControllerNotStash.tsx
+++ b/src/pages/Nominate/Active/ControllerNotStash.tsx
@@ -42,7 +42,7 @@ export const ControllerNotStash = () => {
         ? !isSyncing &&
           !isReadOnlyAccount(activeAccount) && (
             <PageRow>
-              <CardWrapper $warning>
+              <CardWrapper className="warning">
                 <CardHeaderWrapper>
                   <h3>
                     <FontAwesomeIcon icon={faExclamationTriangle} />

--- a/src/pages/Overview/StakeStatus/index.tsx
+++ b/src/pages/Overview/StakeStatus/index.tsx
@@ -14,7 +14,7 @@ export const StakeStatus = () => {
   const showTips = plugins.includes('tips');
 
   return (
-    <CardWrapper $noPadding>
+    <CardWrapper style={{ padding: 0 }}>
       <StatusWrapper>
         <RowSection secondary>
           <section>

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -79,13 +79,13 @@ export const Overview = () => {
       </PageRow>
       <PageRow>
         <RowSection secondary>
-          <CardWrapper height={PAYOUTS_HEIGHT} $flex>
+          <CardWrapper height={PAYOUTS_HEIGHT}>
             <BalanceChart />
             <BalanceLinks />
           </CardWrapper>
         </RowSection>
         <RowSection hLast vLast>
-          <CardWrapper style={{ minHeight: PAYOUTS_HEIGHT }} $flex>
+          <CardWrapper style={{ minHeight: PAYOUTS_HEIGHT }}>
             <SubscanButton />
             <CardHeaderWrapper>
               <h4>{t('overview.recentPayouts')}</h4>

--- a/src/pages/Pools/Create/PoolRoles/index.tsx
+++ b/src/pages/Pools/Create/PoolRoles/index.tsx
@@ -68,16 +68,17 @@ export const PoolRoles = ({ section }: SetupStepProps) => {
         bondFor="pool"
       />
       <MotionContainer thisSection={section} activeSection={setup.section}>
-        <h4 className="withMargin">
+        <h4 style={{ margin: '0.5rem 0' }}>
           <Trans defaults={t('pools.poolCreator')} components={{ b: <b /> }} />
         </h4>
-        <h4 className="withMargin">
+        <h4 style={{ margin: '0.5rem 0 1.5rem 0' }}>
           <Trans
             defaults={t('pools.assignedToAnyAccount')}
             components={{ b: <b /> }}
           />
         </h4>
         <Roles
+          inline
           batchKey="pool_roles_create"
           listenIsValid={setRolesValid}
           defaultRoles={initialValue}

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -6,7 +6,11 @@ import {
   faEdit,
   faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
-import { ButtonHelp, ButtonPrimary } from '@polkadot-cloud/react';
+import {
+  ButtonHelp,
+  ButtonPrimary,
+  ButtonPrimaryInvert,
+} from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
@@ -26,6 +30,7 @@ export const Roles = ({
   batchKey,
   defaultRoles,
   setters = [],
+  inline = false,
   listenIsValid = () => {},
 }: RolesProps) => {
   const { t } = useTranslation('pages');
@@ -140,20 +145,25 @@ export const Roles = ({
     setRoleEdits(newEdit);
   };
 
+  const ButtonType = inline ? ButtonPrimaryInvert : ButtonPrimary;
+
   return (
     <>
       <CardHeaderWrapper $withAction>
-        <h3>
-          {t('pools.roles')}{' '}
-          <ButtonHelp marginLeft onClick={() => openHelp('Pool Roles')} />
-        </h3>
+        {!inline && (
+          <h3>
+            {t('pools.roles')}
+            <ButtonHelp marginLeft onClick={() => openHelp('Pool Roles')} />
+          </h3>
+        )}
+
         {!(isOwner() === true || setters.length) ? (
           <></>
         ) : (
           <>
             {isEditing && (
               <div>
-                <ButtonPrimary
+                <ButtonType
                   iconLeft={faTimesCircle}
                   iconTransform="grow-1"
                   text={t('pools.cancel')}
@@ -164,7 +174,7 @@ export const Roles = ({
             )}
             &nbsp;&nbsp;
             <div>
-              <ButtonPrimary
+              <ButtonType
                 iconLeft={isEditing ? faCheckCircle : faEdit}
                 iconTransform="grow-1"
                 text={isEditing ? t('pools.save') : t('pools.edit')}

--- a/src/pages/Pools/Roles/types.ts
+++ b/src/pages/Pools/Roles/types.ts
@@ -8,6 +8,7 @@ export interface RolesProps {
   defaultRoles: PoolRoles;
   listenIsValid?: any;
   setters?: any;
+  inline?: boolean;
 }
 
 export type RoleEditEntry = {


### PR DESCRIPTION
Legacy classes and refactors for `CardWrapper` so it can be moved to Cloud and use `@container` queries. Includes misc UX fixes.