### PR TITLE
Claim payout fixes

### DIFF
--- a/src/locale/cn/modals.json
+++ b/src/locale/cn/modals.json
@@ -42,7 +42,6 @@
     "checking": "检验中...",
     "chooseLanguage": "选择语言",
     "claim": "申领",
-    "claimAll": "申领所有",
     "claimCommission": "申领佣金",
     "claimOutstandingCommission": "在提名池奖励帐户中申领任何未付佣金",
     "claimPayouts": "申领收益",

--- a/src/locale/en/modals.json
+++ b/src/locale/en/modals.json
@@ -44,7 +44,6 @@
     "checking": "Checking...",
     "chooseLanguage": "Choose Language",
     "claim": "Claim",
-    "claimAll": "Claim All",
     "claimCommission": "Claim Commission",
     "claimOutstandingCommission": " Claim any outstanding commission in the pool reward account.",
     "claimPayouts": "Claim Payouts",

--- a/src/modals/ClaimPayouts/Overview.tsx
+++ b/src/modals/ClaimPayouts/Overview.tsx
@@ -1,10 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { ButtonSubmit, ModalNotes } from '@polkadot-cloud/react';
+import { ModalNotes } from '@polkadot-cloud/react';
 import { forwardRef } from 'react';
 import { usePayouts } from 'contexts/Payouts';
-import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { Item } from './Item';
 import { ContentWrapper } from './Wrappers';
@@ -15,33 +14,9 @@ export const Overview = forwardRef(
     const { t } = useTranslation('modals');
     const { unclaimedPayouts } = usePayouts();
 
-    const claimAllPayouts = Object.entries(unclaimedPayouts || {}).map(
-      ([era, validatorPayout]) => ({
-        era,
-        payout: Object.entries(validatorPayout)
-          .reduce(
-            (acc: BigNumber, [, amount]) => acc.plus(amount),
-            new BigNumber(0)
-          )
-          .toString(),
-        validators: Object.keys(validatorPayout),
-      })
-    );
-
     return (
       <ContentWrapper>
         <div className="padding" ref={ref}>
-          <div style={{ margin: '1rem 0 0.5rem 0' }}>
-            <ButtonSubmit
-              disabled={Object.values(unclaimedPayouts || {}).length === 0}
-              text={t('claimAll')}
-              onClick={() => {
-                setPayouts(claimAllPayouts);
-                setSection(1);
-              }}
-            />
-          </div>
-
           {Object.entries(unclaimedPayouts || {}).map(
             ([era, unclaimedPayout]: any, i: number) => (
               <Item


### PR DESCRIPTION
- Removes "Claim All" due to a transaction block limit that quickly exhausts the function.
- Fixes an issue where syncing was hanging when switching between active nominator accounts with unclaimed payouts.
- Fixes an issue where zero balance unclaimed payouts were being displayed.

Addresses #1429 and #1427.