### PR TITLE
remove clipAddress and replace it with the more advanced EllipsisFn

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@polkadot-cloud/community": "^0.1.10",
     "@polkadot-cloud/core": "^0.1.12",
     "@polkadot-cloud/react": "^0.1.32",
-    "@polkadot-cloud/utils": "^0.0.9",
+    "@polkadot-cloud/utils": "^0.0.11",
     "@polkadot/api": "^10.9.1",
     "@polkadot/keyring": "^12.1.1",
     "@polkadot/rpc-provider": "^10.9.1",

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -4,7 +4,7 @@
 import type { VoidFn } from '@polkadot/api/types';
 import Keyring from '@polkadot/keyring';
 import {
-  clipAddress,
+  ellipsisFn,
   localStorageOrDefault,
   setStateWithRef,
 } from '@polkadot-cloud/utils';
@@ -464,7 +464,7 @@ export const ConnectProvider = ({
     const newAccount = {
       address: formatted,
       network: network.name,
-      name: clipAddress(address),
+      name: ellipsisFn(address),
       source: 'external',
       addedBy,
     };

--- a/src/contexts/Hardware/Vault.tsx
+++ b/src/contexts/Hardware/Vault.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { clipAddress, setStateWithRef } from '@polkadot-cloud/utils';
+import { ellipsisFn, setStateWithRef } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
 import { useApi } from 'contexts/Api';
 import type { VaultAccount } from 'contexts/Connect/types';
@@ -39,7 +39,7 @@ export const VaultHardwareProvider = ({
       const account = {
         address,
         network: network.name,
-        name: clipAddress(address),
+        name: ellipsisFn(address),
         source: 'vault',
         index,
       };

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -4,7 +4,7 @@
 import type { VoidFn } from '@polkadot/api/types';
 import {
   addedTo,
-  clipAddress,
+  ellipsisFn,
   localStorageOrDefault,
   matchedProperties,
   removedFrom,
@@ -151,7 +151,7 @@ export const ProxiesProvider = ({
       .filter(({ proxyType }) => isSupportedProxy(proxyType))
       .map(({ delegator, proxyType }) => ({
         address: delegator,
-        name: clipAddress(delegator),
+        name: ellipsisFn(delegator),
         proxyType,
       }));
     return proxiedAccounts;

--- a/src/library/Account/Default.tsx
+++ b/src/library/Account/Default.tsx
@@ -3,7 +3,7 @@
 
 import { faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { clipAddress, remToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useConnect } from 'contexts/Connect';
@@ -36,15 +36,15 @@ export const Account = ({
       case 'name':
         setDisplayValue(
           value !== ''
-            ? getAccount(value)?.name || clipAddress(value)
-            : clipAddress(value)
+            ? getAccount(value)?.name || ellipsisFn(value)
+            : ellipsisFn(value)
         );
         break;
       case 'text':
         setDisplayValue(value);
         break;
       default:
-        if (value) setDisplayValue(clipAddress(value));
+        if (value) setDisplayValue(ellipsisFn(value));
     }
 
     // if title prop is provided, override `displayValue`

--- a/src/library/Account/Pool.tsx
+++ b/src/library/Account/Pool.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
-import { clipAddress, remToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
@@ -58,7 +58,7 @@ export const Account = ({
   const syncing = metaData === undefined;
 
   // display value
-  const defaultDisplay = clipAddress(pool.addresses.stash);
+  const defaultDisplay = ellipsisFn(pool.addresses.stash);
   let display = syncing ? t('syncing') : metaData ?? defaultDisplay;
 
   // check if super identity has been byte encoded

--- a/src/library/ListItem/Labels/Identity.tsx
+++ b/src/library/ListItem/Labels/Identity.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { clipAddress } from '@polkadot-cloud/utils';
+import { ellipsisFn } from '@polkadot-cloud/utils';
 import { useEffect, useState } from 'react';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { PolkadotIcon } from '@polkadot-cloud/react';
@@ -42,7 +42,7 @@ export const Identity = ({ address }: IdentityProps) => {
         {identitiesSynced && supersSynced && display !== null ? (
           <h4>{display}</h4>
         ) : (
-          <h4>{clipAddress(address)}</h4>
+          <h4>{ellipsisFn(address, 6)}</h4>
         )}
       </div>
     </IdentityWrapper>

--- a/src/library/ListItem/Labels/PoolIdentity.tsx
+++ b/src/library/ListItem/Labels/PoolIdentity.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { clipAddress, determinePoolDisplay } from '@polkadot-cloud/utils';
+import { ellipsisFn, determinePoolDisplay } from '@polkadot-cloud/utils';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { PolkadotIcon } from '@polkadot-cloud/react';
 import { useTheme } from 'contexts/Themes';
@@ -36,7 +36,7 @@ export const PoolIdentity = ({
       />
       <div className="inner">
         {!metadataSynced ? (
-          <h4>{clipAddress(addresses.stash)}</h4>
+          <h4>{ellipsisFn(addresses.stash)}</h4>
         ) : (
           <h4>{display}</h4>
         )}

--- a/src/modals/Accounts/Account.tsx
+++ b/src/modals/Accounts/Account.tsx
@@ -3,7 +3,7 @@
 
 import { faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { clipAddress, planckToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
 import { Extensions } from '@polkadot-cloud/community/extensions';
 import { useConnect } from 'contexts/Connect';
@@ -107,7 +107,7 @@ export const AccountButton = ({
                   </span>
                 </>
               )}
-              {meta?.name ?? clipAddress(address ?? '')}
+              {meta?.name ?? ellipsisFn(address ?? '')}
             </span>
             {meta?.source === 'external' && (
               <div

--- a/src/modals/ChangePoolRoles/RoleChange.tsx
+++ b/src/modals/ChangePoolRoles/RoleChange.tsx
@@ -3,7 +3,7 @@
 
 import { faAnglesRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { clipAddress, remToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
 import { PolkadotIcon } from '@polkadot-cloud/react';
 import { useTheme } from 'contexts/Themes';
 import { RoleChangeWrapper } from './Wrapper';
@@ -24,7 +24,7 @@ export const RoleChange = ({ roleName, oldAddress, newAddress }: any) => {
           <input
             className="input"
             disabled
-            value={oldAddress ? clipAddress(oldAddress) : ''}
+            value={oldAddress ? ellipsisFn(oldAddress) : ''}
           />
         </div>
         <span>
@@ -40,7 +40,7 @@ export const RoleChange = ({ roleName, oldAddress, newAddress }: any) => {
           <input
             className="input"
             disabled
-            value={newAddress ? clipAddress(newAddress) : ''}
+            value={newAddress ? ellipsisFn(newAddress) : ''}
           />
         </div>
       </div>

--- a/src/modals/ImportLedger/Addresses.tsx
+++ b/src/modals/ImportLedger/Addresses.tsx
@@ -7,7 +7,7 @@ import {
   HardwareAddress,
   PolkadotIcon,
 } from '@polkadot-cloud/react';
-import { clipAddress, unescape } from '@polkadot-cloud/utils';
+import { ellipsisFn, unescape } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
@@ -72,7 +72,7 @@ export const Addresess = ({ addresses, handleLedgerLoop }: AnyJson) => {
               );
               return localAddress?.name
                 ? unescape(localAddress.name)
-                : clipAddress(address);
+                : ellipsisFn(address);
             })();
 
             return (

--- a/src/modals/ImportLedger/index.tsx
+++ b/src/modals/ImportLedger/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/polkadot-native authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { clipAddress, setStateWithRef } from '@polkadot-cloud/utils';
+import { ellipsisFn, setStateWithRef } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
 import { useApi } from 'contexts/Api';
 import { useLedgerHardware } from 'contexts/Hardware/Ledger';
@@ -105,7 +105,7 @@ export const ImportLedger: React.FC = () => {
         index: options.accountIndex,
         pubKey,
         address,
-        name: clipAddress(address),
+        name: ellipsisFn(address),
         network: network.name,
       }));
 

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { ButtonHelp, ModalPadding, PolkadotIcon } from '@polkadot-cloud/react';
-import { clipAddress, planckToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -91,7 +91,7 @@ export const ValidatorMetrics = () => {
         />
         <h2>
           &nbsp;&nbsp;
-          {identity === null ? clipAddress(address) : identity}
+          {identity === null ? ellipsisFn(address) : identity}
         </h2>
       </div>
 

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -3,7 +3,7 @@
 
 import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { clipAddress, unitToPlanck } from '@polkadot-cloud/utils';
+import { ellipsisFn, unitToPlanck } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
@@ -94,7 +94,7 @@ export const Summary = ({ section }: SetupStepProps) => {
             </div>
             <div>
               {payee.destination === 'Account'
-                ? `${payeeDisplay}: ${clipAddress(payee.account)}`
+                ? `${payeeDisplay}: ${ellipsisFn(payee.account)}`
                 : payeeDisplay}
             </div>
           </section>

--- a/src/pages/Overview/ActiveAccounts/Item.tsx
+++ b/src/pages/Overview/ActiveAccounts/Item.tsx
@@ -4,7 +4,7 @@
 import { faCopy } from '@fortawesome/free-regular-svg-icons';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { clipAddress, remToUnit } from '@polkadot-cloud/utils';
+import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
 import { useConnect } from 'contexts/Connect';
 import { useNotifications } from 'contexts/Notifications';
@@ -70,7 +70,7 @@ export const Item = ({ address, delegate = null }: ActiveAccountProps) => {
                   </span>
                 </>
               )}
-              {clipAddress(primaryAddress)}
+              {ellipsisFn(primaryAddress)}
               <button
                 type="button"
                 onClick={() => {
@@ -86,7 +86,7 @@ export const Item = ({ address, delegate = null }: ActiveAccountProps) => {
                   transform="shrink-4"
                 />
               </button>
-              {accountData.name !== clipAddress(primaryAddress) && (
+              {accountData.name !== ellipsisFn(primaryAddress) && (
                 <>
                   <div className="sep" />
                   <div className="rest">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,15 +1478,15 @@
     "@polkadot-cloud/utils" "^0.0.6"
     react-error-boundary "^4.0.11"
 
+"@polkadot-cloud/utils@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/utils/-/utils-0.0.11.tgz#1b5afeffb12f6df8958eb6285a8020c28d06eadf"
+  integrity sha512-h73gDY5IDUIVS3KboPE7F5ks0CwVyqYE+jVpGI1kiV5aUseluSaOqRj3enZNWm2q04m358ZUgVxjZ9g9vSoJeA==
+
 "@polkadot-cloud/utils@^0.0.6":
   version "0.0.6"
   resolved "https://registry.npmjs.org/@polkadot-cloud/utils/-/utils-0.0.6.tgz#ea0fc18c6af7cd6a1d14ae6674f19b1b3ef82347"
   integrity sha512-alm1zdqRcuBm9a59jy0yPKWY4FTenQTKvLSrX/+8aV0YbkwQ6vBkUwhs3FMi5GI52pC68X6VO5DzwVscg6kvEg==
-
-"@polkadot-cloud/utils@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/utils/-/utils-0.0.9.tgz#e0d4b7a15fc42b4f321eb8b0182329b4367c573b"
-  integrity sha512-14EowuGj6jl+zf6qXEikaDKkvFREqj8YXs9Z8vgQpdQ55LgXD47M0D5SSKFIfrOCNFymgAXePYru5U0SfxWoLg==
 
 "@polkadot/api-augment@10.9.1":
   version "10.9.1"


### PR DESCRIPTION
[PR #492 of polkadot-cloud](https://github.com/paritytech/polkadot-cloud/pull/492) deprecates the clipAddress from @polkadot-cloud/utils for a more advanced function called ellipsisFn;

As a result we need to update the naming here as well;

Visually absolutely nothing is changed, as `ellipsisFn` is defaulting to 6 characters and "center" positioning of the ellipsis