### PR TITLE
Standalone `Network` context, `network` as name

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -16,7 +16,7 @@ import { HelpProvider } from 'contexts/Help';
 import { IdentitiesProvider } from 'contexts/Identities';
 import { MenuProvider } from 'contexts/Menu';
 import { MigrateProvider } from 'contexts/Migrate';
-import { NetworkMetricsProvider } from 'contexts/Network';
+import { NetworkMetricsProvider } from 'contexts/NetworkMetrics';
 import { NotificationsProvider } from 'contexts/Notifications';
 import { PromptProvider } from 'contexts/Prompt';
 import { PluginsProvider } from 'contexts/Plugins';
@@ -37,10 +37,12 @@ import { ValidatorsProvider } from 'contexts/Validators/ValidatorEntries';
 import { FavoriteValidatorsProvider } from 'contexts/Validators/FavoriteValidators';
 import { withProviders } from 'library/Hooks';
 import { PayoutsProvider } from 'contexts/Payouts';
-import { PolkawatchProvider } from './contexts/Plugins/Polkawatch';
+import { NetworkProvider } from 'contexts/Network';
+import { PolkawatchProvider } from 'contexts/Plugins/Polkawatch';
 
 // !! Provider order matters.
 export const Providers = withProviders(
+  NetworkProvider,
   APIProvider,
   FiltersProvider,
   NotificationsProvider,

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -33,7 +33,7 @@ import { useNetwork } from 'contexts/Network';
 
 export const RouterInner = () => {
   const { t } = useTranslation();
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { pathname } = useLocation();
   const { addNotification } = useNotifications();
   const { accountsInitialised, accounts, activeAccount, connectToAccount } =
@@ -43,7 +43,7 @@ export const RouterInner = () => {
   // Scroll to top of the window on every page change or network change.
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname, networkData]);
+  }, [pathname, network]);
 
   // Set references to UI context and make available throughout app.
   useEffect(() => {
@@ -116,7 +116,7 @@ export const RouterInner = () => {
                         <Page>
                           <Helmet>
                             <title>{`${t(key, { ns: 'base' })} : ${t('title', {
-                              context: `${networkData.name}`,
+                              context: `${network}`,
                               ns: 'base',
                             })}`}</title>
                           </Helmet>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -17,7 +17,6 @@ import {
 } from 'react-router-dom';
 import { Prompt } from 'library/Prompt';
 import { PagesConfig } from 'config/pages';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useNotifications } from 'contexts/Notifications';
 import { useUi } from 'contexts/UI';
@@ -30,10 +29,11 @@ import { Notifications } from 'library/Notifications';
 import { SideMenu } from 'library/SideMenu';
 import { Tooltip } from 'library/Tooltip';
 import { Overlays } from 'overlay';
+import { useNetwork } from 'contexts/Network';
 
 export const RouterInner = () => {
   const { t } = useTranslation();
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { pathname } = useLocation();
   const { addNotification } = useNotifications();
   const { accountsInitialised, accounts, activeAccount, connectToAccount } =
@@ -43,7 +43,7 @@ export const RouterInner = () => {
   // Scroll to top of the window on every page change or network change.
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname, network]);
+  }, [pathname, networkData]);
 
   // Set references to UI context and make available throughout app.
   useEffect(() => {
@@ -116,7 +116,7 @@ export const RouterInner = () => {
                         <Page>
                           <Helmet>
                             <title>{`${t(key, { ns: 'base' })} : ${t('title', {
-                              context: `${network.name}`,
+                              context: `${networkData.name}`,
                               ns: 'base',
                             })}`}</title>
                           </Helmet>

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -4,8 +4,8 @@
 import { ThemeProvider } from 'styled-components';
 import { Entry } from '@polkadot-cloud/react';
 import { Router } from 'Router';
-import { useApi } from 'contexts/Api';
 import { useTheme } from 'contexts/Themes';
+import { useNetwork } from 'contexts/Network';
 
 // App-wide theme classes are inserted here.
 //
@@ -13,11 +13,11 @@ import { useTheme } from 'contexts/Themes';
 // `@polkadot-cloud/react` themes are added to `Entry`.
 export const ThemedRouter = () => {
   const { mode } = useTheme();
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   return (
     <ThemeProvider theme={{ mode }}>
-      <Entry mode={mode} theme={`${network.name}-relay`}>
+      <Entry mode={mode} theme={`${networkData.name}-relay`}>
         <Router />
       </Entry>
     </ThemeProvider>

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -13,11 +13,11 @@ import { useNetwork } from 'contexts/Network';
 // `@polkadot-cloud/react` themes are added to `Entry`.
 export const ThemedRouter = () => {
   const { mode } = useTheme();
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   return (
     <ThemeProvider theme={{ mode }}>
-      <Entry mode={mode} theme={`${networkData.name}-relay`}>
+      <Entry mode={mode} theme={`${network}-relay`}>
         <Router />
       </Entry>
     </ThemeProvider>

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -4,7 +4,6 @@
 
 import { stringToU8a } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
-import { NetworkList } from 'config/networks';
 import type { APIConstants, APIContextInterface } from 'contexts/Api/types';
 
 export const consts: APIConstants = {
@@ -22,14 +21,11 @@ export const consts: APIConstants = {
 };
 
 export const defaultApiContext: APIContextInterface = {
-  switchNetwork: async (n, lc) => {
-    await new Promise((resolve) => resolve(null));
-  },
   api: null,
   consts,
   chainState: undefined,
-  isLightClient: false,
   isReady: false,
   apiStatus: 'disconnected',
-  network: NetworkList.polkadot,
+  isLightClient: false,
+  setIsLightClient: () => {},
 };

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -3,17 +3,11 @@
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { ScProvider } from '@polkadot/rpc-provider/substrate-connect';
-import {
-  extractUrlValue,
-  makeCancelable,
-  rmCommas,
-  varToUrlHash,
-} from '@polkadot-cloud/utils';
+import { makeCancelable, rmCommas } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import React, { useEffect, useState } from 'react';
 import { NetworkList } from 'config/networks';
 import {
-  DefaultNetwork,
   FallbackBondingDuration,
   FallbackEpochDuration,
   FallbackExpectedBlockTime,
@@ -27,71 +21,15 @@ import type {
   APIConstants,
   APIContextInterface,
   ApiStatus,
-  NetworkState,
 } from 'contexts/Api/types';
 import type { AnyApi, NetworkName } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 
 export const APIProvider = ({ children }: { children: React.ReactNode }) => {
-  // Get the initial network and prepare meta tags if necessary.
-  const getInitialNetwork = () => {
-    const urlNetworkRaw = extractUrlValue('n');
-
-    const urlNetworkValid = !!Object.values(NetworkList).find(
-      (n) => n.name === urlNetworkRaw
-    );
-
-    // use network from url if valid.
-    if (urlNetworkValid) {
-      const urlNetwork = urlNetworkRaw as NetworkName;
-
-      if (urlNetworkValid) {
-        return urlNetwork;
-      }
-    }
-    // fallback to localStorage network if there.
-    const localNetwork: NetworkName = localStorage.getItem(
-      'network'
-    ) as NetworkName;
-    const localNetworkValid = !!Object.values(NetworkList).find(
-      (n) => n.name === localNetwork
-    );
-    return localNetworkValid ? localNetwork : DefaultNetwork;
-  };
-
-  // handle network switching
-  const switchNetwork = async (name: NetworkName, lightClient: boolean) => {
-    // disconnect api if there is an existing connection.
-    if (api) {
-      await api.disconnect();
-      setApi(null);
-    }
-    // handle local light client flag.
-    if (lightClient) {
-      localStorage.setItem('light_client', lightClient ? 'true' : '');
-    } else {
-      localStorage.removeItem('light_client');
-    }
-
-    setNetwork({
-      name,
-      meta: NetworkList[name],
-    });
-
-    // handle light client state, which will trigger dynamic Sc import.
-    setIsLightClient(lightClient);
-
-    // update url `n` if needed.
-    varToUrlHash('n', name, false);
-
-    // if not light client, directly connect. Otherwise, `connect` is called after dynamic import of
-    // Sc.
-    if (!lightClient) {
-      setApiStatus('connecting');
-      connectProvider(name);
-    }
-  };
+  const { networkData } = useNetwork();
+  const { name: networkName } = networkData;
 
   // Store povider instance.
   const [provider, setProvider] = useState<WsProvider | ScProvider | null>(
@@ -109,13 +47,6 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   // API instance state.
   const [api, setApi] = useState<ApiPromise | null>(null);
 
-  // Store the initial active network.
-  const initialNetwork = getInitialNetwork();
-  const [network, setNetwork] = useState<NetworkState>({
-    name: initialNetwork,
-    meta: NetworkList[initialNetwork],
-  });
-
   // Store network constants.
   const [consts, setConsts] = useState<APIConstants>(defaults.consts);
 
@@ -125,7 +56,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   // Handle an initial RPC connection.
   useEffect(() => {
     if (!provider && !isLightClient) {
-      connectProvider(getInitialNetwork());
+      connectProvider(networkName);
     }
   });
 
@@ -133,35 +64,58 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   const handleLightClientConnection = async (Sc: AnyApi) => {
     const newProvider = new ScProvider(
       Sc,
-      NetworkList[network.name].endpoints.lightClient
+      NetworkList[networkName].endpoints.lightClient
     );
-    connectProvider(network.name, newProvider);
+    connectProvider(networkName, newProvider);
   };
 
   // Handle a switch in API.
+  let cancelFn: () => void | undefined;
+
   const handleApiSwitch = () => {
     setApi(null);
     setConsts(defaults.consts);
     setchainState(undefined);
   };
+
+  // Handle connect to API.
   // Dynamically load `Sc` when user opts to use light client.
-  useEffect(() => {
-    let cancel: () => void | undefined;
+  const handleConnectApi = async () => {
+    if (api) {
+      await api.disconnect();
+      setApi(null);
+    }
+    // handle local light client flag.
+    if (isLightClient) {
+      localStorage.setItem('light_client', isLightClient ? 'true' : '');
+    } else {
+      localStorage.removeItem('light_client');
+    }
 
     if (isLightClient) {
       handleApiSwitch();
       setApiStatus('connecting');
 
       const ScPromise = makeCancelable(import('@substrate/connect'));
-      cancel = ScPromise.cancel;
+      cancelFn = ScPromise.cancel;
       ScPromise.promise.then((Sc) => {
         handleLightClientConnection(Sc);
       });
+    } else {
+      // if not light client, directly connect.
+      setApiStatus('connecting');
+      connectProvider(networkName);
     }
+  };
+
+  // Trigger API connection handler on network or light client change.
+  useEffect(() => {
+    handleConnectApi();
+
     return () => {
-      cancel?.();
+      cancelFn?.();
     };
-  }, [isLightClient, network.name]);
+  }, [isLightClient, networkName]);
 
   // Initialise provider event handlers when provider is set.
   useEffectIgnoreInitial(() => {
@@ -209,7 +163,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
 
     // store active network in localStorage.
     // NOTE: this should ideally refer to above `chain` value.
-    localStorage.setItem('network', String(network.name));
+    localStorage.setItem('network', String(networkName));
 
     // Assume chain state is correct and bootstrap network consts.
     connectedCallback(newApi);
@@ -304,14 +258,13 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <APIContext.Provider
       value={{
-        switchNetwork,
         api,
         consts,
         chainState,
         isReady: apiStatus === 'connected' && api !== null,
-        network: network.meta,
         apiStatus,
         isLightClient,
+        setIsLightClient,
       }}
     >
       {children}

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -28,8 +28,7 @@ import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 
 export const APIProvider = ({ children }: { children: React.ReactNode }) => {
-  const { networkData } = useNetwork();
-  const { name: networkName } = networkData;
+  const { network } = useNetwork();
 
   // Store povider instance.
   const [provider, setProvider] = useState<WsProvider | ScProvider | null>(
@@ -56,7 +55,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   // Handle an initial RPC connection.
   useEffect(() => {
     if (!provider && !isLightClient) {
-      connectProvider(networkName);
+      connectProvider(network);
     }
   });
 
@@ -64,9 +63,9 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
   const handleLightClientConnection = async (Sc: AnyApi) => {
     const newProvider = new ScProvider(
       Sc,
-      NetworkList[networkName].endpoints.lightClient
+      NetworkList[network].endpoints.lightClient
     );
-    connectProvider(networkName, newProvider);
+    connectProvider(network, newProvider);
   };
 
   // Handle a switch in API.
@@ -104,7 +103,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     } else {
       // if not light client, directly connect.
       setApiStatus('connecting');
-      connectProvider(networkName);
+      connectProvider(network);
     }
   };
 
@@ -115,7 +114,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
     return () => {
       cancelFn?.();
     };
-  }, [isLightClient, networkName]);
+  }, [isLightClient, network]);
 
   // Initialise provider event handlers when provider is set.
   useEffectIgnoreInitial(() => {
@@ -163,7 +162,7 @@ export const APIProvider = ({ children }: { children: React.ReactNode }) => {
 
     // store active network in localStorage.
     // NOTE: this should ideally refer to above `chain` value.
-    localStorage.setItem('network', String(networkName));
+    localStorage.setItem('network', String(network));
 
     // Assume chain state is correct and bootstrap network consts.
     connectedCallback(newApi);

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -35,12 +35,11 @@ export type APIChainState =
   | undefined;
 
 export interface APIContextInterface {
-  switchNetwork: (n: NetworkName, l: boolean) => Promise<void>;
   api: ApiPromise | null;
   consts: APIConstants;
   chainState: APIChainState;
   isReady: boolean;
-  isLightClient: boolean;
   apiStatus: ApiStatus;
-  network: Network;
+  isLightClient: boolean;
+  setIsLightClient: (isLightClient: boolean) => void;
 }

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -35,7 +35,7 @@ export const BalancesProvider = ({
   children: React.ReactNode;
 }) => {
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { accounts, addExternalAccount, getAccount } = useConnect();
 
   const [balances, setBalances] = useState<Balances[]>([]);
@@ -180,13 +180,13 @@ export const BalancesProvider = ({
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, networkData, isReady]);
+  }, [accounts, network, isReady]);
 
   // Unsubscribe from subscriptions on network change & unmount.
   useEffectIgnoreInitial(() => {
     unsubAll();
     return () => unsubAll();
-  }, [networkData]);
+  }, [network]);
 
   // Gets a ledger for a stash address.
   const getStashLedger = (address: MaybeAccount) => {

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -15,6 +15,7 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import type { AnyApi, MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { getLedger } from './Utils';
 import * as defaults from './defaults';
 import type {
@@ -33,7 +34,8 @@ export const BalancesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, isReady, network } = useApi();
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const { accounts, addExternalAccount, getAccount } = useConnect();
 
   const [balances, setBalances] = useState<Balances[]>([]);
@@ -178,13 +180,13 @@ export const BalancesProvider = ({
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, network, isReady]);
+  }, [accounts, networkData, isReady]);
 
   // Unsubscribe from subscriptions on network change & unmount.
   useEffectIgnoreInitial(() => {
     unsubAll();
     return () => unsubAll();
-  }, [network]);
+  }, [networkData]);
 
   // Gets a ledger for a stash address.
   const getStashLedger = (address: MaybeAccount) => {

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -13,11 +13,13 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import type { AnyApi, MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 import type { BondedAccount, BondedContextInterface } from './types';
 
 export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
-  const { api, isReady, network } = useApi();
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const { accounts, addExternalAccount } = useConnect();
 
   // Balance accounts state.
@@ -67,7 +69,7 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, network, isReady]);
+  }, [accounts, networkData, isReady]);
 
   // Unsubscribe from subscriptions on unmount.
   useEffect(

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -18,8 +18,8 @@ import * as defaults from './defaults';
 import type { BondedAccount, BondedContextInterface } from './types';
 
 export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
   const { accounts, addExternalAccount } = useConnect();
 
   // Balance accounts state.
@@ -69,7 +69,7 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, networkData, isReady]);
+  }, [accounts, network, isReady]);
 
   // Unsubscribe from subscriptions on unmount.
   useEffect(

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -19,7 +19,7 @@ import { defaultHandleImportExtension } from '../defaults';
 import type { HandleImportExtension, ImportedAccount } from '../types';
 
 export const useImportExtension = () => {
-  const { networkData } = useNetwork();
+  const { networkData, network } = useNetwork();
   const { setExtensionStatus } = useExtensions();
 
   // Handles importing of an extension.
@@ -75,7 +75,7 @@ export const useImportExtension = () => {
     });
 
     // remove newAccounts from local external accounts if present
-    const inExternal = getInExternalAccounts(newAccounts, networkData.name);
+    const inExternal = getInExternalAccounts(newAccounts, network);
     forget(inExternal);
 
     // find any accounts that have been removed from this extension

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -3,13 +3,13 @@
 
 import Keyring from '@polkadot/keyring';
 import { isValidAddress } from '@polkadot-cloud/utils';
-import { useApi } from 'contexts/Api';
 import { useExtensions } from '@polkadot-cloud/react/hooks';
 import type {
   ExtensionAccount,
   ExtensionInterface,
 } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
 import type { AnyFunction } from 'types';
+import { useNetwork } from 'contexts/Network';
 import {
   addToLocalExtensions,
   getActiveAccountLocal,
@@ -19,7 +19,7 @@ import { defaultHandleImportExtension } from '../defaults';
 import type { HandleImportExtension, ImportedAccount } from '../types';
 
 export const useImportExtension = () => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { setExtensionStatus } = useExtensions();
 
   // Handles importing of an extension.
@@ -62,7 +62,7 @@ export const useImportExtension = () => {
   ): HandleImportExtension => {
     // set network ss58 format
     const keyring = new Keyring();
-    keyring.setSS58Format(network.ss58);
+    keyring.setSS58Format(networkData.ss58);
 
     // remove accounts that do not contain correctly formatted addresses.
     newAccounts = newAccounts.filter((i) => isValidAddress(i.address));
@@ -75,7 +75,7 @@ export const useImportExtension = () => {
     });
 
     // remove newAccounts from local external accounts if present
-    const inExternal = getInExternalAccounts(newAccounts, network.name);
+    const inExternal = getInExternalAccounts(newAccounts, networkData.name);
     forget(inExternal);
 
     // find any accounts that have been removed from this extension
@@ -84,7 +84,7 @@ export const useImportExtension = () => {
       .filter((j) => !newAccounts.find((i) => i.address === j.address));
     // check whether active account is present in forgotten accounts
     const activeGoneFromExtension = goneFromExtension.find(
-      (i) => i.address === getActiveAccountLocal(network)
+      (i) => i.address === getActiveAccountLocal(networkData)
     );
     // commit remove forgotten accounts
     forget(goneFromExtension);
@@ -117,7 +117,8 @@ export const useImportExtension = () => {
   //
   // checks if the local active account is in the extension.
   const getActiveExtensionAccount = (accounts: ImportedAccount[]) =>
-    accounts.find((a) => a.address === getActiveAccountLocal(network)) ?? null;
+    accounts.find((a) => a.address === getActiveAccountLocal(networkData)) ??
+    null;
 
   // Connect active extension account.
   //

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -46,7 +46,7 @@ export const ConnectProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData } = useNetwork();
+  const { networkData, network } = useNetwork();
   const { checkingInjectedWeb3, extensions, setExtensionStatus } =
     useExtensions();
   const {
@@ -75,11 +75,11 @@ export const ConnectProvider = ({
     if (updateLocal) {
       if (newActiveProxy) {
         localStorage.setItem(
-          `${networkData.name}_active_proxy`,
+          `${network}_active_proxy`,
           JSON.stringify(newActiveProxy)
         );
       } else {
-        localStorage.removeItem(`${networkData.name}_active_proxy`);
+        localStorage.removeItem(`${network}_active_proxy`);
       }
     }
     setStateWithRef(newActiveProxy, setActiveProxyState, activeProxyRef);
@@ -135,7 +135,7 @@ export const ConnectProvider = ({
       }
     }
     return () => unsubscribe();
-  }, [extensions?.length, networkData, checkingInjectedWeb3]);
+  }, [extensions?.length, network, checkingInjectedWeb3]);
 
   // Once initialised extensions equal total extensions present in `injectedWeb3`, mark extensions
   // as fetched.
@@ -191,7 +191,7 @@ export const ConnectProvider = ({
     if (
       forget.find((a) => a.address === activeAccountRef.current) !== undefined
     ) {
-      localStorage.removeItem(`${networkData.name}_active_account`);
+      localStorage.removeItem(`${network}_active_account`);
       setStateWithRef(null, setActiveAccount, activeAccountRef);
     }
 
@@ -238,7 +238,7 @@ export const ConnectProvider = ({
   ) => {
     // Get accounts from provided `getter` function. The resulting array of accounts must contain an
     // `address` field.
-    let localAccounts = getter(networkData.name);
+    let localAccounts = getter(network);
 
     if (localAccounts.length) {
       const activeAccountInSet =
@@ -434,9 +434,9 @@ export const ConnectProvider = ({
 
   const setActiveAccount = (address: MaybeAccount) => {
     if (address === null) {
-      localStorage.removeItem(`${networkData.name}_active_account`);
+      localStorage.removeItem(`${network}_active_account`);
     } else {
-      localStorage.setItem(`${networkData.name}_active_account`, address);
+      localStorage.setItem(`${network}_active_account`, address);
     }
     setStateWithRef(address, setActiveAccountState, activeAccountRef);
   };
@@ -446,7 +446,7 @@ export const ConnectProvider = ({
   };
 
   const disconnectFromAccount = () => {
-    localStorage.removeItem(`${networkData.name}_active_account`);
+    localStorage.removeItem(`${network}_active_account`);
     setActiveAccount(null);
   };
 
@@ -464,7 +464,7 @@ export const ConnectProvider = ({
 
     const newAccount = {
       address: formatted,
-      network: networkData.name,
+      network,
       name: ellipsisFn(address),
       source: 'external',
       addedBy,
@@ -473,7 +473,7 @@ export const ConnectProvider = ({
     // get all external accounts from localStorage.
     const localExternalAccounts = getLocalExternalAccounts();
     const existsLocal = localExternalAccounts.find(
-      (l) => l.address === address && l.network === networkData.name
+      (l) => l.address === address && l.network === network
     );
 
     // check that address is not sitting in imported accounts (currently cannot check which

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -10,7 +10,6 @@ import {
 } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
 import { DappName } from 'consts';
-import { useApi } from 'contexts/Api';
 import type {
   ActiveProxy,
   ConnectContextInterface,
@@ -30,6 +29,7 @@ import type {
   ExtensionInjected,
   ExtensionInterface,
 } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
+import { useNetwork } from 'contexts/Network';
 import { useImportExtension } from './Hooks/useImportExtension';
 import {
   extensionIsLocal,
@@ -46,7 +46,7 @@ export const ConnectProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { checkingInjectedWeb3, extensions, setExtensionStatus } =
     useExtensions();
   const {
@@ -75,11 +75,11 @@ export const ConnectProvider = ({
     if (updateLocal) {
       if (newActiveProxy) {
         localStorage.setItem(
-          `${network.name}_active_proxy`,
+          `${networkData.name}_active_proxy`,
           JSON.stringify(newActiveProxy)
         );
       } else {
-        localStorage.removeItem(`${network.name}_active_proxy`);
+        localStorage.removeItem(`${networkData.name}_active_proxy`);
       }
     }
     setStateWithRef(newActiveProxy, setActiveProxyState, activeProxyRef);
@@ -135,7 +135,7 @@ export const ConnectProvider = ({
       }
     }
     return () => unsubscribe();
-  }, [extensions?.length, network, checkingInjectedWeb3]);
+  }, [extensions?.length, networkData, checkingInjectedWeb3]);
 
   // Once initialised extensions equal total extensions present in `injectedWeb3`, mark extensions
   // as fetched.
@@ -191,7 +191,7 @@ export const ConnectProvider = ({
     if (
       forget.find((a) => a.address === activeAccountRef.current) !== undefined
     ) {
-      localStorage.removeItem(`${network.name}_active_account`);
+      localStorage.removeItem(`${networkData.name}_active_account`);
       setStateWithRef(null, setActiveAccount, activeAccountRef);
     }
 
@@ -199,7 +199,7 @@ export const ConnectProvider = ({
     const externalToForget = forget.filter((i) => 'network' in i);
     if (externalToForget.length) {
       removeLocalExternalAccounts(
-        network,
+        networkData,
         externalToForget as ExternalAccount[]
       );
     }
@@ -238,12 +238,12 @@ export const ConnectProvider = ({
   ) => {
     // Get accounts from provided `getter` function. The resulting array of accounts must contain an
     // `address` field.
-    let localAccounts = getter(network.name);
+    let localAccounts = getter(networkData.name);
 
     if (localAccounts.length) {
       const activeAccountInSet =
         localAccounts.find(
-          ({ address }) => address === getActiveAccountLocal(network)
+          ({ address }) => address === getActiveAccountLocal(networkData)
         ) ?? null;
 
       // remove already-imported accounts.
@@ -253,7 +253,7 @@ export const ConnectProvider = ({
           undefined
       );
 
-      // set active account for network.
+      // set active account for networkData.
       if (activeAccountInSet) {
         connectToAccount(activeAccountInSet);
       }
@@ -434,9 +434,9 @@ export const ConnectProvider = ({
 
   const setActiveAccount = (address: MaybeAccount) => {
     if (address === null) {
-      localStorage.removeItem(`${network.name}_active_account`);
+      localStorage.removeItem(`${networkData.name}_active_account`);
     } else {
-      localStorage.setItem(`${network.name}_active_account`, address);
+      localStorage.setItem(`${networkData.name}_active_account`, address);
     }
     setStateWithRef(address, setActiveAccountState, activeAccountRef);
   };
@@ -446,7 +446,7 @@ export const ConnectProvider = ({
   };
 
   const disconnectFromAccount = () => {
-    localStorage.removeItem(`${network.name}_active_account`);
+    localStorage.removeItem(`${networkData.name}_active_account`);
     setActiveAccount(null);
   };
 
@@ -459,12 +459,12 @@ export const ConnectProvider = ({
   const addExternalAccount = (address: string, addedBy: string) => {
     // ensure account is formatted correctly
     const keyring = new Keyring();
-    keyring.setSS58Format(network.ss58);
+    keyring.setSS58Format(networkData.ss58);
     const formatted = keyring.addFromAddress(address).address;
 
     const newAccount = {
       address: formatted,
-      network: network.name,
+      network: networkData.name,
       name: ellipsisFn(address),
       source: 'external',
       addedBy,
@@ -473,7 +473,7 @@ export const ConnectProvider = ({
     // get all external accounts from localStorage.
     const localExternalAccounts = getLocalExternalAccounts();
     const existsLocal = localExternalAccounts.find(
-      (l) => l.address === address && l.network === network.name
+      (l) => l.address === address && l.network === networkData.name
     );
 
     // check that address is not sitting in imported accounts (currently cannot check which
@@ -535,7 +535,7 @@ export const ConnectProvider = ({
   const formatAccountSs58 = (address: string) => {
     try {
       const keyring = new Keyring();
-      keyring.setSS58Format(network.ss58);
+      keyring.setSS58Format(networkData.ss58);
       const formatted = keyring.addFromAddress(address).address;
       if (formatted !== address) {
         return formatted;

--- a/src/contexts/FastUnstake/index.tsx
+++ b/src/contexts/FastUnstake/index.tsx
@@ -33,7 +33,7 @@ export const FastUnstakeProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { activeAccount } = useConnect();
   const { api, isReady, consts } = useApi();
   const { inSetup, fetchEraStakers } = useStaking();
@@ -71,8 +71,7 @@ export const FastUnstakeProvider = ({
   const unsubs = useRef<AnyApi[]>([]);
 
   // localStorage key to fetch local metadata.
-  const getLocalkey = (a: MaybeAccount) =>
-    `${networkData.name}_fast_unstake_${a}`;
+  const getLocalkey = (a: MaybeAccount) => `${network}_fast_unstake_${a}`;
 
   // check until bond duration eras surpasssed.
   const checkToEra = activeEra.index.minus(bondDuration);
@@ -149,7 +148,7 @@ export const FastUnstakeProvider = ({
   }, [
     inSetup(),
     isReady,
-    networkData.name,
+    network,
     activeAccount,
     activeEra.index,
     fastUnstakeErasToCheckPerBlock,
@@ -165,7 +164,7 @@ export const FastUnstakeProvider = ({
 
       // ensure still same conditions.
       const { networkName, who } = data;
-      if (networkName !== networkData.name || who !== activeAccount) return;
+      if (networkName !== network || who !== activeAccount) return;
 
       const { era, exposed } = data;
 
@@ -243,7 +242,7 @@ export const FastUnstakeProvider = ({
       task: 'processEraForExposure',
       era: era.toString(),
       who: activeAccount,
-      networkName: networkData.name,
+      networkName: network,
       exitOnExposed: true,
       exposures,
     });

--- a/src/contexts/Hardware/Ledger.tsx
+++ b/src/contexts/Hardware/Ledger.tsx
@@ -39,10 +39,10 @@ export const LedgerHardwareProvider = ({
   children: React.ReactNode;
 }) => {
   const { t } = useTranslation('modals');
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   const [ledgerAccounts, setLedgerAccountsState] = useState<LedgerAccount[]>(
-    getLocalLedgerAccounts(networkData.name)
+    getLocalLedgerAccounts(network)
   );
   const ledgerAccountsRef = useRef(ledgerAccounts);
 
@@ -79,11 +79,11 @@ export const LedgerHardwareProvider = ({
   // Refresh imported ledger accounts on network change.
   useEffect(() => {
     setStateWithRef(
-      getLocalLedgerAccounts(networkData.name),
+      getLocalLedgerAccounts(network),
       setLedgerAccountsState,
       ledgerAccountsRef
     );
-  }, [networkData.name]);
+  }, [network]);
 
   // Handles errors that occur during `executeLedgerLoop` and `pairDevice` calls.
   const handleErrors = (appName: string, err: AnyJson) => {
@@ -346,25 +346,23 @@ export const LedgerHardwareProvider = ({
   // Check if a Ledger address exists in imported addresses.
   const ledgerAccountExists = (address: string) =>
     !!getLocalLedgerAccounts().find((a) =>
-      isLocalNetworkAddress(networkData.name, a, address)
+      isLocalNetworkAddress(network, a, address)
     );
 
   const addLedgerAccount = (address: string, index: number) => {
     let newLedgerAccounts = getLocalLedgerAccounts();
 
     const ledgerAddress = getLocalLedgerAddresses().find((a) =>
-      isLocalNetworkAddress(networkData.name, a, address)
+      isLocalNetworkAddress(network, a, address)
     );
 
     if (
       ledgerAddress &&
-      !newLedgerAccounts.find((a) =>
-        isLocalNetworkAddress(networkData.name, a, address)
-      )
+      !newLedgerAccounts.find((a) => isLocalNetworkAddress(network, a, address))
     ) {
       const account = {
         address,
-        network: networkData.name,
+        network,
         name: ledgerAddress.name,
         source: 'ledger',
         index,
@@ -379,7 +377,7 @@ export const LedgerHardwareProvider = ({
 
       // store only those accounts on the current network in state.
       setStateWithRef(
-        newLedgerAccounts.filter((a) => a.network === networkData.name),
+        newLedgerAccounts.filter((a) => a.network === network),
         setLedgerAccountsState,
         ledgerAccountsRef
       );
@@ -396,7 +394,7 @@ export const LedgerHardwareProvider = ({
       if (a.address !== address) {
         return true;
       }
-      if (a.network !== networkData.name) {
+      if (a.network !== network) {
         return true;
       }
       return false;
@@ -410,7 +408,7 @@ export const LedgerHardwareProvider = ({
       );
     }
     setStateWithRef(
-      newLedgerAccounts.filter((a) => a.network === networkData.name),
+      newLedgerAccounts.filter((a) => a.network === network),
       setLedgerAccountsState,
       ledgerAccountsRef
     );
@@ -425,7 +423,7 @@ export const LedgerHardwareProvider = ({
     }
     return (
       localLedgerAccounts.find((a) =>
-        isLocalNetworkAddress(networkData.name, a, address)
+        isLocalNetworkAddress(network, a, address)
       ) ?? null
     );
   };
@@ -435,7 +433,7 @@ export const LedgerHardwareProvider = ({
     let newLedgerAccounts = getLocalLedgerAccounts();
 
     newLedgerAccounts = newLedgerAccounts.map((a) =>
-      isLocalNetworkAddress(networkData.name, a, address)
+      isLocalNetworkAddress(network, a, address)
         ? {
             ...a,
             name: newName,
@@ -445,7 +443,7 @@ export const LedgerHardwareProvider = ({
     renameLocalLedgerAddress(address, newName);
     localStorage.setItem('ledger_accounts', JSON.stringify(newLedgerAccounts));
     setStateWithRef(
-      newLedgerAccounts.filter((a) => a.network === networkData.name),
+      newLedgerAccounts.filter((a) => a.network === network),
       setLedgerAccountsState,
       ledgerAccountsRef
     );
@@ -456,7 +454,7 @@ export const LedgerHardwareProvider = ({
     const localLedger = (
       localStorageOrDefault('ledger_addresses', [], true) as LedgerAddress[]
     )?.map((i) =>
-      !(i.address === address && i.network === networkData.name)
+      !(i.address === address && i.network === network)
         ? i
         : {
             ...i,

--- a/src/contexts/Hardware/Vault.tsx
+++ b/src/contexts/Hardware/Vault.tsx
@@ -14,17 +14,17 @@ export const VaultHardwareProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   const [vaultAccounts, seVaultAccountsState] = useState<VaultAccount[]>(
-    getLocalVaultAccounts(networkData.name)
+    getLocalVaultAccounts(network)
   );
   const vaultAccountsRef = useRef(vaultAccounts);
 
   // Check if a Vault address exists in imported addresses.
   const vaultAccountExists = (address: string) =>
     !!getLocalVaultAccounts().find((a) =>
-      isLocalNetworkAddress(networkData.name, a, address)
+      isLocalNetworkAddress(network, a, address)
     );
 
   // Adds a vault account to state and local storage.
@@ -32,13 +32,11 @@ export const VaultHardwareProvider = ({
     let newVaultAccounts = getLocalVaultAccounts();
 
     if (
-      !newVaultAccounts.find((a) =>
-        isLocalNetworkAddress(networkData.name, a, address)
-      )
+      !newVaultAccounts.find((a) => isLocalNetworkAddress(network, a, address))
     ) {
       const account = {
         address,
-        network: networkData.name,
+        network,
         name: ellipsisFn(address),
         source: 'vault',
         index,
@@ -52,7 +50,7 @@ export const VaultHardwareProvider = ({
 
       // store only those accounts on the current network in state.
       setStateWithRef(
-        newVaultAccounts.filter((a) => a.network === networkData.name),
+        newVaultAccounts.filter((a) => a.network === network),
         seVaultAccountsState,
         vaultAccountsRef
       );
@@ -68,7 +66,7 @@ export const VaultHardwareProvider = ({
       if (a.address !== address) {
         return true;
       }
-      if (a.network !== networkData.name) {
+      if (a.network !== network) {
         return true;
       }
       return false;
@@ -83,7 +81,7 @@ export const VaultHardwareProvider = ({
       );
     }
     setStateWithRef(
-      newVaultAccounts.filter((a) => a.network === networkData.name),
+      newVaultAccounts.filter((a) => a.network === network),
       seVaultAccountsState,
       vaultAccountsRef
     );
@@ -96,7 +94,7 @@ export const VaultHardwareProvider = ({
     }
     return (
       localVaultAccounts.find((a) =>
-        isLocalNetworkAddress(networkData.name, a, address)
+        isLocalNetworkAddress(network, a, address)
       ) ?? null
     );
   };
@@ -105,7 +103,7 @@ export const VaultHardwareProvider = ({
     let newVaultAccounts = getLocalVaultAccounts();
 
     newVaultAccounts = newVaultAccounts.map((a) =>
-      isLocalNetworkAddress(networkData.name, a, address)
+      isLocalNetworkAddress(network, a, address)
         ? {
             ...a,
             name: newName,
@@ -117,7 +115,7 @@ export const VaultHardwareProvider = ({
       JSON.stringify(newVaultAccounts)
     );
     setStateWithRef(
-      newVaultAccounts.filter((a) => a.network === networkData.name),
+      newVaultAccounts.filter((a) => a.network === network),
       seVaultAccountsState,
       vaultAccountsRef
     );
@@ -126,11 +124,11 @@ export const VaultHardwareProvider = ({
   // Refresh imported vault accounts on network change.
   useEffect(() => {
     setStateWithRef(
-      getLocalVaultAccounts(networkData.name),
+      getLocalVaultAccounts(network),
       seVaultAccountsState,
       vaultAccountsRef
     );
-  }, [networkData]);
+  }, [network]);
 
   return (
     <VaultHardwareContext.Provider

--- a/src/contexts/Hardware/Vault.tsx
+++ b/src/contexts/Hardware/Vault.tsx
@@ -3,8 +3,8 @@
 
 import { ellipsisFn, setStateWithRef } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
-import { useApi } from 'contexts/Api';
 import type { VaultAccount } from 'contexts/Connect/types';
+import { useNetwork } from 'contexts/Network';
 import { getLocalVaultAccounts, isLocalNetworkAddress } from './Utils';
 import { defaultVaultHardwareContext } from './defaults';
 import type { VaultHardwareContextInterface } from './types';
@@ -14,17 +14,17 @@ export const VaultHardwareProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   const [vaultAccounts, seVaultAccountsState] = useState<VaultAccount[]>(
-    getLocalVaultAccounts(network.name)
+    getLocalVaultAccounts(networkData.name)
   );
   const vaultAccountsRef = useRef(vaultAccounts);
 
   // Check if a Vault address exists in imported addresses.
   const vaultAccountExists = (address: string) =>
     !!getLocalVaultAccounts().find((a) =>
-      isLocalNetworkAddress(network.name, a, address)
+      isLocalNetworkAddress(networkData.name, a, address)
     );
 
   // Adds a vault account to state and local storage.
@@ -33,12 +33,12 @@ export const VaultHardwareProvider = ({
 
     if (
       !newVaultAccounts.find((a) =>
-        isLocalNetworkAddress(network.name, a, address)
+        isLocalNetworkAddress(networkData.name, a, address)
       )
     ) {
       const account = {
         address,
-        network: network.name,
+        network: networkData.name,
         name: ellipsisFn(address),
         source: 'vault',
         index,
@@ -52,7 +52,7 @@ export const VaultHardwareProvider = ({
 
       // store only those accounts on the current network in state.
       setStateWithRef(
-        newVaultAccounts.filter((a) => a.network === network.name),
+        newVaultAccounts.filter((a) => a.network === networkData.name),
         seVaultAccountsState,
         vaultAccountsRef
       );
@@ -68,7 +68,7 @@ export const VaultHardwareProvider = ({
       if (a.address !== address) {
         return true;
       }
-      if (a.network !== network.name) {
+      if (a.network !== networkData.name) {
         return true;
       }
       return false;
@@ -83,7 +83,7 @@ export const VaultHardwareProvider = ({
       );
     }
     setStateWithRef(
-      newVaultAccounts.filter((a) => a.network === network.name),
+      newVaultAccounts.filter((a) => a.network === networkData.name),
       seVaultAccountsState,
       vaultAccountsRef
     );
@@ -96,7 +96,7 @@ export const VaultHardwareProvider = ({
     }
     return (
       localVaultAccounts.find((a) =>
-        isLocalNetworkAddress(network.name, a, address)
+        isLocalNetworkAddress(networkData.name, a, address)
       ) ?? null
     );
   };
@@ -105,7 +105,7 @@ export const VaultHardwareProvider = ({
     let newVaultAccounts = getLocalVaultAccounts();
 
     newVaultAccounts = newVaultAccounts.map((a) =>
-      isLocalNetworkAddress(network.name, a, address)
+      isLocalNetworkAddress(networkData.name, a, address)
         ? {
             ...a,
             name: newName,
@@ -117,7 +117,7 @@ export const VaultHardwareProvider = ({
       JSON.stringify(newVaultAccounts)
     );
     setStateWithRef(
-      newVaultAccounts.filter((a) => a.network === network.name),
+      newVaultAccounts.filter((a) => a.network === networkData.name),
       seVaultAccountsState,
       vaultAccountsRef
     );
@@ -126,11 +126,11 @@ export const VaultHardwareProvider = ({
   // Refresh imported vault accounts on network change.
   useEffect(() => {
     setStateWithRef(
-      getLocalVaultAccounts(network.name),
+      getLocalVaultAccounts(networkData.name),
       seVaultAccountsState,
       vaultAccountsRef
     );
-  }, [network]);
+  }, [networkData]);
 
   return (
     <VaultHardwareContext.Provider

--- a/src/contexts/Network/defaults.ts
+++ b/src/contexts/Network/defaults.ts
@@ -1,26 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import BigNumber from 'bignumber.js';
-import type {
-  ActiveEra,
-  NetworkMetrics,
-  NetworkMetricsContextInterface,
-} from './types';
+import { NetworkList } from 'config/networks';
 
-export const activeEra: ActiveEra = {
-  index: new BigNumber(0),
-  start: new BigNumber(0),
-};
-export const metrics: NetworkMetrics = {
-  totalIssuance: new BigNumber(0),
-  auctionCounter: new BigNumber(0),
-  earliestStoredSession: new BigNumber(0),
-  fastUnstakeErasToCheckPerBlock: 0,
-  minimumActiveStake: new BigNumber(0),
-};
-
-export const defaultNetworkContext: NetworkMetricsContextInterface = {
-  activeEra,
-  metrics,
+export const defaultNetworkContext = {
+  networkData: NetworkList.polkadot,
+  switchNetwork: () => {},
 };

--- a/src/contexts/Network/defaults.ts
+++ b/src/contexts/Network/defaults.ts
@@ -4,6 +4,7 @@
 import { NetworkList } from 'config/networks';
 
 export const defaultNetworkContext = {
+  network: NetworkList.polkadot.name,
   networkData: NetworkList.polkadot,
   switchNetwork: () => {},
 };

--- a/src/contexts/Network/index.tsx
+++ b/src/contexts/Network/index.tsx
@@ -62,6 +62,7 @@ export const NetworkProvider = ({
   return (
     <NetworkContext.Provider
       value={{
+        network: network.name,
         networkData: network.meta,
         switchNetwork,
       }}

--- a/src/contexts/Network/index.tsx
+++ b/src/contexts/Network/index.tsx
@@ -1,154 +1,78 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { setStateWithRef } from '@polkadot-cloud/utils';
-import BigNumber from 'bignumber.js';
-import React, { useRef, useState } from 'react';
-import type { AnyApi, AnyJson } from 'types';
-import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
-import { useApi } from '../Api';
-import * as defaults from './defaults';
-import type {
-  ActiveEra,
-  NetworkMetrics,
-  NetworkMetricsContextInterface,
-} from './types';
+import { extractUrlValue, varToUrlHash } from '@polkadot-cloud/utils';
+import React, { createContext, useContext, useState } from 'react';
+import { NetworkList } from 'config/networks';
+import { DefaultNetwork } from 'consts';
+import type { NetworkName } from 'types';
+import type { NetworkState } from 'contexts/Api/types';
+import type { NetworkContextInterface } from './types';
+import { defaultNetworkContext } from './defaults';
 
-export const NetworkMetricsProvider = ({
+export const NetworkProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const { isReady, api, network } = useApi();
+  // Get the initial network and prepare meta tags if necessary.
+  const getInitialNetwork = () => {
+    const urlNetworkRaw = extractUrlValue('n');
 
-  // Store active era in state.
-  const [activeEra, setActiveEra] = useState<ActiveEra>(defaults.activeEra);
-  const activeEraRef = useRef(activeEra);
+    const urlNetworkValid = !!Object.values(NetworkList).find(
+      (n) => n.name === urlNetworkRaw
+    );
 
-  // Store network metrics in state.
-  const [metrics, setMetrics] = useState<NetworkMetrics>(defaults.metrics);
-  const metricsRef = useRef(metrics);
+    // use network from url if valid.
+    if (urlNetworkValid) {
+      const urlNetwork = urlNetworkRaw as NetworkName;
 
-  // Store unsubscribe objects.
-  const unsubsRef = useRef<AnyApi[]>([]);
-
-  // active subscription
-  const initialiseSubscriptions = async () => {
-    if (!api) return;
-
-    if (isReady) {
-      const subscribeToMetrics = async () => {
-        const unsub = await api.queryMulti(
-          [
-            api.query.balances.totalIssuance,
-            api.query.auctions.auctionCounter,
-            api.query.paraSessionInfo.earliestStoredSession,
-            api.query.fastUnstake.erasToCheckPerBlock,
-            api.query.staking.minimumActiveStake,
-          ],
-          ([
-            totalIssuance,
-            auctionCounter,
-            earliestStoredSession,
-            erasToCheckPerBlock,
-            minimumActiveStake,
-          ]: AnyApi) => {
-            setStateWithRef(
-              {
-                totalIssuance: new BigNumber(totalIssuance.toString()),
-                auctionCounter: new BigNumber(auctionCounter.toString()),
-                earliestStoredSession: new BigNumber(
-                  earliestStoredSession.toString()
-                ),
-                fastUnstakeErasToCheckPerBlock: erasToCheckPerBlock.toNumber(),
-                minimumActiveStake: new BigNumber(
-                  minimumActiveStake.toString()
-                ),
-              },
-              setMetrics,
-              metricsRef
-            );
-          }
-        );
-        return unsub;
-      };
-
-      const subscribeToActiveEra = async () => {
-        const unsub = await api.query.staking.activeEra((result: AnyApi) => {
-          // determine activeEra: toString used as alternative to `toHuman`, that puts commas in
-          // numbers
-          let newActiveEra = result
-            .unwrapOrDefault({
-              index: 0,
-              start: 0,
-            })
-            .toString();
-
-          newActiveEra = JSON.parse(newActiveEra);
-          setStateWithRef(
-            {
-              index: new BigNumber(newActiveEra.index),
-              start: new BigNumber(newActiveEra.start),
-            },
-            setActiveEra,
-            activeEraRef
-          );
-        });
-        return unsub;
-      };
-
-      // initiate subscription, add to unsubs.
-      await Promise.all([subscribeToMetrics(), subscribeToActiveEra()]).then(
-        (u: any) => {
-          unsubsRef.current = unsubsRef.current.concat(u);
-        }
-      );
+      if (urlNetworkValid) {
+        return urlNetwork;
+      }
     }
+    // fallback to localStorage network if there.
+    const localNetwork: NetworkName = localStorage.getItem(
+      'network'
+    ) as NetworkName;
+    const localNetworkValid = !!Object.values(NetworkList).find(
+      (n) => n.name === localNetwork
+    );
+    return localNetworkValid ? localNetwork : DefaultNetwork;
   };
 
-  // Unsubscribe from unsubs
-  const unsubscribe = () => {
-    Object.values(unsubsRef.current).forEach((unsub: AnyJson) => {
-      unsub();
+  // handle network switching
+  const switchNetwork = (name: NetworkName) => {
+    setNetwork({
+      name,
+      meta: NetworkList[name],
     });
+
+    // update url `n` if needed.
+    varToUrlHash('n', name, false);
   };
 
-  // Set defaults for all metrics.
-  const handleResetMetrics = () => {
-    unsubscribe();
-    unsubsRef.current = [];
-    setStateWithRef(defaults.activeEra, setActiveEra, activeEraRef);
-    setStateWithRef(defaults.metrics, setMetrics, metricsRef);
-  };
-
-  // manage unsubscribe
-  useEffectIgnoreInitial(() => {
-    initialiseSubscriptions();
-    return () => {
-      unsubscribe();
-    };
-  }, [isReady]);
-
-  // Reset active era and metrics on network change.
-  useEffectIgnoreInitial(() => {
-    handleResetMetrics();
-  }, [network]);
+  // Store the initial active network.
+  const initialNetwork = getInitialNetwork();
+  const [network, setNetwork] = useState<NetworkState>({
+    name: initialNetwork,
+    meta: NetworkList[initialNetwork],
+  });
 
   return (
-    <NetworkMetricsContext.Provider
+    <NetworkContext.Provider
       value={{
-        activeEra: activeEraRef.current,
-        metrics: metricsRef.current,
+        networkData: network.meta,
+        switchNetwork,
       }}
     >
       {children}
-    </NetworkMetricsContext.Provider>
+    </NetworkContext.Provider>
   );
 };
 
-export const NetworkMetricsContext =
-  React.createContext<NetworkMetricsContextInterface>(
-    defaults.defaultNetworkContext
-  );
+export const NetworkContext = createContext<NetworkContextInterface>(
+  defaultNetworkContext
+);
 
-export const useNetworkMetrics = () => React.useContext(NetworkMetricsContext);
+export const useNetwork = () => useContext(NetworkContext);

--- a/src/contexts/Network/types.ts
+++ b/src/contexts/Network/types.ts
@@ -4,6 +4,7 @@
 import type { Network, NetworkName } from 'types';
 
 export interface NetworkContextInterface {
+  network: NetworkName;
   networkData: Network;
   switchNetwork: (network: NetworkName) => void;
 }

--- a/src/contexts/Network/types.ts
+++ b/src/contexts/Network/types.ts
@@ -1,22 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type BigNumber from 'bignumber.js';
+import type { Network, NetworkName } from 'types';
 
-export interface NetworkMetricsContextInterface {
-  activeEra: ActiveEra;
-  metrics: NetworkMetrics;
-}
-
-export interface NetworkMetrics {
-  totalIssuance: BigNumber;
-  auctionCounter: BigNumber;
-  earliestStoredSession: BigNumber;
-  fastUnstakeErasToCheckPerBlock: number;
-  minimumActiveStake: BigNumber;
-}
-
-export interface ActiveEra {
-  index: BigNumber;
-  start: BigNumber;
+export interface NetworkContextInterface {
+  networkData: Network;
+  switchNetwork: (network: NetworkName) => void;
 }

--- a/src/contexts/NetworkMetrics/defaults.ts
+++ b/src/contexts/NetworkMetrics/defaults.ts
@@ -1,0 +1,26 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import BigNumber from 'bignumber.js';
+import type {
+  ActiveEra,
+  NetworkMetrics,
+  NetworkMetricsContextInterface,
+} from './types';
+
+export const activeEra: ActiveEra = {
+  index: new BigNumber(0),
+  start: new BigNumber(0),
+};
+export const metrics: NetworkMetrics = {
+  totalIssuance: new BigNumber(0),
+  auctionCounter: new BigNumber(0),
+  earliestStoredSession: new BigNumber(0),
+  fastUnstakeErasToCheckPerBlock: 0,
+  minimumActiveStake: new BigNumber(0),
+};
+
+export const defaultNetworkContext: NetworkMetricsContextInterface = {
+  activeEra,
+  metrics,
+};

--- a/src/contexts/NetworkMetrics/index.tsx
+++ b/src/contexts/NetworkMetrics/index.tsx
@@ -1,0 +1,156 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { setStateWithRef } from '@polkadot-cloud/utils';
+import BigNumber from 'bignumber.js';
+import React, { useRef, useState } from 'react';
+import type { AnyApi, AnyJson } from 'types';
+import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
+import { useApi } from '../Api';
+import * as defaults from './defaults';
+import type {
+  ActiveEra,
+  NetworkMetrics,
+  NetworkMetricsContextInterface,
+} from './types';
+
+export const NetworkMetricsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { isReady, api } = useApi();
+  const { networkData } = useNetwork();
+
+  // Store active era in state.
+  const [activeEra, setActiveEra] = useState<ActiveEra>(defaults.activeEra);
+  const activeEraRef = useRef(activeEra);
+
+  // Store network metrics in state.
+  const [metrics, setMetrics] = useState<NetworkMetrics>(defaults.metrics);
+  const metricsRef = useRef(metrics);
+
+  // Store unsubscribe objects.
+  const unsubsRef = useRef<AnyApi[]>([]);
+
+  // active subscription
+  const initialiseSubscriptions = async () => {
+    if (!api) return;
+
+    if (isReady) {
+      const subscribeToMetrics = async () => {
+        const unsub = await api.queryMulti(
+          [
+            api.query.balances.totalIssuance,
+            api.query.auctions.auctionCounter,
+            api.query.paraSessionInfo.earliestStoredSession,
+            api.query.fastUnstake.erasToCheckPerBlock,
+            api.query.staking.minimumActiveStake,
+          ],
+          ([
+            totalIssuance,
+            auctionCounter,
+            earliestStoredSession,
+            erasToCheckPerBlock,
+            minimumActiveStake,
+          ]: AnyApi) => {
+            setStateWithRef(
+              {
+                totalIssuance: new BigNumber(totalIssuance.toString()),
+                auctionCounter: new BigNumber(auctionCounter.toString()),
+                earliestStoredSession: new BigNumber(
+                  earliestStoredSession.toString()
+                ),
+                fastUnstakeErasToCheckPerBlock: erasToCheckPerBlock.toNumber(),
+                minimumActiveStake: new BigNumber(
+                  minimumActiveStake.toString()
+                ),
+              },
+              setMetrics,
+              metricsRef
+            );
+          }
+        );
+        return unsub;
+      };
+
+      const subscribeToActiveEra = async () => {
+        const unsub = await api.query.staking.activeEra((result: AnyApi) => {
+          // determine activeEra: toString used as alternative to `toHuman`, that puts commas in
+          // numbers
+          let newActiveEra = result
+            .unwrapOrDefault({
+              index: 0,
+              start: 0,
+            })
+            .toString();
+
+          newActiveEra = JSON.parse(newActiveEra);
+          setStateWithRef(
+            {
+              index: new BigNumber(newActiveEra.index),
+              start: new BigNumber(newActiveEra.start),
+            },
+            setActiveEra,
+            activeEraRef
+          );
+        });
+        return unsub;
+      };
+
+      // initiate subscription, add to unsubs.
+      await Promise.all([subscribeToMetrics(), subscribeToActiveEra()]).then(
+        (u: any) => {
+          unsubsRef.current = unsubsRef.current.concat(u);
+        }
+      );
+    }
+  };
+
+  // Unsubscribe from unsubs
+  const unsubscribe = () => {
+    Object.values(unsubsRef.current).forEach((unsub: AnyJson) => {
+      unsub();
+    });
+  };
+
+  // Set defaults for all metrics.
+  const handleResetMetrics = () => {
+    unsubscribe();
+    unsubsRef.current = [];
+    setStateWithRef(defaults.activeEra, setActiveEra, activeEraRef);
+    setStateWithRef(defaults.metrics, setMetrics, metricsRef);
+  };
+
+  // manage unsubscribe
+  useEffectIgnoreInitial(() => {
+    initialiseSubscriptions();
+    return () => {
+      unsubscribe();
+    };
+  }, [isReady]);
+
+  // Reset active era and metrics on network change.
+  useEffectIgnoreInitial(() => {
+    handleResetMetrics();
+  }, [networkData]);
+
+  return (
+    <NetworkMetricsContext.Provider
+      value={{
+        activeEra: activeEraRef.current,
+        metrics: metricsRef.current,
+      }}
+    >
+      {children}
+    </NetworkMetricsContext.Provider>
+  );
+};
+
+export const NetworkMetricsContext =
+  React.createContext<NetworkMetricsContextInterface>(
+    defaults.defaultNetworkContext
+  );
+
+export const useNetworkMetrics = () => React.useContext(NetworkMetricsContext);

--- a/src/contexts/NetworkMetrics/index.tsx
+++ b/src/contexts/NetworkMetrics/index.tsx
@@ -20,8 +20,8 @@ export const NetworkMetricsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { isReady, api } = useApi();
-  const { networkData } = useNetwork();
 
   // Store active era in state.
   const [activeEra, setActiveEra] = useState<ActiveEra>(defaults.activeEra);
@@ -134,7 +134,7 @@ export const NetworkMetricsProvider = ({
   // Reset active era and metrics on network change.
   useEffectIgnoreInitial(() => {
     handleResetMetrics();
-  }, [networkData]);
+  }, [network]);
 
   return (
     <NetworkMetricsContext.Provider

--- a/src/contexts/NetworkMetrics/types.ts
+++ b/src/contexts/NetworkMetrics/types.ts
@@ -1,0 +1,22 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type BigNumber from 'bignumber.js';
+
+export interface NetworkMetricsContextInterface {
+  activeEra: ActiveEra;
+  metrics: NetworkMetrics;
+}
+
+export interface NetworkMetrics {
+  totalIssuance: BigNumber;
+  auctionCounter: BigNumber;
+  earliestStoredSession: BigNumber;
+  fastUnstakeErasToCheckPerBlock: number;
+  minimumActiveStake: BigNumber;
+}
+
+export interface ActiveEra {
+  index: BigNumber;
+  start: BigNumber;
+}

--- a/src/contexts/Payouts/index.tsx
+++ b/src/contexts/Payouts/index.tsx
@@ -6,10 +6,11 @@ import { useStaking } from 'contexts/Staking';
 import { useApi } from 'contexts/Api';
 import type { AnyApi, AnyJson, Sync } from 'types';
 import { useConnect } from 'contexts/Connect';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import Worker from 'workers/stakers?worker';
 import { rmCommas, setStateWithRef } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
+import { useNetwork } from 'contexts/Network';
 import { MaxSupportedPayoutEras, defaultPayoutsContext } from './defaults';
 import type {
   LocalValidatorExposure,
@@ -30,7 +31,8 @@ export const PayoutsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
   const { isNominating, fetchEraStakers } = useStaking();
@@ -77,7 +79,7 @@ export const PayoutsProvider = ({
     if (!activeAccount) return;
 
     // Bypass worker if local exposure data is available.
-    if (hasLocalEraExposure(network.name, era.toString(), activeAccount)) {
+    if (hasLocalEraExposure(networkData.name, era.toString(), activeAccount)) {
       // Continue processing eras, or move onto reward processing.
       shouldContinueProcessing(era, getErasInterval().endEra);
     } else {
@@ -86,7 +88,7 @@ export const PayoutsProvider = ({
         task: 'processEraForExposure',
         era: String(era),
         who: activeAccount,
-        networkName: network.name,
+        networkName: networkData.name,
         exposures,
       });
     }
@@ -102,7 +104,7 @@ export const PayoutsProvider = ({
 
       // Exit early if network or account conditions have changed.
       const { networkName, who } = data;
-      if (networkName !== network.name || who !== activeAccount) return;
+      if (networkName !== networkData.name || who !== activeAccount) return;
       const { era, exposedValidators } = data;
       const { endEra } = getErasInterval();
 
@@ -131,7 +133,11 @@ export const PayoutsProvider = ({
     let currentEra = startEra;
     while (currentEra.isGreaterThanOrEqualTo(endEra)) {
       const validators = Object.keys(
-        getLocalEraExposure(network.name, currentEra.toString(), activeAccount)
+        getLocalEraExposure(
+          networkData.name,
+          currentEra.toString(),
+          activeAccount
+        )
       );
       erasValidators.push(...validators);
       erasToCheck.push(currentEra.toString());
@@ -152,7 +158,9 @@ export const PayoutsProvider = ({
       for (const era of erasToCheck)
         if (
           Object.values(
-            Object.keys(getLocalEraExposure(network.name, era, activeAccount))
+            Object.keys(
+              getLocalEraExposure(networkData.name, era, activeAccount)
+            )
           )?.[0] === validator
         )
           exposedEras.push(era);
@@ -239,7 +247,7 @@ export const PayoutsProvider = ({
         const validator = unclaimedValidators?.[j] || '';
 
         const localExposed: LocalValidatorExposure | null = getLocalEraExposure(
-          network.name,
+          networkData.name,
           era,
           activeAccount
         )?.[validator];
@@ -281,7 +289,7 @@ export const PayoutsProvider = ({
       // This is not currently useful for preventing re-syncing. Need to know the eras that have
       // been claimed already and remove them from `erasToCheck`.
       setLocalUnclaimedPayouts(
-        network.name,
+        networkData.name,
         era,
         activeAccount,
         unclaimed[era],
@@ -324,7 +332,7 @@ export const PayoutsProvider = ({
   useEffect(() => {
     setUnclaimedPayouts(null);
     setStateWithRef('unsynced', setPayoutsSynced, payoutsSyncedRef);
-  }, [network, activeAccount]);
+  }, [networkData, activeAccount]);
 
   return (
     <PayoutsContext.Provider

--- a/src/contexts/Plugins/Polkawatch/index.tsx
+++ b/src/contexts/Plugins/Polkawatch/index.tsx
@@ -4,7 +4,7 @@
 import { Configuration, PolkawatchApi } from '@polkawatch/ddp-client';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
-import { useApi } from '../../Api';
+import { useNetwork } from 'contexts/Network';
 import type { NetworkName } from '../../../types';
 import type { PolkawatchState } from './types';
 import { DefaultNetwork } from '../../../consts';
@@ -42,7 +42,7 @@ export const PolkawatchProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { name } = useApi().network;
+  const { name } = useNetwork().networkData;
 
   const [state, setState] = useState<PolkawatchState>(PolkawatchInitialState);
 

--- a/src/contexts/Plugins/Polkawatch/index.tsx
+++ b/src/contexts/Plugins/Polkawatch/index.tsx
@@ -42,7 +42,7 @@ export const PolkawatchProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { name } = useNetwork().networkData;
+  const { network } = useNetwork();
 
   const [state, setState] = useState<PolkawatchState>(PolkawatchInitialState);
 
@@ -52,10 +52,10 @@ export const PolkawatchProvider = ({
    */
   useEffect(() => {
     setState({
-      pwApi: new PolkawatchApi(apiConfiguration(name)),
-      networkSupported: PolkaWatchNetworks.includes(name),
+      pwApi: new PolkawatchApi(apiConfiguration(network)),
+      networkSupported: PolkaWatchNetworks.includes(network),
     });
-  }, [name]);
+  }, [network]);
 
   return (
     <PolkawatchContext.Provider value={state}>

--- a/src/contexts/Plugins/Subscan/index.tsx
+++ b/src/contexts/Plugins/Subscan/index.tsx
@@ -31,7 +31,10 @@ export const SubscanProvider = ({
 }) => {
   const { i18n } = useTranslation();
   const { isReady } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    network,
+    networkData: { subscanEndpoint },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
   const { erasToSeconds } = useErasToTimeLeft();
@@ -85,14 +88,14 @@ export const SubscanProvider = ({
   // Reset payouts on network switch.
   useEffectIgnoreInitial(() => {
     resetPayouts();
-  }, [networkData]);
+  }, [network]);
 
   // Fetch payouts as soon as network is ready.
   useEffectIgnoreInitial(() => {
     if (isReady && isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
-  }, [isReady, networkData, activeAccount, activeEra]);
+  }, [isReady, network, activeAccount, activeEra]);
 
   // Store start and end date of fetched payouts.
   useEffectIgnoreInitial(() => {
@@ -262,7 +265,7 @@ export const SubscanProvider = ({
       return [];
     }
     const res: Response = await fetch(
-      networkData.subscanEndpoint + ApiEndpoints.subscanPoolDetails,
+      subscanEndpoint + ApiEndpoints.subscanPoolDetails,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -330,7 +333,7 @@ export const SubscanProvider = ({
       page,
       ...body,
     };
-    const res: Response = await fetch(networkData.subscanEndpoint + endpoint, {
+    const res: Response = await fetch(subscanEndpoint + endpoint, {
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': ApiSubscanKey,

--- a/src/contexts/Plugins/Subscan/index.tsx
+++ b/src/contexts/Plugins/Subscan/index.tsx
@@ -11,12 +11,13 @@ import {
   DefaultLocale,
   ListItemsPerPage,
 } from 'consts';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { sortNonZeroPayouts } from 'library/Graphs/Utils';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
 import { locales } from 'locale';
 import type { AnyApi, AnySubscan } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import { usePlugins } from '..';
@@ -29,7 +30,8 @@ export const SubscanProvider = ({
   children: React.ReactNode;
 }) => {
   const { i18n } = useTranslation();
-  const { network, isReady } = useApi();
+  const { isReady } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
   const { erasToSeconds } = useErasToTimeLeft();
@@ -83,14 +85,14 @@ export const SubscanProvider = ({
   // Reset payouts on network switch.
   useEffectIgnoreInitial(() => {
     resetPayouts();
-  }, [network]);
+  }, [networkData]);
 
   // Fetch payouts as soon as network is ready.
   useEffectIgnoreInitial(() => {
     if (isReady && isNotZero(activeEra.index)) {
       handleFetchPayouts();
     }
-  }, [isReady, network, activeAccount, activeEra]);
+  }, [isReady, networkData, activeAccount, activeEra]);
 
   // Store start and end date of fetched payouts.
   useEffectIgnoreInitial(() => {
@@ -260,7 +262,7 @@ export const SubscanProvider = ({
       return [];
     }
     const res: Response = await fetch(
-      network.subscanEndpoint + ApiEndpoints.subscanPoolDetails,
+      networkData.subscanEndpoint + ApiEndpoints.subscanPoolDetails,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -328,7 +330,7 @@ export const SubscanProvider = ({
       page,
       ...body,
     };
-    const res: Response = await fetch(network.subscanEndpoint + endpoint, {
+    const res: Response = await fetch(networkData.subscanEndpoint + endpoint, {
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': ApiSubscanKey,

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -28,9 +28,9 @@ export const ActivePoolsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
   const { eraStakers } = useStaking();
-  const { networkData } = useNetwork();
   const { pluginEnabled } = usePlugins();
   const { activeAccount } = useConnect();
   const { fetchPoolDetails } = useSubscan();
@@ -469,7 +469,7 @@ export const ActivePoolsProvider = ({
       setStateWithRef('syncing', setSynced, syncedRef);
       handlePoolSubscriptions();
     }
-  }, [networkData, isReady, syncedRef.current]);
+  }, [network, isReady, syncedRef.current]);
 
   // unsubscribe all on component unmount
   useEffect(
@@ -477,14 +477,14 @@ export const ActivePoolsProvider = ({
       unsubscribeActivePools();
       unsubscribePoolNominations();
     },
-    [networkData]
+    [network]
   );
 
   // re-calculate pending rewards when membership changes
   useEffectIgnoreInitial(() => {
     updatePendingRewards();
   }, [
-    networkData,
+    network,
     isReady,
     getActivePoolMembership()?.bondedPool,
     getActivePoolMembership()?.rewardPool,

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -14,6 +14,7 @@ import type { AnyApi, AnyJson, Sync } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useSubscan } from 'contexts/Plugins/Subscan';
 import { usePlugins } from 'contexts/Plugins';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import { useBondedPools } from '../BondedPools';
@@ -27,11 +28,12 @@ export const ActivePoolsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { api, isReady } = useApi();
   const { eraStakers } = useStaking();
+  const { networkData } = useNetwork();
   const { pluginEnabled } = usePlugins();
   const { activeAccount } = useConnect();
   const { fetchPoolDetails } = useSubscan();
-  const { api, network, isReady } = useApi();
   const { membership } = usePoolMemberships();
   const { createAccounts } = usePoolsConfig();
   const { getAccountPools, bondedPools } = useBondedPools();
@@ -467,7 +469,7 @@ export const ActivePoolsProvider = ({
       setStateWithRef('syncing', setSynced, syncedRef);
       handlePoolSubscriptions();
     }
-  }, [network, isReady, syncedRef.current]);
+  }, [networkData, isReady, syncedRef.current]);
 
   // unsubscribe all on component unmount
   useEffect(
@@ -475,14 +477,14 @@ export const ActivePoolsProvider = ({
       unsubscribeActivePools();
       unsubscribePoolNominations();
     },
-    [network]
+    [networkData]
   );
 
   // re-calculate pending rewards when membership changes
   useEffectIgnoreInitial(() => {
     updatePendingRewards();
   }, [
-    network,
+    networkData,
     isReady,
     getActivePoolMembership()?.bondedPool,
     getActivePoolMembership()?.rewardPool,

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -23,8 +23,8 @@ export const BondedPoolsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
   const { getNominationsStatusFromTargets } = useStaking();
   const { createAccounts, stats } = usePoolsConfig();
   const { lastPoolId } = stats;
@@ -43,7 +43,7 @@ export const BondedPoolsProvider = ({
   useEffectIgnoreInitial(() => {
     setBondedPools([]);
     setStateWithRef({}, setPoolMetaBatch, poolMetaBatchesRef);
-  }, [networkData]);
+  }, [network]);
 
   // initial setup for fetching bonded pools
   useEffectIgnoreInitial(() => {
@@ -54,7 +54,7 @@ export const BondedPoolsProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [networkData, isReady, lastPoolId]);
+  }, [network, isReady, lastPoolId]);
 
   // after bonded pools have synced, fetch metabatch
   useEffectIgnoreInitial(() => {

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -13,6 +13,7 @@ import type {
 import { useStaking } from 'contexts/Staking';
 import type { AnyApi, AnyMetaBatch, Fn, MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import { usePoolsConfig } from '../PoolsConfig';
 import { defaultBondedPoolsContext } from './defaults';
@@ -22,7 +23,8 @@ export const BondedPoolsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, network, isReady } = useApi();
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const { getNominationsStatusFromTargets } = useStaking();
   const { createAccounts, stats } = usePoolsConfig();
   const { lastPoolId } = stats;
@@ -41,7 +43,7 @@ export const BondedPoolsProvider = ({
   useEffectIgnoreInitial(() => {
     setBondedPools([]);
     setStateWithRef({}, setPoolMetaBatch, poolMetaBatchesRef);
-  }, [network]);
+  }, [networkData]);
 
   // initial setup for fetching bonded pools
   useEffectIgnoreInitial(() => {
@@ -52,7 +54,7 @@ export const BondedPoolsProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [network, isReady, lastPoolId]);
+  }, [networkData, isReady, lastPoolId]);
 
   // after bonded pools have synced, fetch metabatch
   useEffectIgnoreInitial(() => {

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -8,6 +8,7 @@ import { usePlugins } from 'contexts/Plugins';
 import type { PoolMember, PoolMemberContext } from 'contexts/Pools/types';
 import type { AnyApi, AnyMetaBatch, Fn, MaybeAccount, Sync } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import { defaultPoolMembers } from './defaults';
 
@@ -16,9 +17,10 @@ export const PoolMembersProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const { pluginEnabled } = usePlugins();
   const { activeAccount } = useConnect();
-  const { api, network, isReady } = useApi();
 
   // Store pool members from node.
   const [poolMembersNode, setPoolMembersNode] = useState<PoolMember[]>([]);
@@ -46,7 +48,7 @@ export const PoolMembersProvider = ({
   useEffectIgnoreInitial(() => {
     setPoolMembersNode([]);
     unsubscribeAndResetMeta();
-  }, [network]);
+  }, [networkData]);
 
   // Clear meta state when activeAccount changes
   useEffectIgnoreInitial(() => {
@@ -64,7 +66,7 @@ export const PoolMembersProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [network, isReady, pluginEnabled('subscan')]);
+  }, [networkData, isReady, pluginEnabled('subscan')]);
 
   const unsubscribe = () => {
     unsubscribeAndResetMeta();

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -17,8 +17,8 @@ export const PoolMembersProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
   const { pluginEnabled } = usePlugins();
   const { activeAccount } = useConnect();
 
@@ -48,7 +48,7 @@ export const PoolMembersProvider = ({
   useEffectIgnoreInitial(() => {
     setPoolMembersNode([]);
     unsubscribeAndResetMeta();
-  }, [networkData]);
+  }, [network]);
 
   // Clear meta state when activeAccount changes
   useEffectIgnoreInitial(() => {
@@ -66,7 +66,7 @@ export const PoolMembersProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [networkData, isReady, pluginEnabled('subscan')]);
+  }, [network, isReady, pluginEnabled('subscan')]);
 
   const unsubscribe = () => {
     unsubscribeAndResetMeta();

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -23,8 +23,8 @@ export const PoolMembershipsProvider = ({
   children: React.ReactNode;
 }) => {
   const { t } = useTranslation('base');
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
   const { accounts: connectAccounts, activeAccount } = useConnect();
 
   // Stores pool memberships for the imported accounts.
@@ -42,7 +42,7 @@ export const PoolMembershipsProvider = ({
         getPoolMemberships();
       })();
     }
-  }, [networkData, isReady, connectAccounts]);
+  }, [network, isReady, connectAccounts]);
 
   // subscribe to account pool memberships
   const getPoolMemberships = async () => {

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -12,6 +12,7 @@ import type {
 } from 'contexts/Pools/types';
 import type { AnyApi, Fn } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import { useConnect } from '../../Connect';
 import * as defaults from './defaults';
@@ -22,7 +23,8 @@ export const PoolMembershipsProvider = ({
   children: React.ReactNode;
 }) => {
   const { t } = useTranslation('base');
-  const { api, network, isReady } = useApi();
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const { accounts: connectAccounts, activeAccount } = useConnect();
 
   // Stores pool memberships for the imported accounts.
@@ -40,7 +42,7 @@ export const PoolMembershipsProvider = ({
         getPoolMemberships();
       })();
     }
-  }, [network, isReady, connectAccounts]);
+  }, [networkData, isReady, connectAccounts]);
 
   // subscribe to account pool memberships
   const getPoolMemberships = async () => {

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -22,7 +22,7 @@ export const PoolsConfigProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData, network } = useNetwork();
+  const { network } = useNetwork();
   const { api, isReady, consts } = useApi();
   const { poolsPalletId } = consts;
 
@@ -49,7 +49,7 @@ export const PoolsConfigProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [networkData, isReady]);
+  }, [network, isReady]);
 
   const unsubscribe = () => {
     if (poolsConfigRef.current.unsub !== null) {

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -13,6 +13,7 @@ import type {
 } from 'contexts/Pools/types';
 import type { AnyApi } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
 import * as defaults from './defaults';
 
@@ -21,7 +22,8 @@ export const PoolsConfigProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, network, isReady, consts } = useApi();
+  const { networkData } = useNetwork();
+  const { api, isReady, consts } = useApi();
   const { poolsPalletId } = consts;
 
   // store pool metadata
@@ -34,7 +36,7 @@ export const PoolsConfigProvider = ({
   // get favorite pools from local storage.
   const getLocalFavorites = () => {
     const localFavorites = localStorage.getItem(
-      `${network.name}_favorite_pools`
+      `${networkData.name}_favorite_pools`
     );
     return localFavorites !== null ? JSON.parse(localFavorites) : [];
   };
@@ -49,7 +51,7 @@ export const PoolsConfigProvider = ({
     return () => {
       unsubscribe();
     };
-  }, [network, isReady]);
+  }, [networkData, isReady]);
 
   const unsubscribe = () => {
     if (poolsConfigRef.current.unsub !== null) {
@@ -152,7 +154,7 @@ export const PoolsConfigProvider = ({
     }
 
     localStorage.setItem(
-      `${network.name}_favorite_pools`,
+      `${networkData.name}_favorite_pools`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);
@@ -167,7 +169,7 @@ export const PoolsConfigProvider = ({
       (validator: string) => validator !== address
     );
     localStorage.setItem(
-      `${network.name}_favorite_pools`,
+      `${networkData.name}_favorite_pools`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -22,7 +22,7 @@ export const PoolsConfigProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData } = useNetwork();
+  const { networkData, network } = useNetwork();
   const { api, isReady, consts } = useApi();
   const { poolsPalletId } = consts;
 
@@ -35,9 +35,7 @@ export const PoolsConfigProvider = ({
 
   // get favorite pools from local storage.
   const getLocalFavorites = () => {
-    const localFavorites = localStorage.getItem(
-      `${networkData.name}_favorite_pools`
-    );
+    const localFavorites = localStorage.getItem(`${network}_favorite_pools`);
     return localFavorites !== null ? JSON.parse(localFavorites) : [];
   };
 
@@ -154,7 +152,7 @@ export const PoolsConfigProvider = ({
     }
 
     localStorage.setItem(
-      `${networkData.name}_favorite_pools`,
+      `${network}_favorite_pools`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);
@@ -169,7 +167,7 @@ export const PoolsConfigProvider = ({
       (validator: string) => validator !== address
     );
     localStorage.setItem(
-      `${networkData.name}_favorite_pools`,
+      `${network}_favorite_pools`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -34,8 +34,8 @@ export const ProxiesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { api, isReady } = useApi();
-  const { networkData } = useNetwork();
   const {
     accounts,
     activeProxy,
@@ -173,13 +173,13 @@ export const ProxiesProvider = ({
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, isReady, networkData]);
+  }, [accounts, isReady, network]);
 
   // If active proxy has not yet been set, check local storage `activeProxy` & set it as active
   // proxy if it is the delegate of `activeAccount`.
   useEffectIgnoreInitial(() => {
     const localActiveProxy = localStorageOrDefault(
-      `${networkData.name}_active_proxy`,
+      `${network}_active_proxy`,
       null
     );
 
@@ -208,17 +208,17 @@ export const ProxiesProvider = ({
         }
       } catch (e) {
         // Corrupt local active proxy record. Remove it.
-        localStorage.removeItem(`${networkData.name}_active_proxy`);
+        localStorage.removeItem(`${network}_active_proxy`);
       }
     }
-  }, [accounts, activeAccount, proxiesRef.current, networkData]);
+  }, [accounts, activeAccount, proxiesRef.current, network]);
 
   // Reset active proxy state, unsubscribe from subscriptions on network change & unmount.
   useEffectIgnoreInitial(() => {
     setActiveProxy(null, false);
     unsubAll();
     return () => unsubAll();
-  }, [networkData]);
+  }, [network]);
 
   const unsubAll = () => {
     for (const unsub of Object.values(unsubs.current)) {

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -18,6 +18,7 @@ import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import type { AnyApi, MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 import type {
   Delegates,
@@ -33,7 +34,8 @@ export const ProxiesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { api, isReady, network } = useApi();
+  const { api, isReady } = useApi();
+  const { networkData } = useNetwork();
   const {
     accounts,
     activeProxy,
@@ -171,13 +173,13 @@ export const ProxiesProvider = ({
     if (isReady) {
       handleSyncAccounts();
     }
-  }, [accounts, isReady, network]);
+  }, [accounts, isReady, networkData]);
 
   // If active proxy has not yet been set, check local storage `activeProxy` & set it as active
   // proxy if it is the delegate of `activeAccount`.
   useEffectIgnoreInitial(() => {
     const localActiveProxy = localStorageOrDefault(
-      `${network.name}_active_proxy`,
+      `${networkData.name}_active_proxy`,
       null
     );
 
@@ -206,17 +208,17 @@ export const ProxiesProvider = ({
         }
       } catch (e) {
         // Corrupt local active proxy record. Remove it.
-        localStorage.removeItem(`${network.name}_active_proxy`);
+        localStorage.removeItem(`${networkData.name}_active_proxy`);
       }
     }
-  }, [accounts, activeAccount, proxiesRef.current, network]);
+  }, [accounts, activeAccount, proxiesRef.current, networkData]);
 
   // Reset active proxy state, unsubscribe from subscriptions on network change & unmount.
   useEffectIgnoreInitial(() => {
     setActiveProxy(null, false);
     unsubAll();
     return () => unsubAll();
-  }, [network]);
+  }, [networkData]);
 
   const unsubAll = () => {
     for (const unsub of Object.values(unsubs.current)) {

--- a/src/contexts/Setup/index.tsx
+++ b/src/contexts/Setup/index.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import type { BondFor, MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
-import { useApi } from '../Api';
+import { useNetwork } from 'contexts/Network';
 import { useConnect } from '../Connect';
 import { useStaking } from '../Staking';
 import {
@@ -29,8 +29,8 @@ import type {
 } from './types';
 
 export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
-  const { network } = useApi();
   const { inSetup } = useStaking();
+  const { networkData } = useNetwork();
   const { accounts, activeAccount } = useConnect();
   const { membership: poolMembership } = usePoolMemberships();
 
@@ -138,7 +138,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (!address) return 0;
     const setup = getSetupProgress('nominator', address) as NominatorSetup;
     const { progress } = setup;
-    const bond = unitToPlanck(progress?.bond || '0', network.units);
+    const bond = unitToPlanck(progress?.bond || '0', networkData.units);
 
     const p = 33;
     let percentage = 0;
@@ -153,7 +153,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (!address) return 0;
     const setup = getSetupProgress('pool', address) as PoolSetup;
     const { progress } = setup;
-    const bond = unitToPlanck(progress?.bond || '0', network.units);
+    const bond = unitToPlanck(progress?.bond || '0', networkData.units);
 
     const p = 25;
     let percentage = 0;
@@ -214,12 +214,12 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (poolMembership) {
       setOnPoolSetup(false);
     }
-  }, [inSetup(), network, poolMembership]);
+  }, [inSetup(), networkData, poolMembership]);
 
   // Update setup state when activeAccount changes
   useEffectIgnoreInitial(() => {
     if (accounts.length) refreshSetups();
-  }, [activeAccount, network, accounts]);
+  }, [activeAccount, networkData, accounts]);
 
   return (
     <SetupContext.Provider

--- a/src/contexts/Setup/index.tsx
+++ b/src/contexts/Setup/index.tsx
@@ -30,7 +30,10 @@ import type {
 
 export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
   const { inSetup } = useStaking();
-  const { networkData } = useNetwork();
+  const {
+    network,
+    networkData: { units },
+  } = useNetwork();
   const { accounts, activeAccount } = useConnect();
   const { membership: poolMembership } = usePoolMemberships();
 
@@ -138,7 +141,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (!address) return 0;
     const setup = getSetupProgress('nominator', address) as NominatorSetup;
     const { progress } = setup;
-    const bond = unitToPlanck(progress?.bond || '0', networkData.units);
+    const bond = unitToPlanck(progress?.bond || '0', units);
 
     const p = 33;
     let percentage = 0;
@@ -153,7 +156,7 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (!address) return 0;
     const setup = getSetupProgress('pool', address) as PoolSetup;
     const { progress } = setup;
-    const bond = unitToPlanck(progress?.bond || '0', networkData.units);
+    const bond = unitToPlanck(progress?.bond || '0', units);
 
     const p = 25;
     let percentage = 0;
@@ -214,12 +217,12 @@ export const SetupProvider = ({ children }: { children: React.ReactNode }) => {
     if (poolMembership) {
       setOnPoolSetup(false);
     }
-  }, [inSetup(), networkData, poolMembership]);
+  }, [inSetup(), network, poolMembership]);
 
   // Update setup state when activeAccount changes
   useEffectIgnoreInitial(() => {
     if (accounts.length) refreshSetups();
-  }, [activeAccount, networkData, accounts]);
+  }, [activeAccount, network, accounts]);
 
   return (
     <SetupContext.Provider

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -53,9 +53,9 @@ export const StakingProvider = ({
     accounts: connectAccounts,
     getActiveAccount,
   } = useConnect();
-  const { networkData } = useNetwork();
   const { getStashLedger } = useBalances();
   const { activeEra } = useNetworkMetrics();
+  const { networkData, network } = useNetwork();
   const { isReady, api, apiStatus, consts } = useApi();
   const { bondedAccounts, getBondedAccount, getAccountNominations } =
     useBonded();
@@ -102,7 +102,7 @@ export const StakingProvider = ({
       // ensure task matches, & era is still the same.
       if (
         task !== 'processExposures' ||
-        networkName !== networkData.name ||
+        networkName !== network ||
         era !== activeEra.index.toString()
       )
         return;
@@ -201,7 +201,7 @@ export const StakingProvider = ({
 
     let exposures: Exposure[] = [];
     const localExposures = getLocalEraExposures(
-      networkData.name,
+      network,
       era,
       activeEra.index.toString()
     );
@@ -216,7 +216,7 @@ export const StakingProvider = ({
 
     // For resource limitation concerns, only store the current era in local storage.
     if (era === activeEra.index.toString())
-      setLocalEraExposures(networkData.name, era, exposures);
+      setLocalEraExposures(network, era, exposures);
 
     return exposures;
   };
@@ -233,7 +233,7 @@ export const StakingProvider = ({
     // worker to calculate stats
     worker.postMessage({
       era: activeEra.index.toString(),
-      networkName: networkData.name,
+      networkName: network,
       task: 'processExposures',
       activeAccount,
       units: networkData.units,

--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -8,10 +8,11 @@ import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import type { MaybeAccount } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 import type { TransferOptions, TransferOptionsContextInterface } from './types';
 
@@ -20,10 +21,10 @@ export const TransferOptionsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { consts } = useApi();
   const {
-    consts,
-    network: { name, units, defaultFeeReserve },
-  } = useApi();
+    networkData: { name, units, defaultFeeReserve },
+  } = useNetwork();
   const { activeEra } = useNetworkMetrics();
   const { getStashLedger, getBalance, getLocks } = useBalances();
   const { getAccount } = useBonded();

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -11,7 +11,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useApi } from '../Api';
 import { useConnect } from '../Connect';
-import { useNetworkMetrics } from '../Network';
+import { useNetworkMetrics } from '../NetworkMetrics';
 import { useStaking } from '../Staking';
 import * as defaults from './defaults';
 import type { UIContextInterface } from './types';

--- a/src/contexts/Validators/FavoriteValidators/index.tsx
+++ b/src/contexts/Validators/FavoriteValidators/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState } from 'react';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useApi } from 'contexts/Api';
 import type { Validator, FavoriteValidatorsContextInterface } from '../types';
 import { getLocalFavorites } from '../Utils';
@@ -14,9 +15,10 @@ export const FavoriteValidatorsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { isReady, network } = useApi();
+  const { isReady } = useApi();
+  const { networkData } = useNetwork();
   const { fetchValidatorPrefs } = useValidators();
-  const { name } = network;
+  const { name } = networkData;
 
   // Stores the user's favorite validators.
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites(name));
@@ -42,7 +44,7 @@ export const FavoriteValidatorsProvider = ({
     }
 
     localStorage.setItem(
-      `${network.name}_favorites`,
+      `${networkData.name}_favorites`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);
@@ -54,7 +56,7 @@ export const FavoriteValidatorsProvider = ({
       (validator: string) => validator !== address
     );
     localStorage.setItem(
-      `${network.name}_favorites`,
+      `${networkData.name}_favorites`,
       JSON.stringify(newFavorites)
     );
     setFavorites([...newFavorites]);
@@ -63,7 +65,7 @@ export const FavoriteValidatorsProvider = ({
   // Re-fetch favorites on network change
   useEffectIgnoreInitial(() => {
     setFavorites(getLocalFavorites(name));
-  }, [network]);
+  }, [networkData]);
 
   // Fetch favorites in validator list format
   useEffectIgnoreInitial(() => {

--- a/src/contexts/Validators/FavoriteValidators/index.tsx
+++ b/src/contexts/Validators/FavoriteValidators/index.tsx
@@ -16,9 +16,11 @@ export const FavoriteValidatorsProvider = ({
   children: React.ReactNode;
 }) => {
   const { isReady } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { name },
+    network,
+  } = useNetwork();
   const { fetchValidatorPrefs } = useValidators();
-  const { name } = networkData;
 
   // Stores the user's favorite validators.
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites(name));
@@ -43,10 +45,7 @@ export const FavoriteValidatorsProvider = ({
       newFavorites.push(address);
     }
 
-    localStorage.setItem(
-      `${networkData.name}_favorites`,
-      JSON.stringify(newFavorites)
-    );
+    localStorage.setItem(`${network}_favorites`, JSON.stringify(newFavorites));
     setFavorites([...newFavorites]);
   };
 
@@ -55,17 +54,14 @@ export const FavoriteValidatorsProvider = ({
     const newFavorites = Object.assign(favorites).filter(
       (validator: string) => validator !== address
     );
-    localStorage.setItem(
-      `${networkData.name}_favorites`,
-      JSON.stringify(newFavorites)
-    );
+    localStorage.setItem(`${network}_favorites`, JSON.stringify(newFavorites));
     setFavorites([...newFavorites]);
   };
 
   // Re-fetch favorites on network change
   useEffectIgnoreInitial(() => {
     setFavorites(getLocalFavorites(name));
-  }, [networkData]);
+  }, [network]);
 
   // Fetch favorites in validator list format
   useEffectIgnoreInitial(() => {

--- a/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -28,13 +28,12 @@ export const ValidatorsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network } = useNetwork();
   const { isReady, api } = useApi();
-  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { poolNominations } = useActivePools();
   const { activeEra, metrics } = useNetworkMetrics();
   const { bondedAccounts, getAccountNominations } = useBonded();
-  const { name } = networkData;
   const { earliestStoredSession } = metrics;
 
   // Stores all validator entries.
@@ -84,7 +83,7 @@ export const ValidatorsProvider = ({
     setValidators([]);
     setValidatorIdentities({});
     setValidatorSupers({});
-  }, [networkData]);
+  }, [network]);
 
   // fetch validators and session validators when activeEra ready
   useEffectIgnoreInitial(() => {
@@ -140,7 +139,7 @@ export const ValidatorsProvider = ({
       sessionUnsub.current?.();
       sessionParaUnsub.current?.();
     };
-  }, [networkData]);
+  }, [network]);
 
   const fetchPoolNominatedList = async () => {
     // get raw nominations list
@@ -192,7 +191,7 @@ export const ValidatorsProvider = ({
     // If local validator entries exist for the current era, store these values in state. Otherwise,
     // fetch entries from API.
     const localEraValidators = getLocalEraValidators(
-      name,
+      network,
       activeEra.index.toString()
     );
 
@@ -219,7 +218,7 @@ export const ValidatorsProvider = ({
 
     // Set entries data for the era to local storage.
     setLocalEraValidators(
-      name,
+      network,
       activeEra.index.toString(),
       validatorEntries,
       avg

--- a/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -7,11 +7,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ValidatorCommunity } from '@polkadot-cloud/assets/validators';
 import type { AnyApi, Fn, Sync } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
-import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useActivePools } from 'contexts/Pools/ActivePools';
+import { useNetwork } from 'contexts/Network';
+import { useApi } from 'contexts/Api';
 import type {
   Identity,
   Validator,
@@ -27,12 +28,13 @@ export const ValidatorsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { isReady, api } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
-  const { isReady, api, network } = useApi();
   const { poolNominations } = useActivePools();
   const { activeEra, metrics } = useNetworkMetrics();
   const { bondedAccounts, getAccountNominations } = useBonded();
-  const { name } = network;
+  const { name } = networkData;
   const { earliestStoredSession } = metrics;
 
   // Stores all validator entries.
@@ -82,7 +84,7 @@ export const ValidatorsProvider = ({
     setValidators([]);
     setValidatorIdentities({});
     setValidatorSupers({});
-  }, [network]);
+  }, [networkData]);
 
   // fetch validators and session validators when activeEra ready
   useEffectIgnoreInitial(() => {
@@ -138,7 +140,7 @@ export const ValidatorsProvider = ({
       sessionUnsub.current?.();
       sessionParaUnsub.current?.();
     };
-  }, [network]);
+  }, [networkData]);
 
   const fetchPoolNominatedList = async () => {
     // get raw nominations list

--- a/src/library/BarChart/BondedChart.tsx
+++ b/src/library/BarChart/BondedChart.tsx
@@ -4,10 +4,10 @@
 import { greaterThanZero } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { BarSegment } from 'library/BarChart/BarSegment';
 import { LegendItem } from 'library/BarChart/LegendItem';
 import { Bar, BarChartWrapper, Legend } from 'library/BarChart/Wrappers';
+import { useNetwork } from 'contexts/Network';
 import type { BondedChartProps } from '../../pages/Nominate/Active/types';
 
 export const BondedChart = ({
@@ -19,8 +19,8 @@ export const BondedChart = ({
 }: BondedChartProps) => {
   const { t } = useTranslation('library');
   const {
-    network: { unit },
-  } = useApi();
+    networkData: { unit },
+  } = useNetwork();
   const totalUnlocking = unlocking.plus(unlocked);
 
   // graph percentages

--- a/src/library/EstimatedTxFee/index.tsx
+++ b/src/library/EstimatedTxFee/index.tsx
@@ -5,15 +5,15 @@ import { planckToUnit } from '@polkadot-cloud/utils';
 import type { Context } from 'react';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { TxMetaContext, useTxMeta } from 'contexts/TxMeta';
 import type { TxMetaContextInterface } from 'contexts/TxMeta/types';
+import { useNetwork } from 'contexts/Network';
 import { Wrapper } from './Wrapper';
 import type { EstimatedTxFeeProps } from './types';
 
 export const EstimatedTxFeeInner = ({ format }: EstimatedTxFeeProps) => {
   const { t } = useTranslation('library');
-  const { unit, units } = useApi().network;
+  const { unit, units } = useNetwork().networkData;
   const { txFees, resetTxFees } = useTxMeta();
 
   useEffect(() => () => resetTxFees(), []);

--- a/src/library/Form/Bond/BondFeedback.tsx
+++ b/src/library/Form/Bond/BondFeedback.tsx
@@ -5,12 +5,12 @@ import { planckToUnit, unitToPlanck } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
+import { useNetwork } from 'contexts/Network';
 import { Warning } from '../Warning';
 import { Spacer } from '../Wrappers';
 import type { BondFeedbackProps } from '../types';
@@ -30,14 +30,15 @@ export const BondFeedback = ({
   syncing = false,
 }: BondFeedbackProps) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
-  const { activeAccount } = useConnect();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { staking } = useStaking();
-  const { getTransferOptions } = useTransferOptions();
-  const { isDepositor } = useActivePools();
+  const { activeAccount } = useConnect();
   const { stats } = usePoolsConfig();
+  const { isDepositor } = useActivePools();
+  const { getTransferOptions } = useTransferOptions();
   const { minJoinBond, minCreateBond } = stats;
-  const { units, unit } = network;
   const { minNominatorBond } = staking;
   const allTransferOptions = getTransferOptions(activeAccount);
 

--- a/src/library/Form/Bond/BondInput.tsx
+++ b/src/library/Form/Bond/BondInput.tsx
@@ -5,8 +5,8 @@ import { ButtonSubmitInvert } from '@polkadot-cloud/react';
 import BigNumber from 'bignumber.js';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
+import { useNetwork } from 'contexts/Network';
 import { InputWrapper } from '../Wrappers';
 import type { BondInputProps } from '../types';
 
@@ -20,7 +20,9 @@ export const BondInput = ({
   syncing = false,
 }: BondInputProps) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
+  const {
+    networkData: { unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
 
   // the current local bond value
@@ -60,9 +62,7 @@ export const BondInput = ({
   // available funds as jsx.
   const availableFundsJsx = (
     <p>
-      {syncing
-        ? '...'
-        : `${freeBalance.toFormat()} ${network.unit} ${t('available')}`}
+      {syncing ? '...' : `${freeBalance.toFormat()} ${unit} ${t('available')}`}
     </p>
   );
 
@@ -74,7 +74,7 @@ export const BondInput = ({
             <div>
               <input
                 type="text"
-                placeholder={`0 ${network.unit}`}
+                placeholder={`0 ${unit}`}
                 value={localBond}
                 onChange={(e) => {
                   handleChangeBond(e);

--- a/src/library/Form/CreatePoolStatusBar/index.tsx
+++ b/src/library/Form/CreatePoolStatusBar/index.tsx
@@ -5,16 +5,16 @@ import { faFlag } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useUi } from 'contexts/UI';
+import { useNetwork } from 'contexts/Network';
 import type { NominateStatusBarProps } from '../types';
 import { Wrapper } from './Wrapper';
 
 export const CreatePoolStatusBar = ({ value }: NominateStatusBarProps) => {
   const { t } = useTranslation('library');
   const { isSyncing } = useUi();
-  const { unit, units } = useApi().network;
+  const { unit, units } = useNetwork().networkData;
   const { minCreateBond } = usePoolsConfig().stats;
 
   const minCreateBondUnit = planckToUnit(minCreateBond, units);

--- a/src/library/Form/NominateStatusBar/index.tsx
+++ b/src/library/Form/NominateStatusBar/index.tsx
@@ -6,11 +6,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ButtonHelp } from '@polkadot-cloud/react';
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useHelp } from 'contexts/Help';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
+import { useNetwork } from 'contexts/Network';
 import type { NominateStatusBarProps } from '../types';
 import { Wrapper } from './Wrapper';
 
@@ -18,7 +18,7 @@ export const NominateStatusBar = ({ value }: NominateStatusBarProps) => {
   const { t } = useTranslation('library');
   const { staking } = useStaking();
   const { isSyncing } = useUi();
-  const { unit, units } = useApi().network;
+  const { unit, units } = useNetwork().networkData;
   const { minNominatorBond } = staking;
   const { metrics } = useNetworkMetrics();
   const { minimumActiveStake } = metrics;

--- a/src/library/Form/Unbond/UnbondFeedback.tsx
+++ b/src/library/Form/Unbond/UnbondFeedback.tsx
@@ -5,12 +5,12 @@ import { isNotZero, planckToUnit, unitToPlanck } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
+import { useNetwork } from 'contexts/Network';
 import { Warning } from '../Warning';
 import { Spacer } from '../Wrappers';
 import type { UnbondFeedbackProps } from '../types';
@@ -27,14 +27,15 @@ export const UnbondFeedback = ({
   txFees,
 }: UnbondFeedbackProps) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { staking } = useStaking();
   const { getTransferOptions } = useTransferOptions();
   const { isDepositor } = useActivePools();
   const { stats } = usePoolsConfig();
   const { minJoinBond, minCreateBond } = stats;
-  const { units, unit } = network;
   const { minNominatorBond } = staking;
   const allTransferOptions = getTransferOptions(activeAccount);
 

--- a/src/library/Form/Unbond/UnbondInput.tsx
+++ b/src/library/Form/Unbond/UnbondInput.tsx
@@ -6,8 +6,8 @@ import { planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
+import { useNetwork } from 'contexts/Network';
 import { InputWrapper } from '../Wrappers';
 import type { UnbondInputProps } from '../types';
 
@@ -20,11 +20,11 @@ export const UnbondInput = ({
   active,
 }: UnbondInputProps) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
 
   // get the actively bonded amount.
-  const activeUnit = planckToUnit(active, network.units);
+  const activeUnit = planckToUnit(active, networkData.units);
 
   // the current local bond value.
   const [localBond, setLocalBond] = useState(value);
@@ -55,12 +55,12 @@ export const UnbondInput = ({
   };
 
   // unbond to min as unit.
-  const unbondToMinUnit = planckToUnit(unbondToMin, network.units);
+  const unbondToMinUnit = planckToUnit(unbondToMin, networkData.units);
 
   // available funds as jsx.
   const maxBondedJsx = (
     <p>
-      {activeUnit.toFormat()} {network.unit} {t('bonded')}
+      {activeUnit.toFormat()} {networkData.unit} {t('bonded')}
     </p>
   );
 
@@ -72,7 +72,7 @@ export const UnbondInput = ({
             <div>
               <input
                 type="text"
-                placeholder={`0 ${network.unit}`}
+                placeholder={`0 ${networkData.unit}`}
                 value={localBond}
                 onChange={(e) => {
                   handleChangeUnbond(e);

--- a/src/library/Graphs/EraPoints.tsx
+++ b/src/library/Graphs/EraPoints.tsx
@@ -13,9 +13,9 @@ import {
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useTheme } from 'contexts/Themes';
 import { graphColors } from 'styles/graphs';
+import { useNetwork } from 'contexts/Network';
 import type { EraPointsProps } from './types';
 
 ChartJS.register(
@@ -31,7 +31,7 @@ ChartJS.register(
 export const EraPoints = ({ items = [], height }: EraPointsProps) => {
   const { t } = useTranslation('library');
   const { mode } = useTheme();
-  const { colors } = useApi().network;
+  const { colors } = useNetwork().networkData;
 
   const options = {
     responsive: true,

--- a/src/library/Graphs/GeoDonut.tsx
+++ b/src/library/Graphs/GeoDonut.tsx
@@ -3,11 +3,11 @@
 
 import { ArcElement, Chart as ChartJS, Legend, Tooltip } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
-import { useApi } from 'contexts/Api';
 import { useTheme } from 'contexts/Themes';
 import { graphColors } from 'styles/graphs';
 import chroma from 'chroma-js';
 import { ellipsisFn } from '@polkadot-cloud/utils';
+import { useNetwork } from 'contexts/Network';
 import type { GeoDonutProps } from './types';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -18,8 +18,9 @@ export const GeoDonut = ({
   height = 'auto',
   width = 'auto',
 }: GeoDonutProps) => {
-  const { colors } = useApi().network;
   const { mode } = useTheme();
+  const { colors } = useNetwork().networkData;
+
   const { labels } = series;
   let { data } = series;
   const isZero = data.length === 0;

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -17,7 +17,6 @@ import { format, fromUnixTime } from 'date-fns';
 import { Bar } from 'react-chartjs-2';
 import { useTranslation } from 'react-i18next';
 import { DefaultLocale } from 'consts';
-import { useApi } from 'contexts/Api';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { useStaking } from 'contexts/Staking';
 import { useSubscan } from 'contexts/Plugins/Subscan';
@@ -26,6 +25,7 @@ import { useUi } from 'contexts/UI';
 import { locales } from 'locale';
 import { graphColors } from 'styles/graphs';
 import type { AnySubscan } from 'types';
+import { useNetwork } from 'contexts/Network';
 import type { PayoutBarProps } from './types';
 import { formatRewardsForGraphs } from './Utils';
 
@@ -43,10 +43,10 @@ ChartJS.register(
 export const PayoutBar = ({ days, height }: PayoutBarProps) => {
   const { i18n, t } = useTranslation('library');
   const { mode } = useTheme();
-  const { unit, units, colors } = useApi().network;
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
   const { membership } = usePoolMemberships();
+  const { unit, units, colors } = useNetwork().networkData;
   const { payouts, poolClaims, unclaimedPayouts } = useSubscan();
   const notStaking = !isSyncing && inSetup() && !membership;
 

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -14,7 +14,6 @@ import {
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { useStaking } from 'contexts/Staking';
 import { useSubscan } from 'contexts/Plugins/Subscan';
@@ -22,6 +21,7 @@ import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
 import { graphColors } from 'styles/graphs';
 import type { AnySubscan } from 'types';
+import { useNetwork } from 'contexts/Network';
 import type { PayoutLineProps } from './types';
 import {
   calculatePayoutAverages,
@@ -47,11 +47,11 @@ export const PayoutLine = ({
 }: PayoutLineProps) => {
   const { t } = useTranslation('library');
   const { mode } = useTheme();
-  const { unit, units, colors } = useApi().network;
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
-  const { membership: poolMembership } = usePoolMemberships();
   const { payouts, poolClaims } = useSubscan();
+  const { unit, units, colors } = useNetwork().networkData;
+  const { membership: poolMembership } = usePoolMemberships();
 
   const notStaking = !isSyncing && inSetup() && !poolMembership;
   const poolingOnly = !isSyncing && inSetup() && poolMembership !== null;

--- a/src/library/Hooks/useBlockNumber/index.tsx
+++ b/src/library/Hooks/useBlockNumber/index.tsx
@@ -9,8 +9,8 @@ import type { AnyApi } from 'types';
 import { useNetwork } from 'contexts/Network';
 
 export const useBlockNumber = () => {
+  const { network } = useNetwork();
   const { isReady, api } = useApi();
-  const { networkData } = useNetwork();
 
   // store the current block number.
   const [block, setBlock] = useState<BigNumber>(new BigNumber(0));
@@ -25,7 +25,7 @@ export const useBlockNumber = () => {
     return () => {
       if (unsub.current) unsub.current();
     };
-  }, [networkData, isReady]);
+  }, [network, isReady]);
 
   const subscribeBlockNumber = async () => {
     if (!api) return;

--- a/src/library/Hooks/useBlockNumber/index.tsx
+++ b/src/library/Hooks/useBlockNumber/index.tsx
@@ -6,9 +6,11 @@ import BigNumber from 'bignumber.js';
 import { useEffect, useRef, useState } from 'react';
 import { useApi } from 'contexts/Api';
 import type { AnyApi } from 'types';
+import { useNetwork } from 'contexts/Network';
 
 export const useBlockNumber = () => {
-  const { isReady, api, network } = useApi();
+  const { isReady, api } = useApi();
+  const { networkData } = useNetwork();
 
   // store the current block number.
   const [block, setBlock] = useState<BigNumber>(new BigNumber(0));
@@ -23,7 +25,7 @@ export const useBlockNumber = () => {
     return () => {
       if (unsub.current) unsub.current();
     };
-  }, [network, isReady]);
+  }, [networkData, isReady]);
 
   const subscribeBlockNumber = async () => {
     if (!api) return;

--- a/src/library/Hooks/useEraTimeLeft/index.tsx
+++ b/src/library/Hooks/useEraTimeLeft/index.tsx
@@ -4,7 +4,7 @@
 import BigNumber from 'bignumber.js';
 import { getUnixTime } from 'date-fns';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 
 export const useEraTimeLeft = () => {
   const { consts } = useApi();

--- a/src/library/Hooks/useFillVariables/index.tsx
+++ b/src/library/Hooks/useFillVariables/index.tsx
@@ -3,13 +3,15 @@
 
 import { capitalizeFirstLetter, planckToUnit } from '@polkadot-cloud/utils';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetwork } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import type { AnyJson } from 'types';
 
 export const useFillVariables = () => {
-  const { network, consts } = useApi();
+  const { consts } = useApi();
   const { stats } = usePoolsConfig();
+  const { networkData } = useNetwork();
   const {
     maxNominations,
     maxNominatorRewardedPerValidator,
@@ -26,8 +28,8 @@ export const useFillVariables = () => {
     const transformed = Object.entries(fields).map(
       ([, [key, val]]: AnyJson) => {
         const varsToValues = [
-          ['{NETWORK_UNIT}', network.unit],
-          ['{NETWORK_NAME}', capitalizeFirstLetter(network.name)],
+          ['{NETWORK_UNIT}', networkData.unit],
+          ['{NETWORK_NAME}', capitalizeFirstLetter(networkData.name)],
           [
             '{MAX_NOMINATOR_REWARDED_PER_VALIDATOR}',
             maxNominatorRewardedPerValidator.toString(),
@@ -35,25 +37,25 @@ export const useFillVariables = () => {
           ['{MAX_NOMINATIONS}', maxNominations.toString()],
           [
             '{MIN_ACTIVE_STAKE}',
-            planckToUnit(minimumActiveStake, network.units)
+            planckToUnit(minimumActiveStake, networkData.units)
               .decimalPlaces(3)
               .toFormat(),
           ],
           [
             '{MIN_POOL_JOIN_BOND}',
-            planckToUnit(minJoinBond, network.units)
+            planckToUnit(minJoinBond, networkData.units)
               .decimalPlaces(3)
               .toFormat(),
           ],
           [
             '{MIN_POOL_CREATE_BOND}',
-            planckToUnit(minCreateBond, network.units)
+            planckToUnit(minCreateBond, networkData.units)
               .decimalPlaces(3)
               .toFormat(),
           ],
           [
             '{EXISTENTIAL_DEPOSIT}',
-            planckToUnit(existentialDeposit, network.units).toFormat(),
+            planckToUnit(existentialDeposit, networkData.units).toFormat(),
           ],
         ];
 

--- a/src/library/Hooks/useInflation/index.tsx
+++ b/src/library/Hooks/useInflation/index.tsx
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js';
-import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetwork } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useStaking } from 'contexts/Staking';
 
 export const useInflation = () => {
-  const { network } = useApi();
+  const {
+    networkData: { params },
+  } = useNetwork();
   const { metrics } = useNetworkMetrics();
   const { staking } = useStaking();
-  const { params } = network;
   const { lastTotalStake } = staking;
   const { totalIssuance, auctionCounter } = metrics;
 

--- a/src/library/Hooks/useLedgerLoop/index.tsx
+++ b/src/library/Hooks/useLedgerLoop/index.tsx
@@ -10,11 +10,9 @@ import type { LederLoopProps } from './types';
 export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
   const { setIsPaired, getIsExecuting, getStatusCodes, executeLedgerLoop } =
     useLedgerHardware();
-  const {
-    networkData: { name },
-  } = useNetwork();
+  const { network } = useNetwork();
   const { getTxPayload, getPayloadUid } = useTxMeta();
-  const { appName } = getLedgerApp(name);
+  const { appName } = getLedgerApp(network);
 
   // Connect to Ledger device and perform necessary tasks.
   //

--- a/src/library/Hooks/useLedgerLoop/index.tsx
+++ b/src/library/Hooks/useLedgerLoop/index.tsx
@@ -1,18 +1,18 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useApi } from 'contexts/Api';
 import { useLedgerHardware } from 'contexts/Hardware/Ledger';
 import { getLedgerApp } from 'contexts/Hardware/Utils';
 import { useTxMeta } from 'contexts/TxMeta';
+import { useNetwork } from 'contexts/Network';
 import type { LederLoopProps } from './types';
 
 export const useLedgerLoop = ({ tasks, options, mounted }: LederLoopProps) => {
   const { setIsPaired, getIsExecuting, getStatusCodes, executeLedgerLoop } =
     useLedgerHardware();
   const {
-    network: { name },
-  } = useApi();
+    networkData: { name },
+  } = useNetwork();
   const { getTxPayload, getPayloadUid } = useTxMeta();
   const { appName } = getLedgerApp(name);
 

--- a/src/library/Hooks/useNominationStatus/index.tsx
+++ b/src/library/Hooks/useNominationStatus/index.tsx
@@ -4,18 +4,20 @@
 import { planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { AnyJson, MaybeAccount } from 'types';
+import { useNetwork } from 'contexts/Network';
 
 export const useNominationStatus = () => {
   const { t } = useTranslation();
-  const { network } = useApi();
   const { isSyncing } = useUi();
+  const {
+    networkData: { units },
+  } = useNetwork();
   const { validators } = useValidators();
   const { poolNominations } = useActivePools();
   const { getAccountNominations } = useBonded();
@@ -75,7 +77,7 @@ export const useNominationStatus = () => {
               if (
                 planckToUnit(
                   new BigNumber(stakedValue),
-                  network.units
+                  units
                 ).isGreaterThanOrEqualTo(lowest)
               ) {
                 earningRewards = true;

--- a/src/library/Hooks/usePrices/index.tsx
+++ b/src/library/Hooks/usePrices/index.tsx
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useEffect, useRef, useState } from 'react';
-import { useApi } from 'contexts/Api';
 import { usePlugins } from 'contexts/Plugins';
 import { useUnitPrice } from 'library/Hooks/useUnitPrice';
+import { useNetwork } from 'contexts/Network';
 
 export const usePrices = () => {
-  const { network } = useApi();
   const { plugins } = usePlugins();
+  const { networkData } = useNetwork();
   const fetchUnitPrice = useUnitPrice();
 
   const pricesLocalStorage = () => {
-    const pricesLocal = localStorage.getItem(`${network.name}_prices`);
+    const pricesLocal = localStorage.getItem(`${networkData.name}_prices`);
     return pricesLocal === null
       ? {
           lastPrice: 0,
@@ -25,7 +25,7 @@ export const usePrices = () => {
   const pricesRef = useRef(prices);
 
   const setPrices = (p: any) => {
-    localStorage.setItem(`${network.name}_prices`, JSON.stringify(p));
+    localStorage.setItem(`${networkData.name}_prices`, JSON.stringify(p));
     pricesRef.current = {
       ...pricesRef.current,
       ...p,
@@ -66,7 +66,7 @@ export const usePrices = () => {
       clearInterval(priceHandle);
     }
     initiatePriceInterval();
-  }, [network]);
+  }, [networkData]);
 
   // servie toggle
   useEffect(() => {

--- a/src/library/Hooks/usePrices/index.tsx
+++ b/src/library/Hooks/usePrices/index.tsx
@@ -7,12 +7,12 @@ import { useUnitPrice } from 'library/Hooks/useUnitPrice';
 import { useNetwork } from 'contexts/Network';
 
 export const usePrices = () => {
+  const { network } = useNetwork();
   const { plugins } = usePlugins();
-  const { networkData } = useNetwork();
   const fetchUnitPrice = useUnitPrice();
 
   const pricesLocalStorage = () => {
-    const pricesLocal = localStorage.getItem(`${networkData.name}_prices`);
+    const pricesLocal = localStorage.getItem(`${network}_prices`);
     return pricesLocal === null
       ? {
           lastPrice: 0,
@@ -25,7 +25,7 @@ export const usePrices = () => {
   const pricesRef = useRef(prices);
 
   const setPrices = (p: any) => {
-    localStorage.setItem(`${networkData.name}_prices`, JSON.stringify(p));
+    localStorage.setItem(`${network}_prices`, JSON.stringify(p));
     pricesRef.current = {
       ...pricesRef.current,
       ...p,
@@ -66,7 +66,7 @@ export const usePrices = () => {
       clearInterval(priceHandle);
     }
     initiatePriceInterval();
-  }, [networkData]);
+  }, [network]);
 
   // servie toggle
   useEffect(() => {

--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -14,8 +14,8 @@ import type {
 import { getDuration } from './utils';
 
 export const useTimeLeft = () => {
+  const { network } = useNetwork();
   const { t, i18n } = useTranslation();
-  const { networkData } = useNetwork();
 
   // check whether timeleft is within a minute of finishing.
   const inLastHour = () => {
@@ -107,7 +107,7 @@ export const useTimeLeft = () => {
         setStateWithRef(interval, setMinInterval, minIntervalRef);
       }
     }
-  }, [to, inLastHour(), lastMinuteCountdown(), networkData]);
+  }, [to, inLastHour(), lastMinuteCountdown(), network]);
 
   // re-render the timeleft upon langauge switch.
   useEffect(() => {

--- a/src/library/Hooks/useTimeLeft/index.tsx
+++ b/src/library/Hooks/useTimeLeft/index.tsx
@@ -4,7 +4,7 @@
 import { setStateWithRef } from '@polkadot-cloud/utils';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
+import { useNetwork } from 'contexts/Network';
 import type {
   TimeLeftAll,
   TimeLeftFormatted,
@@ -15,7 +15,7 @@ import { getDuration } from './utils';
 
 export const useTimeLeft = () => {
   const { t, i18n } = useTranslation();
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   // check whether timeleft is within a minute of finishing.
   const inLastHour = () => {
@@ -107,7 +107,7 @@ export const useTimeLeft = () => {
         setStateWithRef(interval, setMinInterval, minIntervalRef);
       }
     }
-  }, [to, inLastHour(), lastMinuteCountdown(), network]);
+  }, [to, inLastHour(), lastMinuteCountdown(), networkData]);
 
   // re-render the timeleft upon langauge switch.
   useEffect(() => {

--- a/src/library/Hooks/useUnitPrice/index.tsx
+++ b/src/library/Hooks/useUnitPrice/index.tsx
@@ -6,13 +6,11 @@ import { ApiEndpoints } from 'consts';
 import { useNetwork } from 'contexts/Network';
 
 export const useUnitPrice = () => {
-  const {
-    networkData: { name },
-  } = useNetwork();
+  const { network } = useNetwork();
 
   const fetchUnitPrice = async () => {
     const urls = [
-      `${ApiEndpoints.priceChange}${NetworkList[name].api.priceTicker}`,
+      `${ApiEndpoints.priceChange}${NetworkList[network].api.priceTicker}`,
     ];
 
     const responses = await Promise.all(

--- a/src/library/Hooks/useUnitPrice/index.tsx
+++ b/src/library/Hooks/useUnitPrice/index.tsx
@@ -3,14 +3,16 @@
 
 import { NetworkList } from 'config/networks';
 import { ApiEndpoints } from 'consts';
-import { useApi } from 'contexts/Api';
+import { useNetwork } from 'contexts/Network';
 
 export const useUnitPrice = () => {
-  const { network } = useApi();
+  const {
+    networkData: { name },
+  } = useNetwork();
 
   const fetchUnitPrice = async () => {
     const urls = [
-      `${ApiEndpoints.priceChange}${NetworkList[network.name].api.priceTicker}`,
+      `${ApiEndpoints.priceChange}${NetworkList[name].api.priceTicker}`,
     ];
 
     const responses = await Promise.all(

--- a/src/library/Hooks/useUnstaking/index.tsx
+++ b/src/library/Hooks/useUnstaking/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useFastUnstake } from 'contexts/FastUnstake';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import type { AnyJson } from 'types';

--- a/src/library/ListItem/Labels/EraStatus.tsx
+++ b/src/library/ListItem/Labels/EraStatus.tsx
@@ -4,17 +4,17 @@
 import { capitalizeFirstLetter, planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
 import type { MaybeAccount } from 'types';
+import { useNetwork } from 'contexts/Network';
 
 export const EraStatus = ({ address }: { address: MaybeAccount }) => {
   const { t } = useTranslation('library');
   const {
-    network: { unit, units },
-  } = useApi();
+    networkData: { unit, units },
+  } = useNetwork();
   const {
     eraStakers: { stakers },
     erasStakersSyncing,

--- a/src/library/ListItem/Labels/NominationStatus.tsx
+++ b/src/library/ListItem/Labels/NominationStatus.tsx
@@ -4,12 +4,12 @@
 import { greaterThanZero, planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useStaking } from 'contexts/Staking';
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
 import { useNominationStatus } from 'library/Hooks/useNominationStatus';
 import { useConnect } from 'contexts/Connect';
+import { useNetwork } from 'contexts/Network';
 import type { NominationStatusProps } from '../types';
 
 export const NominationStatus = ({
@@ -19,8 +19,8 @@ export const NominationStatus = ({
 }: NominationStatusProps) => {
   const { t } = useTranslation('library');
   const {
-    network: { unit, units },
-  } = useApi();
+    networkData: { unit, units },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { getPoolNominationStatus } = useBondedPools();
   const { getNomineesStatus } = useNominationStatus();

--- a/src/library/ListItem/Labels/Oversubscribed.tsx
+++ b/src/library/ListItem/Labels/Oversubscribed.tsx
@@ -6,18 +6,20 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { MinBondPrecision } from 'consts';
-import { useApi } from 'contexts/Api';
 import { useTooltip } from 'contexts/Tooltip';
 import {
   OverSubscribedWrapper,
   TooltipTrigger,
 } from 'library/ListItem/Wrappers';
 import { useStaking } from 'contexts/Staking';
+import { useNetwork } from 'contexts/Network';
 import type { OversubscribedProps } from '../types';
 
 export const Oversubscribed = ({ address }: OversubscribedProps) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
+  const {
+    networkData: { unit },
+  } = useNetwork();
   const { setTooltipTextAndOpen } = useTooltip();
   const { erasStakersSyncing, getLowestRewardFromStaker } = useStaking();
 
@@ -31,7 +33,7 @@ export const Oversubscribed = ({ address }: OversubscribedProps) => {
 
   const tooltipText = `${t(
     'overSubscribedMinReward'
-  )} ${lowestRewardFormatted} ${network.unit}`;
+  )} ${lowestRewardFormatted} ${unit}`;
 
   return (
     <>
@@ -55,7 +57,7 @@ export const Oversubscribed = ({ address }: OversubscribedProps) => {
                   className="warning"
                 />
               </span>
-              {lowestRewardFormatted} {network.unit}
+              {lowestRewardFormatted} {unit}
             </OverSubscribedWrapper>
           </div>
         </motion.div>

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -9,11 +9,11 @@ import {
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useStaking } from 'contexts/Staking';
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
 import type { Pool } from 'library/Pool/types';
+import { useNetwork } from 'contexts/Network';
 
 export const PoolBonded = ({
   pool,
@@ -25,11 +25,12 @@ export const PoolBonded = ({
   batchIndex: number;
 }) => {
   const { t } = useTranslation('library');
-  const { network } = useApi();
-  const { eraStakers, getNominationsStatusFromTargets } = useStaking();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { meta, getPoolNominationStatusCode } = useBondedPools();
+  const { eraStakers, getNominationsStatusFromTargets } = useStaking();
   const { addresses, points } = pool;
-  const { units, unit } = network;
 
   // get pool targets from nominations meta batch
   const nominations = meta[batchKey]?.nominations ?? [];

--- a/src/library/ListItem/Labels/PoolMemberBonded.tsx
+++ b/src/library/ListItem/Labels/PoolMemberBonded.tsx
@@ -4,12 +4,12 @@
 import { greaterThanZero, planckToUnit, rmCommas } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
+import { useNetwork } from 'contexts/Network';
 
 export const PoolMemberBonded = ({ meta, batchKey, batchIndex }: any) => {
   const { t } = useTranslation('library');
-  const { units, unit } = useApi().network;
+  const { units, unit } = useNetwork().networkData;
 
   const poolMembers = meta[batchKey]?.poolMembers ?? [];
   const poolMember = poolMembers[batchIndex] ?? null;

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -15,7 +15,7 @@ export const NetworkBar = () => {
   const { t } = useTranslation('library');
   const { plugins } = usePlugins();
   const { isLightClient } = useApi();
-  const { networkData } = useNetwork();
+  const { networkData, network } = useNetwork();
   const prices = usePrices();
 
   const PRIVACY_URL = import.meta.env.VITE_PRIVACY_URL;
@@ -24,16 +24,14 @@ export const NetworkBar = () => {
   const LEGAL_DISCLOSURES_URL = import.meta.env.VITE_LEGAL_DISCLOSURES_URL;
 
   const [networkName, setNetworkName] = useState<string>(
-    capitalizeFirstLetter(networkData.name)
+    capitalizeFirstLetter(network)
   );
 
   useEffect(() => {
     setNetworkName(
-      `${capitalizeFirstLetter(networkData.name)}${
-        isLightClient ? ` Light` : ``
-      }`
+      `${capitalizeFirstLetter(network)}${isLightClient ? ` Light` : ``}`
     );
-  }, [networkData.name, isLightClient]);
+  }, [network, isLightClient]);
 
   return (
     <Wrapper>

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -7,13 +7,15 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { usePlugins } from 'contexts/Plugins';
 import { usePrices } from 'library/Hooks/usePrices';
+import { useNetwork } from 'contexts/Network';
 import { Status } from './Status';
 import { Summary, Wrapper } from './Wrappers';
 
 export const NetworkBar = () => {
   const { t } = useTranslation('library');
   const { plugins } = usePlugins();
-  const { network, isLightClient } = useApi();
+  const { isLightClient } = useApi();
+  const { networkData } = useNetwork();
   const prices = usePrices();
 
   const PRIVACY_URL = import.meta.env.VITE_PRIVACY_URL;
@@ -22,18 +24,20 @@ export const NetworkBar = () => {
   const LEGAL_DISCLOSURES_URL = import.meta.env.VITE_LEGAL_DISCLOSURES_URL;
 
   const [networkName, setNetworkName] = useState<string>(
-    capitalizeFirstLetter(network.name)
+    capitalizeFirstLetter(networkData.name)
   );
 
   useEffect(() => {
     setNetworkName(
-      `${capitalizeFirstLetter(network.name)}${isLightClient ? ` Light` : ``}`
+      `${capitalizeFirstLetter(networkData.name)}${
+        isLightClient ? ` Light` : ``
+      }`
     );
-  }, [network.name, isLightClient]);
+  }, [networkData.name, isLightClient]);
 
   return (
     <Wrapper>
-      <network.brand.icon className="network_icon" />
+      <networkData.brand.icon className="network_icon" />
       <Summary>
         <section>
           <p>{ORGANISATION === undefined ? networkName : ORGANISATION}</p>
@@ -88,7 +92,7 @@ export const NetworkBar = () => {
                   </span>
                 </div>
                 <div className="stat">
-                  1 {network.api.unit} / {prices.lastPrice} USD
+                  1 {networkData.api.unit} / {prices.lastPrice} USD
                 </div>
               </>
             )}

--- a/src/library/PoolList/Default.tsx
+++ b/src/library/PoolList/Default.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ListItemsPerBatch, ListItemsPerPage } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useFilters } from 'contexts/Filters';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
@@ -21,6 +21,7 @@ import { MotionContainer } from 'library/List/MotionContainer';
 import { Pagination } from 'library/List/Pagination';
 import { SearchInput } from 'library/List/SearchInput';
 import { Pool } from 'library/Pool';
+import { useNetwork } from 'contexts/Network';
 import { usePoolList } from './context';
 import type { PoolListProps } from './types';
 
@@ -36,10 +37,10 @@ export const PoolList = ({
 }: PoolListProps) => {
   const { t } = useTranslation('library');
   const { mode } = useTheme();
+  const { isReady } = useApi();
   const {
-    isReady,
-    network: { colors },
-  } = useApi();
+    networkData: { colors },
+  } = useNetwork();
   const { isSyncing } = useUi();
   const { applyFilter } = usePoolFilters();
   const { activeEra } = useNetworkMetrics();

--- a/src/library/SideMenu/Main.tsx
+++ b/src/library/SideMenu/Main.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { PageCategories, PagesConfig } from 'config/pages';
 import { PolkadotUrl } from 'consts';
-import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
@@ -16,13 +15,14 @@ import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import type { UIContextInterface } from 'contexts/UI/types';
 import type { PageCategory, PageItem, PagesConfigItems } from 'types';
+import { useNetwork } from 'contexts/Network';
 import { Heading } from './Heading/Heading';
 import { Primary } from './Primary';
 import { LogoWrapper } from './Wrapper';
 
 export const Main = () => {
   const { t, i18n } = useTranslation('base');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount, accounts } = useConnect();
   const { pathname } = useLocation();
   const { getBondedAccount } = useBonded();
@@ -117,7 +117,7 @@ export const Main = () => {
       pages,
     });
   }, [
-    network,
+    networkData,
     activeAccount,
     accounts,
     controllerDifferentToStash,
@@ -141,14 +141,16 @@ export const Main = () => {
         onClick={() => window.open(PolkadotUrl, '_blank')}
       >
         {sideMenuMinimised ? (
-          <network.brand.icon style={{ maxHeight: '100%', width: '2rem' }} />
+          <networkData.brand.icon
+            style={{ maxHeight: '100%', width: '2rem' }}
+          />
         ) : (
           <>
-            <network.brand.logo.svg
+            <networkData.brand.logo.svg
               style={{
                 maxHeight: '100%',
                 height: '100%',
-                width: network.brand.logo.width,
+                width: networkData.brand.logo.width,
               }}
             />
           </>

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -22,6 +22,7 @@ import MoonOutlineSVG from 'img/moon-outline.svg?react';
 import SunnyOutlineSVG from 'img/sunny-outline.svg?react';
 import { useOutsideAlerter } from 'library/Hooks';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { Heading } from './Heading/Heading';
 import { Main } from './Main';
 import { Secondary } from './Secondary';
@@ -29,7 +30,8 @@ import { ConnectionSymbol, Separator, Wrapper } from './Wrapper';
 
 export const SideMenu = () => {
   const { t } = useTranslation('base');
-  const { network, apiStatus } = useApi();
+  const { apiStatus } = useApi();
+  const { networkData } = useNetwork();
   const { mode, toggleTheme } = useTheme();
   const { openModal } = useOverlay().modal;
   const {
@@ -99,11 +101,11 @@ export const SideMenu = () => {
         <Heading title={t('network')} minimised={sideMenuMinimised} />
         <Secondary
           classes={[apiStatusClass]}
-          name={capitalizeFirstLetter(network.name)}
+          name={capitalizeFirstLetter(networkData.name)}
           onClick={() => openModal({ key: 'Networks' })}
           icon={{
-            Svg: network.brand.inline.svg,
-            size: network.brand.inline.size,
+            Svg: networkData.brand.inline.svg,
+            size: networkData.brand.inline.size,
           }}
           minimised={sideMenuMinimised}
           action={

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -31,7 +31,7 @@ import { ConnectionSymbol, Separator, Wrapper } from './Wrapper';
 export const SideMenu = () => {
   const { t } = useTranslation('base');
   const { apiStatus } = useApi();
-  const { networkData } = useNetwork();
+  const { networkData, network } = useNetwork();
   const { mode, toggleTheme } = useTheme();
   const { openModal } = useOverlay().modal;
   const {
@@ -101,7 +101,7 @@ export const SideMenu = () => {
         <Heading title={t('network')} minimised={sideMenuMinimised} />
         <Secondary
           classes={[apiStatusClass]}
-          name={capitalizeFirstLetter(networkData.name)}
+          name={capitalizeFirstLetter(network)}
           onClick={() => openModal({ key: 'Networks' })}
           icon={{
             Svg: networkData.brand.inline.svg,

--- a/src/library/Stat/index.tsx
+++ b/src/library/Stat/index.tsx
@@ -14,7 +14,7 @@ import { applyWidthAsPadding, minDecimalPlaces } from '@polkadot-cloud/utils';
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { useHelp } from 'contexts/Help';
 import { useNotifications } from 'contexts/Notifications';
-import { useApi } from 'contexts/Api';
+import { useNetwork } from 'contexts/Network';
 import { Wrapper } from './Wrapper';
 import type { StatAddress, StatProps } from './types';
 
@@ -30,7 +30,7 @@ export const Stat = ({
 }: StatProps) => {
   const {
     brand: { token: Token },
-  } = useApi().network;
+  } = useNetwork().networkData;
   const { openHelp } = useHelp();
   const { addNotification } = useNotifications();
 

--- a/src/library/SubmitTx/index.tsx
+++ b/src/library/SubmitTx/index.tsx
@@ -4,11 +4,11 @@
 import { Tx } from '@polkadot-cloud/react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { Default } from './Default';
 import { ManualSign } from './ManualSign';
 import type { SubmitTxProps } from './types';
@@ -25,8 +25,8 @@ export const SubmitTx = ({
   fromController = false,
 }: SubmitTxProps) => {
   const { t } = useTranslation();
-  const { unit } = useApi().network;
   const { getBondedAccount } = useBonded();
+  const { unit } = useNetwork().networkData;
   const { setModalResize } = useOverlay().modal;
   const { notEnoughFunds, sender, setTxSignature } = useTxMeta();
   const { requiresManualSign, activeAccount, activeProxy, getAccount } =

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -11,7 +11,7 @@ import { ListItemsPerBatch, ListItemsPerPage } from 'consts';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useFilters } from 'contexts/Filters';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
 import { Header, List, Wrapper as ListWrapper } from 'library/List';
@@ -21,6 +21,7 @@ import { SearchInput } from 'library/List/SearchInput';
 import { Selectable } from 'library/List/Selectable';
 import { Validator } from 'library/ValidatorList/Validator';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { useValidatorFilters } from '../Hooks/useValidatorFilters';
 import { ListProvider, useList } from '../List/context';
 import { Filters } from './Filters';
@@ -47,10 +48,10 @@ export const ValidatorListInner = ({
   disableThrottle = false,
 }: any) => {
   const { t } = useTranslation('library');
+  const { isReady } = useApi();
   const {
-    isReady,
-    network: { colors },
-  } = useApi();
+    networkData: { colors },
+  } = useNetwork();
   const { setModalResize } = useOverlay().modal;
   const provider = useList();
   const { mode } = useTheme();

--- a/src/modals/Accounts/Account.tsx
+++ b/src/modals/Accounts/Account.tsx
@@ -10,9 +10,9 @@ import { useConnect } from 'contexts/Connect';
 import LedgerIconSVG from 'img/ledgerIcon.svg?react';
 import PolkadotVaultIconSVG from 'img/polkadotVault.svg?react';
 import { Polkicon } from '@polkadot-cloud/react';
-import { useApi } from 'contexts/Api';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { AccountWrapper } from './Wrappers';
 import type { AccountItemProps } from './types';
 
@@ -33,7 +33,7 @@ export const AccountButton = ({
     connectToAccount,
   } = useConnect();
   const { setModalStatus } = useOverlay().modal;
-  const { units, unit } = useApi().network;
+  const { units, unit } = useNetwork().networkData;
   const { getTransferOptions } = useTransferOptions();
   const { freeBalance } = getTransferOptions(address || '');
 

--- a/src/modals/BalanceTest/index.tsx
+++ b/src/modals/BalanceTest/index.tsx
@@ -12,14 +12,17 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useEffect } from 'react';
+import { useNetwork } from 'contexts/Network';
 
 export const BalanceTest = () => {
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const {
+    networkData: { units },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { newBatchCall } = useBatchCall();
   const { setModalStatus, setModalResize } = useOverlay().modal;
-  const { units } = network;
 
   // tx to submit
   const getTx = () => {

--- a/src/modals/Bond/index.tsx
+++ b/src/modals/Bond/index.tsx
@@ -19,10 +19,12 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const Bond = () => {
   const { t } = useTranslation('modals');
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { selectedActivePool } = useActivePools();
@@ -33,7 +35,7 @@ export const Bond = () => {
     config: { options },
     setModalResize,
   } = useOverlay().modal;
-  const { units } = network;
+  const { units } = networkData;
   const { bondFor } = options;
   const isStaking = bondFor === 'nominator';
   const isPooling = bondFor === 'pool';
@@ -50,7 +52,7 @@ export const Bond = () => {
   // calculate any unclaimed pool rewards.
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, network.units);
+  pendingRewards = planckToUnit(pendingRewards, networkData.units);
 
   // local bond value.
   const [bond, setBond] = useState<{ bond: string }>({
@@ -147,7 +149,7 @@ export const Bond = () => {
           <ModalWarnings withMargin>
             <Warning
               text={`${t('bondingWithdraw')} ${pendingRewards} ${
-                network.unit
+                networkData.unit
               }.`}
             />
           </ModalWarnings>

--- a/src/modals/Bond/index.tsx
+++ b/src/modals/Bond/index.tsx
@@ -24,7 +24,9 @@ import { useNetwork } from 'contexts/Network';
 export const Bond = () => {
   const { t } = useTranslation('modals');
   const { api } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { selectedActivePool } = useActivePools();
@@ -35,7 +37,7 @@ export const Bond = () => {
     config: { options },
     setModalResize,
   } = useOverlay().modal;
-  const { units } = networkData;
+
   const { bondFor } = options;
   const isStaking = bondFor === 'nominator';
   const isPooling = bondFor === 'pool';
@@ -52,7 +54,7 @@ export const Bond = () => {
   // calculate any unclaimed pool rewards.
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, networkData.units);
+  pendingRewards = planckToUnit(pendingRewards, units);
 
   // local bond value.
   const [bond, setBond] = useState<{ bond: string }>({
@@ -148,9 +150,7 @@ export const Bond = () => {
         {pendingRewards > 0 && bondFor === 'pool' ? (
           <ModalWarnings withMargin>
             <Warning
-              text={`${t('bondingWithdraw')} ${pendingRewards} ${
-                networkData.unit
-              }.`}
+              text={`${t('bondingWithdraw')} ${pendingRewards} ${unit}.`}
             />
           </ModalWarnings>
         ) : null}

--- a/src/modals/ClaimPayouts/Forms.tsx
+++ b/src/modals/ClaimPayouts/Forms.tsx
@@ -30,7 +30,9 @@ export const Forms = forwardRef(
   ({ setSection, payouts, setPayouts }: FormProps, ref: any) => {
     const { t } = useTranslation('modals');
     const { api } = useApi();
-    const { networkData } = useNetwork();
+    const {
+      networkData: { units, unit },
+    } = useNetwork();
     const { activeAccount } = useConnect();
     const { newBatchCall } = useBatchCall();
     const { removeEraPayout } = usePayouts();
@@ -38,7 +40,6 @@ export const Forms = forwardRef(
     const { getSignerWarnings } = useSignerWarnings();
     const { unclaimedPayouts: unclaimedPayoutsSubscan, setUnclaimedPayouts } =
       useSubscan();
-    const { units } = networkData;
 
     const totalPayout =
       payouts?.reduce(
@@ -133,9 +134,10 @@ export const Forms = forwardRef(
             ) : null}
             <div style={{ marginBottom: '2rem' }}>
               <ActionItem
-                text={`${t('claim')} ${planckToUnit(totalPayout, units)} ${
-                  networkData.unit
-                }`}
+                text={`${t('claim')} ${planckToUnit(
+                  totalPayout,
+                  units
+                )} ${unit}`}
               />
               <p>{t('afterClaiming')}</p>
             </div>

--- a/src/modals/ClaimPayouts/Forms.tsx
+++ b/src/modals/ClaimPayouts/Forms.tsx
@@ -22,13 +22,15 @@ import { useBatchCall } from 'library/Hooks/useBatchCall';
 import type { AnyApi, AnySubscan } from 'types';
 import { useSubscan } from 'contexts/Plugins/Subscan';
 import { usePayouts } from 'contexts/Payouts';
+import { useNetwork } from 'contexts/Network';
 import type { FormProps, ActivePayout } from './types';
 import { ContentWrapper } from './Wrappers';
 
 export const Forms = forwardRef(
   ({ setSection, payouts, setPayouts }: FormProps, ref: any) => {
     const { t } = useTranslation('modals');
-    const { api, network } = useApi();
+    const { api } = useApi();
+    const { networkData } = useNetwork();
     const { activeAccount } = useConnect();
     const { newBatchCall } = useBatchCall();
     const { removeEraPayout } = usePayouts();
@@ -36,7 +38,7 @@ export const Forms = forwardRef(
     const { getSignerWarnings } = useSignerWarnings();
     const { unclaimedPayouts: unclaimedPayoutsSubscan, setUnclaimedPayouts } =
       useSubscan();
-    const { units } = network;
+    const { units } = networkData;
 
     const totalPayout =
       payouts?.reduce(
@@ -132,7 +134,7 @@ export const Forms = forwardRef(
             <div style={{ marginBottom: '2rem' }}>
               <ActionItem
                 text={`${t('claim')} ${planckToUnit(totalPayout, units)} ${
-                  network.unit
+                  networkData.unit
                 }`}
               />
               <p>{t('afterClaiming')}</p>

--- a/src/modals/ClaimPayouts/Item.tsx
+++ b/src/modals/ClaimPayouts/Item.tsx
@@ -3,9 +3,9 @@
 
 import { ButtonSubmit } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import BigNumber from 'bignumber.js';
 import { planckToUnit } from '@polkadot-cloud/utils';
+import { useNetwork } from 'contexts/Network';
 import { ItemWrapper } from './Wrappers';
 import type { ItemProps } from './types';
 
@@ -16,7 +16,7 @@ export const Item = ({
   setSection,
 }: ItemProps) => {
   const { t } = useTranslation('modals');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   const totalPayout = Object.values(unclaimedPayout).reduce(
     (acc: BigNumber, cur: string) => acc.plus(cur),
@@ -38,7 +38,8 @@ export const Item = ({
             </span>
           </h4>
           <h2>
-            {planckToUnit(totalPayout, network.units).toString()} {network.unit}
+            {planckToUnit(totalPayout, networkData.units).toString()}{' '}
+            {networkData.unit}
           </h2>
         </section>
 

--- a/src/modals/ClaimPayouts/Item.tsx
+++ b/src/modals/ClaimPayouts/Item.tsx
@@ -16,7 +16,9 @@ export const Item = ({
   setSection,
 }: ItemProps) => {
   const { t } = useTranslation('modals');
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
 
   const totalPayout = Object.values(unclaimedPayout).reduce(
     (acc: BigNumber, cur: string) => acc.plus(cur),
@@ -38,8 +40,7 @@ export const Item = ({
             </span>
           </h4>
           <h2>
-            {planckToUnit(totalPayout, networkData.units).toString()}{' '}
-            {networkData.unit}
+            {planckToUnit(totalPayout, units).toString()} {unit}
           </h2>
         </section>
 

--- a/src/modals/ClaimReward/index.tsx
+++ b/src/modals/ClaimReward/index.tsx
@@ -16,10 +16,14 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ClaimReward = () => {
   const { t } = useTranslation('modals');
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { selectedActivePool } = useActivePools();
@@ -30,7 +34,6 @@ export const ClaimReward = () => {
     setModalResize,
   } = useOverlay().modal;
 
-  const { units, unit } = network;
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
   const { claimType } = options;

--- a/src/modals/Connect/Ledger.tsx
+++ b/src/modals/Connect/Ledger.tsx
@@ -16,15 +16,15 @@ import {
 } from '@polkadot-cloud/react';
 import { inChrome } from '@polkadot-cloud/utils';
 import React from 'react';
-import { useApi } from 'contexts/Api';
 import { useHelp } from 'contexts/Help';
 import LedgerLogoSVG from 'img/ledgerLogo.svg?react';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const Ledger = (): React.ReactElement => {
   const { openHelp } = useHelp();
   const { replaceModal } = useOverlay().modal;
-  const { name } = useApi().network;
+  const { name } = useNetwork().networkData;
   const url = 'ledger.com';
 
   // Only render on Polkadot and Kusama networks.

--- a/src/modals/Connect/Ledger.tsx
+++ b/src/modals/Connect/Ledger.tsx
@@ -24,11 +24,11 @@ import { useNetwork } from 'contexts/Network';
 export const Ledger = (): React.ReactElement => {
   const { openHelp } = useHelp();
   const { replaceModal } = useOverlay().modal;
-  const { name } = useNetwork().networkData;
+  const { network } = useNetwork();
   const url = 'ledger.com';
 
   // Only render on Polkadot and Kusama networks.
-  if (!['polkadot', 'kusama'].includes(name)) {
+  if (!['polkadot', 'kusama'].includes(network)) {
     return <></>;
   }
 
@@ -44,10 +44,12 @@ export const Ledger = (): React.ReactElement => {
           </div>
           <div className="row margin">
             <ButtonText
-              text={name === 'polkadot' ? 'BETA' : 'EXPERIMENTAL'}
+              text={network === 'polkadot' ? 'BETA' : 'EXPERIMENTAL'}
               disabled
               marginRight
-              iconLeft={name === 'polkadot' ? undefined : faExclamationTriangle}
+              iconLeft={
+                network === 'polkadot' ? undefined : faExclamationTriangle
+              }
               style={{ opacity: 0.5 }}
             />
             <ButtonText

--- a/src/modals/ImportLedger/Addresses.tsx
+++ b/src/modals/ImportLedger/Addresses.tsx
@@ -5,7 +5,6 @@ import { faArrowDown } from '@fortawesome/free-solid-svg-icons';
 import { ButtonText, HardwareAddress, Polkicon } from '@polkadot-cloud/react';
 import { ellipsisFn, unescape } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useLedgerHardware } from 'contexts/Hardware/Ledger';
 import { getLocalLedgerAddresses } from 'contexts/Hardware/Utils';
@@ -14,10 +13,11 @@ import { Confirm } from 'library/Import/Confirm';
 import { Remove } from 'library/Import/Remove';
 import { AddressesWrapper } from 'library/Import/Wrappers';
 import type { AnyJson } from 'types';
+import { useNetwork } from 'contexts/Network';
 
 export const Addresess = ({ addresses, handleLedgerLoop }: AnyJson) => {
   const { t } = useTranslation('modals');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   const {
     getIsExecuting,
@@ -63,7 +63,7 @@ export const Addresess = ({ addresses, handleLedgerLoop }: AnyJson) => {
           {addresses.map(({ address, index }: AnyJson, i: number) => {
             const initialName = (() => {
               const localAddress = getLocalLedgerAddresses().find(
-                (a) => a.address === address && a.network === network.name
+                (a) => a.address === address && a.network === networkData.name
               );
               return localAddress?.name
                 ? unescape(localAddress.name)

--- a/src/modals/ImportLedger/Addresses.tsx
+++ b/src/modals/ImportLedger/Addresses.tsx
@@ -17,7 +17,7 @@ import { useNetwork } from 'contexts/Network';
 
 export const Addresess = ({ addresses, handleLedgerLoop }: AnyJson) => {
   const { t } = useTranslation('modals');
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   const {
     getIsExecuting,
@@ -63,7 +63,7 @@ export const Addresess = ({ addresses, handleLedgerLoop }: AnyJson) => {
           {addresses.map(({ address, index }: AnyJson, i: number) => {
             const initialName = (() => {
               const localAddress = getLocalLedgerAddresses().find(
-                (a) => a.address === address && a.network === networkData.name
+                (a) => a.address === address && a.network === network
               );
               return localAddress?.name
                 ? unescape(localAddress.name)

--- a/src/modals/ImportLedger/Manage.tsx
+++ b/src/modals/ImportLedger/Manage.tsx
@@ -21,14 +21,14 @@ export const Manage = ({
   removeLedgerAddress,
 }: AnyJson) => {
   const { t } = useTranslation();
-  const { name } = useNetwork().networkData;
+  const { network } = useNetwork();
   const { setIsExecuting, getIsExecuting, resetStatusCodes, getFeedback } =
     useLedgerHardware();
   const { openPromptWith } = usePrompt();
   const { replaceModal } = useOverlay().modal;
   const { openHelp } = useHelp();
 
-  const { appName, Icon } = getLedgerApp(name);
+  const { appName, Icon } = getLedgerApp(network);
   const isExecuting = getIsExecuting();
 
   const fallbackMessage = `${t('ledgerAccounts', {

--- a/src/modals/ImportLedger/Manage.tsx
+++ b/src/modals/ImportLedger/Manage.tsx
@@ -3,7 +3,6 @@
 
 import { HardwareStatusBar } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useLedgerHardware } from 'contexts/Hardware/Ledger';
 import { getLedgerApp } from 'contexts/Hardware/Utils';
 import { useHelp } from 'contexts/Help';
@@ -12,6 +11,7 @@ import StatusBarSVG from 'img/ledgerIcon.svg?react';
 import { Heading } from 'library/Import/Heading';
 import type { AnyJson } from 'types';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { Addresess } from './Addresses';
 import { Reset } from './Reset';
 
@@ -21,7 +21,7 @@ export const Manage = ({
   removeLedgerAddress,
 }: AnyJson) => {
   const { t } = useTranslation();
-  const { name } = useApi().network;
+  const { name } = useNetwork().networkData;
   const { setIsExecuting, getIsExecuting, resetStatusCodes, getFeedback } =
     useLedgerHardware();
   const { openPromptWith } = usePrompt();

--- a/src/modals/ImportLedger/index.tsx
+++ b/src/modals/ImportLedger/index.tsx
@@ -3,18 +3,18 @@
 
 import { ellipsisFn, setStateWithRef } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
-import { useApi } from 'contexts/Api';
 import { useLedgerHardware } from 'contexts/Hardware/Ledger';
 import { getLocalLedgerAddresses } from 'contexts/Hardware/Utils';
 import type { LedgerAddress, LedgerResponse } from 'contexts/Hardware/types';
 import { useLedgerLoop } from 'library/Hooks/useLedgerLoop';
 import type { AnyJson } from 'types';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { Manage } from './Manage';
 import { Splash } from './Splash';
 
 export const ImportLedger: React.FC = () => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { setModalResize } = useOverlay().modal;
   const {
     transportResponse,
@@ -51,7 +51,7 @@ export const ImportLedger: React.FC = () => {
 
   // Store addresses retreived from Ledger device. Defaults to local addresses.
   const [addresses, setAddresses] = useState<LedgerAddress[]>(
-    getLocalLedgerAddresses(network.name)
+    getLocalLedgerAddresses(networkData.name)
   );
   const addressesRef = useRef(addresses);
 
@@ -62,7 +62,7 @@ export const ImportLedger: React.FC = () => {
       if (a.address !== address) {
         return true;
       }
-      if (a.network !== network.name) {
+      if (a.network !== networkData.name) {
         return true;
       }
       return false;
@@ -77,7 +77,7 @@ export const ImportLedger: React.FC = () => {
     }
     setStateWithRef(
       newLedgerAddresses.filter(
-        (a: LedgerAddress) => a.network === network.name
+        (a: LedgerAddress) => a.network === networkData.name
       ),
       setAddresses,
       addressesRef
@@ -87,11 +87,11 @@ export const ImportLedger: React.FC = () => {
   // refresh imported ledger accounts on network change.
   useEffect(() => {
     setStateWithRef(
-      getLocalLedgerAddresses(network.name),
+      getLocalLedgerAddresses(networkData.name),
       setAddresses,
       addressesRef
     );
-  }, [network]);
+  }, [networkData]);
 
   // Handle new Ledger status report.
   const handleLedgerStatusResponse = (response: LedgerResponse) => {
@@ -106,7 +106,7 @@ export const ImportLedger: React.FC = () => {
         pubKey,
         address,
         name: ellipsisFn(address),
-        network: network.name,
+        network: networkData.name,
       }));
 
       // update the full list of local ledger addresses with new entry.
@@ -115,7 +115,7 @@ export const ImportLedger: React.FC = () => {
           if (a.address !== newAddress.address) {
             return true;
           }
-          if (a.network !== network.name) {
+          if (a.network !== networkData.name) {
             return true;
           }
           return false;
@@ -127,7 +127,7 @@ export const ImportLedger: React.FC = () => {
 
       // store only those accounts on the current network in state.
       setStateWithRef(
-        newAddresses.filter((a) => a.network === network.name),
+        newAddresses.filter((a) => a.network === networkData.name),
         setAddresses,
         addressesRef
       );

--- a/src/modals/ImportLedger/index.tsx
+++ b/src/modals/ImportLedger/index.tsx
@@ -14,7 +14,7 @@ import { Manage } from './Manage';
 import { Splash } from './Splash';
 
 export const ImportLedger: React.FC = () => {
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { setModalResize } = useOverlay().modal;
   const {
     transportResponse,
@@ -51,7 +51,7 @@ export const ImportLedger: React.FC = () => {
 
   // Store addresses retreived from Ledger device. Defaults to local addresses.
   const [addresses, setAddresses] = useState<LedgerAddress[]>(
-    getLocalLedgerAddresses(networkData.name)
+    getLocalLedgerAddresses(network)
   );
   const addressesRef = useRef(addresses);
 
@@ -62,7 +62,7 @@ export const ImportLedger: React.FC = () => {
       if (a.address !== address) {
         return true;
       }
-      if (a.network !== networkData.name) {
+      if (a.network !== network) {
         return true;
       }
       return false;
@@ -76,9 +76,7 @@ export const ImportLedger: React.FC = () => {
       );
     }
     setStateWithRef(
-      newLedgerAddresses.filter(
-        (a: LedgerAddress) => a.network === networkData.name
-      ),
+      newLedgerAddresses.filter((a: LedgerAddress) => a.network === network),
       setAddresses,
       addressesRef
     );
@@ -87,11 +85,11 @@ export const ImportLedger: React.FC = () => {
   // refresh imported ledger accounts on network change.
   useEffect(() => {
     setStateWithRef(
-      getLocalLedgerAddresses(networkData.name),
+      getLocalLedgerAddresses(network),
       setAddresses,
       addressesRef
     );
-  }, [networkData]);
+  }, [network]);
 
   // Handle new Ledger status report.
   const handleLedgerStatusResponse = (response: LedgerResponse) => {
@@ -106,7 +104,7 @@ export const ImportLedger: React.FC = () => {
         pubKey,
         address,
         name: ellipsisFn(address),
-        network: networkData.name,
+        network,
       }));
 
       // update the full list of local ledger addresses with new entry.
@@ -115,7 +113,7 @@ export const ImportLedger: React.FC = () => {
           if (a.address !== newAddress.address) {
             return true;
           }
-          if (a.network !== networkData.name) {
+          if (a.network !== network) {
             return true;
           }
           return false;
@@ -127,7 +125,7 @@ export const ImportLedger: React.FC = () => {
 
       // store only those accounts on the current network in state.
       setStateWithRef(
-        newAddresses.filter((a) => a.network === networkData.name),
+        newAddresses.filter((a) => a.network === network),
         setAddresses,
         addressesRef
       );

--- a/src/modals/JoinPool/index.tsx
+++ b/src/modals/JoinPool/index.tsx
@@ -23,10 +23,14 @@ import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const JoinPool = () => {
   const { t } = useTranslation('modals');
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const {
+    networkData: { units },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { newBatchCall } = useBatchCall();
   const { setActiveAccountSetup } = useSetup();
@@ -41,7 +45,6 @@ export const JoinPool = () => {
   } = useOverlay().modal;
 
   const { id: poolId, setActiveTab } = options;
-  const { units } = network;
 
   const { totalPossibleBond, totalAdditionalBond } =
     getTransferOptions(activeAccount).pool;

--- a/src/modals/ManageFastUnstake/index.tsx
+++ b/src/modals/ManageFastUnstake/index.tsx
@@ -15,7 +15,7 @@ import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useFastUnstake } from 'contexts/FastUnstake';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { Warning } from 'library/Form/Warning';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
@@ -25,13 +25,15 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ManageFastUnstake = () => {
   const { t } = useTranslation('modals');
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
-  const { api, consts, network } = useApi();
   const { isFastUnstaking } = useUnstaking();
   const { setModalResize, setModalStatus } = useOverlay().modal;
   const { getSignerWarnings } = useSignerWarnings();
@@ -114,8 +116,8 @@ export const ManageFastUnstake = () => {
       warnings.push(
         `${t('noEnough')} ${planckToUnit(
           fastUnstakeDeposit,
-          network.units
-        ).toString()} ${network.unit}`
+          networkData.units
+        ).toString()} ${networkData.unit}`
       );
     }
 
@@ -179,9 +181,9 @@ export const ManageFastUnstake = () => {
                       {t('registerFastUnstake')}{' '}
                       {planckToUnit(
                         fastUnstakeDeposit,
-                        network.units
+                        networkData.units
                       ).toString()}{' '}
-                      {network.unit}. {t('fastUnstakeOnceRegistered')}
+                      {networkData.unit}. {t('fastUnstakeOnceRegistered')}
                     </>
                   </p>
                   <p>

--- a/src/modals/ManageFastUnstake/index.tsx
+++ b/src/modals/ManageFastUnstake/index.tsx
@@ -30,7 +30,9 @@ import { useNetwork } from 'contexts/Network';
 export const ManageFastUnstake = () => {
   const { t } = useTranslation('modals');
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
@@ -116,8 +118,8 @@ export const ManageFastUnstake = () => {
       warnings.push(
         `${t('noEnough')} ${planckToUnit(
           fastUnstakeDeposit,
-          networkData.units
-        ).toString()} ${networkData.unit}`
+          units
+        ).toString()} ${unit}`
       );
     }
 
@@ -179,11 +181,8 @@ export const ManageFastUnstake = () => {
                   <p>
                     <>
                       {t('registerFastUnstake')}{' '}
-                      {planckToUnit(
-                        fastUnstakeDeposit,
-                        networkData.units
-                      ).toString()}{' '}
-                      {networkData.unit}. {t('fastUnstakeOnceRegistered')}
+                      {planckToUnit(fastUnstakeDeposit, units).toString()}{' '}
+                      {unit}. {t('fastUnstakeOnceRegistered')}
                     </>
                   </p>
                   <p>

--- a/src/modals/ManagePool/Forms/ClaimCommission.tsx
+++ b/src/modals/ManagePool/Forms/ClaimCommission.tsx
@@ -20,10 +20,12 @@ import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { SubmitTx } from 'library/SubmitTx';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ClaimCommission = ({ setSection }: any) => {
   const { t } = useTranslation('modals');
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const { networkData } = useNetwork();
   const { setModalStatus } = useOverlay().modal;
   const { activeAccount } = useConnect();
   const { isOwner, selectedActivePool } = useActivePools();
@@ -77,8 +79,8 @@ export const ClaimCommission = ({ setSection }: any) => {
         <ActionItem
           text={`${t('claim')} ${planckToUnit(
             pendingCommission,
-            network.units
-          )} ${network.unit} `}
+            networkData.units
+          )} ${networkData.unit} `}
         />
         <ModalNotes>
           <p>{t('sentToCommissionPayee')}</p>

--- a/src/modals/ManagePool/Forms/ClaimCommission.tsx
+++ b/src/modals/ManagePool/Forms/ClaimCommission.tsx
@@ -25,7 +25,9 @@ import { useNetwork } from 'contexts/Network';
 export const ClaimCommission = ({ setSection }: any) => {
   const { t } = useTranslation('modals');
   const { api } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { setModalStatus } = useOverlay().modal;
   const { activeAccount } = useConnect();
   const { isOwner, selectedActivePool } = useActivePools();
@@ -79,8 +81,8 @@ export const ClaimCommission = ({ setSection }: any) => {
         <ActionItem
           text={`${t('claim')} ${planckToUnit(
             pendingCommission,
-            networkData.units
-          )} ${networkData.unit} `}
+            units
+          )} ${unit} `}
         />
         <ModalNotes>
           <p>{t('sentToCommissionPayee')}</p>

--- a/src/modals/ManagePool/Forms/LeavePool.tsx
+++ b/src/modals/ManagePool/Forms/LeavePool.tsx
@@ -28,12 +28,14 @@ import { timeleftAsString } from 'library/Hooks/useTimeLeft/utils';
 import { SubmitTx } from 'library/SubmitTx';
 import { StaticNote } from 'modals/Utils/StaticNote';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const LeavePool = ({ setSection }: any) => {
   const { t } = useTranslation('modals');
-  const { api, network, consts } = useApi();
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
-  const { units } = network;
+  const { units } = networkData;
   const { setModalStatus, setModalResize } = useOverlay().modal;
   const { getTransferOptions } = useTransferOptions();
   const { selectedActivePool } = useActivePools();
@@ -53,7 +55,7 @@ export const LeavePool = ({ setSection }: any) => {
 
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, network.units);
+  pendingRewards = planckToUnit(pendingRewards, networkData.units);
 
   // convert BigNumber values to number
   const freeToUnbond = planckToUnit(activeBn, units);
@@ -109,7 +111,9 @@ export const LeavePool = ({ setSection }: any) => {
 
   if (greaterThanZero(pendingRewards)) {
     warnings.push(
-      `${t('unbondingWithdraw')} ${pendingRewards.toString()} ${network.unit}.`
+      `${t('unbondingWithdraw')} ${pendingRewards.toString()} ${
+        networkData.unit
+      }.`
     );
   }
 
@@ -123,7 +127,9 @@ export const LeavePool = ({ setSection }: any) => {
             ))}
           </ModalWarnings>
         ) : null}
-        <ActionItem text={`${t('unbond')} ${freeToUnbond} ${network.unit}`} />
+        <ActionItem
+          text={`${t('unbond')} ${freeToUnbond} ${networkData.unit}`}
+        />
         <StaticNote
           value={bondDurationFormatted}
           tKey="onceUnbonding"

--- a/src/modals/ManagePool/Forms/LeavePool.tsx
+++ b/src/modals/ManagePool/Forms/LeavePool.tsx
@@ -33,9 +33,10 @@ import { useNetwork } from 'contexts/Network';
 export const LeavePool = ({ setSection }: any) => {
   const { t } = useTranslation('modals');
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
-  const { units } = networkData;
   const { setModalStatus, setModalResize } = useOverlay().modal;
   const { getTransferOptions } = useTransferOptions();
   const { selectedActivePool } = useActivePools();
@@ -55,7 +56,7 @@ export const LeavePool = ({ setSection }: any) => {
 
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, networkData.units);
+  pendingRewards = planckToUnit(pendingRewards, units);
 
   // convert BigNumber values to number
   const freeToUnbond = planckToUnit(activeBn, units);
@@ -111,9 +112,7 @@ export const LeavePool = ({ setSection }: any) => {
 
   if (greaterThanZero(pendingRewards)) {
     warnings.push(
-      `${t('unbondingWithdraw')} ${pendingRewards.toString()} ${
-        networkData.unit
-      }.`
+      `${t('unbondingWithdraw')} ${pendingRewards.toString()} ${unit}.`
     );
   }
 
@@ -127,9 +126,7 @@ export const LeavePool = ({ setSection }: any) => {
             ))}
           </ModalWarnings>
         ) : null}
-        <ActionItem
-          text={`${t('unbond')} ${freeToUnbond} ${networkData.unit}`}
-        />
+        <ActionItem text={`${t('unbond')} ${freeToUnbond} ${unit}`} />
         <StaticNote
           value={bondDurationFormatted}
           tKey="onceUnbonding"

--- a/src/modals/Networks/index.tsx
+++ b/src/modals/Networks/index.tsx
@@ -24,10 +24,10 @@ import {
 
 export const Networks = () => {
   const { t } = useTranslation('modals');
-  const { setModalStatus, setModalResize } = useOverlay().modal;
+  const { network, switchNetwork } = useNetwork();
   const { isLightClient, setIsLightClient } = useApi();
-  const { networkData, switchNetwork } = useNetwork();
-  const networkKey: string = networkData.name;
+  const { setModalStatus, setModalResize } = useOverlay().modal;
+  const networkKey: string = network;
 
   const [braveBrowser, setBraveBrowser] = useState<boolean>(false);
 

--- a/src/modals/Networks/index.tsx
+++ b/src/modals/Networks/index.tsx
@@ -12,6 +12,7 @@ import { useApi } from 'contexts/Api';
 import { Title } from 'library/Modal/Title';
 import type { AnyJson, NetworkName } from 'types';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import BraveIconSVG from '../../img/brave-logo.svg?react';
 import {
   BraveWarning,
@@ -24,8 +25,9 @@ import {
 export const Networks = () => {
   const { t } = useTranslation('modals');
   const { setModalStatus, setModalResize } = useOverlay().modal;
-  const { switchNetwork, network, isLightClient } = useApi();
-  const networkKey: string = network.name;
+  const { isLightClient, setIsLightClient } = useApi();
+  const { networkData, switchNetwork } = useNetwork();
+  const networkKey: string = networkData.name;
 
   const [braveBrowser, setBraveBrowser] = useState<boolean>(false);
 
@@ -58,7 +60,7 @@ export const Networks = () => {
                     type="button"
                     onClick={() => {
                       if (networkKey !== key) {
-                        switchNetwork(key, isLightClient);
+                        switchNetwork(key);
                         setModalStatus('closing');
                       }
                     }}
@@ -91,7 +93,8 @@ export const Networks = () => {
               disabled={!isLightClient}
               type="button"
               onClick={() => {
-                switchNetwork(networkKey as NetworkName, false);
+                setIsLightClient(false);
+                switchNetwork(networkKey as NetworkName);
                 setModalStatus('closing');
               }}
             >
@@ -103,7 +106,8 @@ export const Networks = () => {
               className="off"
               type="button"
               onClick={() => {
-                switchNetwork(networkKey as NetworkName, true);
+                setIsLightClient(true);
+                switchNetwork(networkKey as NetworkName);
                 setModalStatus('closing');
               }}
             >

--- a/src/modals/Nominate/index.tsx
+++ b/src/modals/Nominate/index.tsx
@@ -17,10 +17,14 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const Nominate = () => {
   const { t } = useTranslation('modals');
-  const { api, network } = useApi();
+  const { api } = useApi();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
@@ -29,7 +33,6 @@ export const Nominate = () => {
   const { getSignerWarnings } = useSignerWarnings();
   const { setModalStatus, setModalResize } = useOverlay().modal;
 
-  const { units, unit } = network;
   const { minNominatorBond } = staking;
   const controller = getBondedAccount(activeAccount);
   const { nominations } = targets;

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -36,7 +36,9 @@ export const Unbond = () => {
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
   const { getTransferOptions } = useTransferOptions();
@@ -47,7 +49,6 @@ export const Unbond = () => {
     config: { options },
   } = useOverlay().modal;
 
-  const { units } = networkData;
   const { bondFor } = options;
   const controller = getBondedAccount(activeAccount);
   const { minNominatorBond: minNominatorBondBn } = staking;
@@ -63,7 +64,7 @@ export const Unbond = () => {
 
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, networkData.units);
+  pendingRewards = planckToUnit(pendingRewards, units);
 
   const isStaking = bondFor === 'nominator';
   const isPooling = bondFor === 'pool';
@@ -150,15 +151,13 @@ export const Unbond = () => {
   );
 
   if (pendingRewards > 0 && bondFor === 'pool') {
-    warnings.push(
-      `${t('unbondingWithdraw')} ${pendingRewards} ${networkData.unit}.`
-    );
+    warnings.push(`${t('unbondingWithdraw')} ${pendingRewards} ${unit}.`);
   }
   if (nominatorActiveBelowMin) {
     warnings.push(
       t('unbondErrorBelowMinimum', {
         bond: minNominatorBond,
-        unit: networkData.unit,
+        unit,
       })
     );
   }
@@ -166,12 +165,12 @@ export const Unbond = () => {
     warnings.push(
       t('unbondErrorBelowMinimum', {
         bond: planckToUnit(poolToMinBn, units),
-        unit: networkData.unit,
+        unit,
       })
     );
   }
   if (activeBn.isZero()) {
-    warnings.push(t('unbondErrorNoFunds', { unit: networkData.unit }));
+    warnings.push(t('unbondErrorNoFunds', { unit }));
   }
 
   // modal resize on form update
@@ -214,7 +213,7 @@ export const Unbond = () => {
                   {t('notePoolDepositorMinBond', {
                     context: 'depositor',
                     bond: minCreateBond,
-                    unit: networkData.unit,
+                    unit,
                   })}
                 </p>
               ) : (
@@ -222,7 +221,7 @@ export const Unbond = () => {
                   {t('notePoolDepositorMinBond', {
                     context: 'member',
                     bond: minJoinBond,
-                    unit: networkData.unit,
+                    unit,
                   })}
                 </p>
               )}

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -25,6 +25,7 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { StaticNote } from 'modals/Utils/StaticNote';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const Unbond = () => {
   const { t } = useTranslation('modals');
@@ -34,7 +35,8 @@ export const Unbond = () => {
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
-  const { api, network, consts } = useApi();
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
   const { getTransferOptions } = useTransferOptions();
@@ -45,7 +47,7 @@ export const Unbond = () => {
     config: { options },
   } = useOverlay().modal;
 
-  const { units } = network;
+  const { units } = networkData;
   const { bondFor } = options;
   const controller = getBondedAccount(activeAccount);
   const { minNominatorBond: minNominatorBondBn } = staking;
@@ -61,7 +63,7 @@ export const Unbond = () => {
 
   let { pendingRewards } = selectedActivePool || {};
   pendingRewards = pendingRewards ?? new BigNumber(0);
-  pendingRewards = planckToUnit(pendingRewards, network.units);
+  pendingRewards = planckToUnit(pendingRewards, networkData.units);
 
   const isStaking = bondFor === 'nominator';
   const isPooling = bondFor === 'pool';
@@ -149,14 +151,14 @@ export const Unbond = () => {
 
   if (pendingRewards > 0 && bondFor === 'pool') {
     warnings.push(
-      `${t('unbondingWithdraw')} ${pendingRewards} ${network.unit}.`
+      `${t('unbondingWithdraw')} ${pendingRewards} ${networkData.unit}.`
     );
   }
   if (nominatorActiveBelowMin) {
     warnings.push(
       t('unbondErrorBelowMinimum', {
         bond: minNominatorBond,
-        unit: network.unit,
+        unit: networkData.unit,
       })
     );
   }
@@ -164,12 +166,12 @@ export const Unbond = () => {
     warnings.push(
       t('unbondErrorBelowMinimum', {
         bond: planckToUnit(poolToMinBn, units),
-        unit: network.unit,
+        unit: networkData.unit,
       })
     );
   }
   if (activeBn.isZero()) {
-    warnings.push(t('unbondErrorNoFunds', { unit: network.unit }));
+    warnings.push(t('unbondErrorNoFunds', { unit: networkData.unit }));
   }
 
   // modal resize on form update
@@ -212,7 +214,7 @@ export const Unbond = () => {
                   {t('notePoolDepositorMinBond', {
                     context: 'depositor',
                     bond: minCreateBond,
-                    unit: network.unit,
+                    unit: networkData.unit,
                   })}
                 </p>
               ) : (
@@ -220,7 +222,7 @@ export const Unbond = () => {
                   {t('notePoolDepositorMinBond', {
                     context: 'member',
                     bond: minJoinBond,
-                    unit: network.unit,
+                    unit: networkData.unit,
                   })}
                 </p>
               )}

--- a/src/modals/UnbondPoolMember/index.tsx
+++ b/src/modals/UnbondPoolMember/index.tsx
@@ -29,7 +29,9 @@ import { useNetwork } from 'contexts/Network';
 export const UnbondPoolMember = () => {
   const { t } = useTranslation('modals');
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
   const { erasToSeconds } = useErasToTimeLeft();
@@ -40,7 +42,6 @@ export const UnbondPoolMember = () => {
     config: { options },
   } = useOverlay().modal;
 
-  const { units } = networkData;
   const { bondDuration } = consts;
   const { member, who } = options;
   const { points } = member;
@@ -113,9 +114,7 @@ export const UnbondPoolMember = () => {
             ))}
           </ModalWarnings>
         ) : null}
-        <ActionItem
-          text={`${t('unbond')} ${freeToUnbond} ${networkData.unit}`}
-        />
+        <ActionItem text={`${t('unbond')} ${freeToUnbond} ${unit}`} />
         <StaticNote
           value={bondDurationFormatted}
           tKey="onceUnbonding"

--- a/src/modals/UnbondPoolMember/index.tsx
+++ b/src/modals/UnbondPoolMember/index.tsx
@@ -24,12 +24,14 @@ import { SubmitTx } from 'library/SubmitTx';
 import { StaticNote } from 'modals/Utils/StaticNote';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const UnbondPoolMember = () => {
   const { t } = useTranslation('modals');
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { notEnoughFunds } = useTxMeta();
-  const { api, network, consts } = useApi();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
   const {
@@ -38,7 +40,7 @@ export const UnbondPoolMember = () => {
     config: { options },
   } = useOverlay().modal;
 
-  const { units } = network;
+  const { units } = networkData;
   const { bondDuration } = consts;
   const { member, who } = options;
   const { points } = member;
@@ -111,7 +113,9 @@ export const UnbondPoolMember = () => {
             ))}
           </ModalWarnings>
         ) : null}
-        <ActionItem text={`${t('unbond')} ${freeToUnbond} ${network.unit}`} />
+        <ActionItem
+          text={`${t('unbond')} ${freeToUnbond} ${networkData.unit}`}
+        />
         <StaticNote
           value={bondDurationFormatted}
           tKey="onceUnbonding"

--- a/src/modals/UnlockChunks/Chunk.tsx
+++ b/src/modals/UnlockChunks/Chunk.tsx
@@ -7,25 +7,25 @@ import BigNumber from 'bignumber.js';
 import { fromUnixTime } from 'date-fns';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { Countdown } from 'library/Countdown';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
 import { useTimeLeft } from 'library/Hooks/useTimeLeft';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
+import { useNetwork } from 'contexts/Network';
 import { ChunkWrapper } from './Wrappers';
 
 export const Chunk = ({ chunk, bondFor, onRebond }: any) => {
   const { t } = useTranslation('modals');
 
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
-  const { units } = network;
   const { isFastUnstaking } = useUnstaking();
   const { erasToSeconds } = useErasToTimeLeft();
   const { timeleft, setFromNow } = useTimeLeft();
+  const { units } = networkData;
   const isStaking = bondFor === 'nominator';
 
   const { era, value } = chunk;
@@ -39,13 +39,13 @@ export const Chunk = ({ chunk, bondFor, onRebond }: any) => {
   // reset timer on account or network change.
   useEffect(() => {
     setFromNow(dateFrom, dateTo);
-  }, [activeAccount, network]);
+  }, [activeAccount, networkData]);
 
   return (
     <ChunkWrapper>
       <div>
         <section>
-          <h2>{`${planckToUnit(value, units)} ${network.unit}`}</h2>
+          <h2>{`${planckToUnit(value, units)} ${networkData.unit}`}</h2>
           <h4>
             {left.isLessThanOrEqualTo(0) ? (
               t('unlocked')

--- a/src/modals/UnlockChunks/Chunk.tsx
+++ b/src/modals/UnlockChunks/Chunk.tsx
@@ -19,13 +19,15 @@ import { ChunkWrapper } from './Wrappers';
 export const Chunk = ({ chunk, bondFor, onRebond }: any) => {
   const { t } = useTranslation('modals');
 
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+    network,
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const { activeEra } = useNetworkMetrics();
   const { isFastUnstaking } = useUnstaking();
   const { erasToSeconds } = useErasToTimeLeft();
   const { timeleft, setFromNow } = useTimeLeft();
-  const { units } = networkData;
   const isStaking = bondFor === 'nominator';
 
   const { era, value } = chunk;
@@ -39,13 +41,13 @@ export const Chunk = ({ chunk, bondFor, onRebond }: any) => {
   // reset timer on account or network change.
   useEffect(() => {
     setFromNow(dateFrom, dateTo);
-  }, [activeAccount, networkData]);
+  }, [activeAccount, network]);
 
   return (
     <ChunkWrapper>
       <div>
         <section>
-          <h2>{`${planckToUnit(value, units)} ${networkData.unit}`}</h2>
+          <h2>{`${planckToUnit(value, units)} ${unit}`}</h2>
           <h4>
             {left.isLessThanOrEqualTo(0) ? (
               t('unlocked')

--- a/src/modals/UnlockChunks/Forms.tsx
+++ b/src/modals/UnlockChunks/Forms.tsx
@@ -24,12 +24,14 @@ import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
 import { SubmitTx } from 'library/SubmitTx';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { ContentWrapper } from './Wrappers';
 
 export const Forms = forwardRef(
   ({ setSection, unlock, task }: any, ref: any) => {
     const { t } = useTranslation('modals');
-    const { api, network, consts } = useApi();
+    const { api, consts } = useApi();
+    const { networkData } = useNetwork();
     const { activeAccount } = useConnect();
     const { removeFavorite: removeFavoritePool } = usePoolsConfig();
     const { membership } = usePoolMemberships();
@@ -45,7 +47,7 @@ export const Forms = forwardRef(
 
     const { bondFor, poolClosure } = options || {};
     const { historyDepth } = consts;
-    const { units } = network;
+    const { units } = networkData;
     const controller = getBondedAccount(activeAccount);
 
     const isStaking = bondFor === 'nominator';
@@ -98,7 +100,7 @@ export const Forms = forwardRef(
         // if no more bonded funds from pool, remove from poolMembers list
         if (bondFor === 'pool') {
           const points = membership?.points ? rmCommas(membership.points) : 0;
-          const bonded = planckToUnit(new BigNumber(points), network.units);
+          const bonded = planckToUnit(new BigNumber(points), networkData.units);
           if (bonded.isZero()) {
             removePoolMember(activeAccount);
           }
@@ -130,7 +132,7 @@ export const Forms = forwardRef(
                 <>
                   <ActionItem
                     text={`${t('rebond')} ${planckToUnit(value, units)} ${
-                      network.unit
+                      networkData.unit
                     }`}
                   />
                   <p>{t('rebondSubtitle')}</p>
@@ -140,7 +142,7 @@ export const Forms = forwardRef(
                 <>
                   <ActionItem
                     text={`${t('withdraw')} ${planckToUnit(value, units)} ${
-                      network.unit
+                      networkData.unit
                     }`}
                   />
                   <p>{t('withdrawSubtitle')}</p>

--- a/src/modals/UnlockChunks/Forms.tsx
+++ b/src/modals/UnlockChunks/Forms.tsx
@@ -31,7 +31,9 @@ export const Forms = forwardRef(
   ({ setSection, unlock, task }: any, ref: any) => {
     const { t } = useTranslation('modals');
     const { api, consts } = useApi();
-    const { networkData } = useNetwork();
+    const {
+      networkData: { units, unit },
+    } = useNetwork();
     const { activeAccount } = useConnect();
     const { removeFavorite: removeFavoritePool } = usePoolsConfig();
     const { membership } = usePoolMemberships();
@@ -47,7 +49,6 @@ export const Forms = forwardRef(
 
     const { bondFor, poolClosure } = options || {};
     const { historyDepth } = consts;
-    const { units } = networkData;
     const controller = getBondedAccount(activeAccount);
 
     const isStaking = bondFor === 'nominator';
@@ -100,7 +101,7 @@ export const Forms = forwardRef(
         // if no more bonded funds from pool, remove from poolMembers list
         if (bondFor === 'pool') {
           const points = membership?.points ? rmCommas(membership.points) : 0;
-          const bonded = planckToUnit(new BigNumber(points), networkData.units);
+          const bonded = planckToUnit(new BigNumber(points), units);
           if (bonded.isZero()) {
             removePoolMember(activeAccount);
           }
@@ -131,9 +132,10 @@ export const Forms = forwardRef(
               {task === 'rebond' && (
                 <>
                   <ActionItem
-                    text={`${t('rebond')} ${planckToUnit(value, units)} ${
-                      networkData.unit
-                    }`}
+                    text={`${t('rebond')} ${planckToUnit(
+                      value,
+                      units
+                    )} ${unit}`}
                   />
                   <p>{t('rebondSubtitle')}</p>
                 </>
@@ -141,9 +143,10 @@ export const Forms = forwardRef(
               {task === 'withdraw' && (
                 <>
                   <ActionItem
-                    text={`${t('withdraw')} ${planckToUnit(value, units)} ${
-                      networkData.unit
-                    }`}
+                    text={`${t('withdraw')} ${planckToUnit(
+                      value,
+                      units
+                    )} ${unit}`}
                   />
                   <p>{t('withdrawSubtitle')}</p>
                 </>

--- a/src/modals/UnlockChunks/Overview.tsx
+++ b/src/modals/UnlockChunks/Overview.tsx
@@ -25,10 +25,11 @@ export const Overview = forwardRef(
   ({ unlocking, bondFor, setSection, setUnlock, setTask }: any, ref: any) => {
     const { t } = useTranslation('modals');
     const { consts } = useApi();
-    const { networkData } = useNetwork();
+    const {
+      networkData: { units, unit },
+    } = useNetwork();
     const { activeEra } = useNetworkMetrics();
     const { bondDuration } = consts;
-    const { units } = networkData;
     const { isFastUnstaking } = useUnstaking();
     const { erasToSeconds } = useErasToTimeLeft();
 
@@ -73,7 +74,7 @@ export const Overview = forwardRef(
                   {planckToUnit(withdrawAvailable, units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {networkData.unit}
+                  {unit}
                 </h2>
               </div>
             </StatWrapper>
@@ -87,7 +88,7 @@ export const Overview = forwardRef(
                   {planckToUnit(totalUnbonding.minus(withdrawAvailable), units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {networkData.unit}
+                  {unit}
                 </h2>
               </div>
             </StatWrapper>
@@ -98,7 +99,7 @@ export const Overview = forwardRef(
                   {planckToUnit(totalUnbonding, units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {networkData.unit}
+                  {unit}
                 </h2>
               </div>
             </StatWrapper>

--- a/src/modals/UnlockChunks/Overview.tsx
+++ b/src/modals/UnlockChunks/Overview.tsx
@@ -10,23 +10,25 @@ import { getUnixTime } from 'date-fns';
 import { forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useErasToTimeLeft } from 'library/Hooks/useErasToTimeLeft';
 import { timeleftAsString } from 'library/Hooks/useTimeLeft/utils';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
 import { StatWrapper, StatsWrapper } from 'library/Modal/Wrappers';
 import { StaticNote } from 'modals/Utils/StaticNote';
 import type { AnyJson } from 'types';
+import { useNetwork } from 'contexts/Network';
 import { Chunk } from './Chunk';
 import { ContentWrapper } from './Wrappers';
 
 export const Overview = forwardRef(
   ({ unlocking, bondFor, setSection, setUnlock, setTask }: any, ref: any) => {
     const { t } = useTranslation('modals');
-    const { network, consts } = useApi();
+    const { consts } = useApi();
+    const { networkData } = useNetwork();
     const { activeEra } = useNetworkMetrics();
     const { bondDuration } = consts;
-    const { units } = network;
+    const { units } = networkData;
     const { isFastUnstaking } = useUnstaking();
     const { erasToSeconds } = useErasToTimeLeft();
 
@@ -71,7 +73,7 @@ export const Overview = forwardRef(
                   {planckToUnit(withdrawAvailable, units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {network.unit}
+                  {networkData.unit}
                 </h2>
               </div>
             </StatWrapper>
@@ -85,7 +87,7 @@ export const Overview = forwardRef(
                   {planckToUnit(totalUnbonding.minus(withdrawAvailable), units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {network.unit}
+                  {networkData.unit}
                 </h2>
               </div>
             </StatWrapper>
@@ -96,7 +98,7 @@ export const Overview = forwardRef(
                   {planckToUnit(totalUnbonding, units)
                     .decimalPlaces(3)
                     .toFormat()}{' '}
-                  {network.unit}
+                  {networkData.unit}
                 </h2>
               </div>
             </StatWrapper>

--- a/src/modals/Unstake/index.tsx
+++ b/src/modals/Unstake/index.tsx
@@ -25,20 +25,22 @@ import { SubmitTx } from 'library/SubmitTx';
 import { StaticNote } from 'modals/Utils/StaticNote';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const Unstake = () => {
   const { t } = useTranslation('modals');
   const { newBatchCall } = useBatchCall();
   const { notEnoughFunds } = useTxMeta();
   const { activeAccount } = useConnect();
-  const { api, network, consts } = useApi();
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
   const { getTransferOptions } = useTransferOptions();
   const { setModalStatus, setModalResize } = useOverlay().modal;
   const { getBondedAccount, getAccountNominations } = useBonded();
 
-  const { units } = network;
+  const { units } = networkData;
   const controller = getBondedAccount(activeAccount);
   const nominations = getAccountNominations(activeAccount);
   const { bondDuration } = consts;
@@ -127,7 +129,7 @@ export const Unstake = () => {
           <ActionItem
             text={t('unstakeUnbond', {
               bond: freeToUnbond.toFormat(),
-              unit: network.unit,
+              unit: networkData.unit,
             })}
           />
         ) : null}

--- a/src/modals/Unstake/index.tsx
+++ b/src/modals/Unstake/index.tsx
@@ -33,14 +33,15 @@ export const Unstake = () => {
   const { notEnoughFunds } = useTxMeta();
   const { activeAccount } = useConnect();
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getSignerWarnings } = useSignerWarnings();
   const { getTransferOptions } = useTransferOptions();
   const { setModalStatus, setModalResize } = useOverlay().modal;
   const { getBondedAccount, getAccountNominations } = useBonded();
 
-  const { units } = networkData;
   const controller = getBondedAccount(activeAccount);
   const nominations = getAccountNominations(activeAccount);
   const { bondDuration } = consts;
@@ -129,7 +130,7 @@ export const Unstake = () => {
           <ActionItem
             text={t('unstakeUnbond', {
               bond: freeToUnbond.toFormat(),
-              unit: networkData.unit,
+              unit,
             })}
           />
         ) : null}

--- a/src/modals/UpdateReserve/index.tsx
+++ b/src/modals/UpdateReserve/index.tsx
@@ -13,7 +13,6 @@ import BigNumber from 'bignumber.js';
 import Slider from 'rc-slider';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useHelp } from 'contexts/Help';
 import { useTransferOptions } from 'contexts/TransferOptions';
@@ -23,13 +22,13 @@ import { Title } from 'library/Modal/Title';
 import { SliderWrapper } from 'modals/ManagePool/Wrappers';
 import 'rc-slider/assets/index.css';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const UpdateReserve = () => {
   const { t } = useTranslation('modals');
   const {
-    network: { units, unit },
-  } = useApi();
-  const { network } = useApi();
+    networkData: { units, unit, name },
+  } = useNetwork();
   const { openHelp } = useHelp();
   const { setModalStatus } = useOverlay().modal;
   const { activeAccount, accountHasSigner } = useConnect();
@@ -39,7 +38,7 @@ export const UpdateReserve = () => {
   const { edReserved } = getTransferOptions(activeAccount);
   const minReserve = planckToUnit(edReserved, units);
   const maxReserve = minReserve.plus(
-    ['polkadot', 'westend'].includes(network.name) ? 3 : 1
+    ['polkadot', 'westend'].includes(name) ? 3 : 1
   );
 
   const [sliderReserve, setSliderReserve] = useState<number>(

--- a/src/modals/UpdateReserve/index.tsx
+++ b/src/modals/UpdateReserve/index.tsx
@@ -27,7 +27,8 @@ import { useNetwork } from 'contexts/Network';
 export const UpdateReserve = () => {
   const { t } = useTranslation('modals');
   const {
-    networkData: { units, unit, name },
+    network,
+    networkData: { units, unit },
   } = useNetwork();
   const { openHelp } = useHelp();
   const { setModalStatus } = useOverlay().modal;
@@ -38,7 +39,7 @@ export const UpdateReserve = () => {
   const { edReserved } = getTransferOptions(activeAccount);
   const minReserve = planckToUnit(edReserved, units);
   const maxReserve = minReserve.plus(
-    ['polkadot', 'westend'].includes(name) ? 3 : 1
+    ['polkadot', 'westend'].includes(network) ? 3 : 1
   );
 
   const [sliderReserve, setSliderReserve] = useState<number>(

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -6,9 +6,8 @@ import { ellipsisFn, planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useHelp } from 'contexts/Help';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useStaking } from 'contexts/Staking';
 import { useSubscan } from 'contexts/Plugins/Subscan';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
@@ -21,12 +20,13 @@ import { StatWrapper, StatsWrapper } from 'library/Modal/Wrappers';
 import { StatusLabel } from 'library/StatusLabel';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { PluginLabel } from 'library/PluginLabel';
+import { useNetwork } from 'contexts/Network';
 
 export const ValidatorMetrics = () => {
   const { t } = useTranslation('modals');
   const {
-    network: { units, unit },
-  } = useApi();
+    networkData: { units, unit },
+  } = useNetwork();
   const { options } = useOverlay().modal.config;
   const { address, identity } = options;
   const { fetchEraPoints }: any = useSubscan();

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { Warning } from 'library/Form/Warning';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
@@ -17,10 +17,12 @@ import { Close } from 'library/Modal/Close';
 import { SubmitTx } from 'library/SubmitTx';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const WithdrawPoolMember = () => {
   const { t } = useTranslation('modals');
-  const { api, network, consts } = useApi();
+  const { api, consts } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const {
     setModalStatus,
@@ -48,11 +50,14 @@ export const WithdrawPoolMember = () => {
     }
   });
 
-  const bonded = planckToUnit(new BigNumber(rmCommas(points)), network.units);
+  const bonded = planckToUnit(
+    new BigNumber(rmCommas(points)),
+    networkData.units
+  );
 
   const totalWithdraw = planckToUnit(
     new BigNumber(totalWithdrawUnit),
-    network.units
+    networkData.units
   );
 
   // valid to submit transaction
@@ -96,7 +101,7 @@ export const WithdrawPoolMember = () => {
       <ModalPadding>
         <h2 className="title">{t('withdrawMemberFunds')}</h2>
         <ActionItem
-          text={`${t('withdraw')} ${totalWithdraw} ${network.unit}`}
+          text={`${t('withdraw')} ${totalWithdraw} ${networkData.unit}`}
         />
         {warnings.length > 0 ? (
           <ModalWarnings withMargin>

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -22,7 +22,9 @@ import { useNetwork } from 'contexts/Network';
 export const WithdrawPoolMember = () => {
   const { t } = useTranslation('modals');
   const { api, consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { activeAccount } = useConnect();
   const {
     setModalStatus,
@@ -50,15 +52,9 @@ export const WithdrawPoolMember = () => {
     }
   });
 
-  const bonded = planckToUnit(
-    new BigNumber(rmCommas(points)),
-    networkData.units
-  );
+  const bonded = planckToUnit(new BigNumber(rmCommas(points)), units);
 
-  const totalWithdraw = planckToUnit(
-    new BigNumber(totalWithdrawUnit),
-    networkData.units
-  );
+  const totalWithdraw = planckToUnit(new BigNumber(totalWithdrawUnit), units);
 
   // valid to submit transaction
   const [valid] = useState<boolean>(isNotZero(totalWithdraw) ?? false);
@@ -100,9 +96,7 @@ export const WithdrawPoolMember = () => {
       <Close />
       <ModalPadding>
         <h2 className="title">{t('withdrawMemberFunds')}</h2>
-        <ActionItem
-          text={`${t('withdraw')} ${totalWithdraw} ${networkData.unit}`}
-        />
+        <ActionItem text={`${t('withdraw')} ${totalWithdraw} ${unit}`} />
         {warnings.length > 0 ? (
           <ModalWarnings withMargin>
             {warnings.map((text, i) => (

--- a/src/pages/Community/Entity.tsx
+++ b/src/pages/Community/Entity.tsx
@@ -9,18 +9,20 @@ import { useApi } from 'contexts/Api';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { ValidatorList } from 'library/ValidatorList';
+import { useNetwork } from 'contexts/Network';
 import { Item } from './Item';
 import { ItemsWrapper } from './Wrappers';
 import { useCommunitySections } from './context';
 
 export const Entity = () => {
   const { t } = useTranslation('pages');
-  const { isReady, network } = useApi();
+  const { isReady } = useApi();
+  const { networkData } = useNetwork();
   const { validators: allValidators } = useValidators();
   const { setActiveSection, activeItem } = useCommunitySections();
 
   const { name, validators: entityAllValidators } = activeItem;
-  const validators = entityAllValidators[network.name] ?? [];
+  const validators = entityAllValidators[networkData.name] ?? [];
 
   // include validators that exist in `erasStakers`
   const [activeValidators, setActiveValidators] = useState(
@@ -31,12 +33,12 @@ export const Entity = () => {
     setActiveValidators(
       allValidators.filter((v) => validators.includes(v.address))
     );
-  }, [allValidators, network]);
+  }, [allValidators, networkData]);
 
   useEffect(() => {
     const newValidators = [...activeValidators];
     setActiveValidators(newValidators);
-  }, [name, activeItem, network]);
+  }, [name, activeItem, networkData]);
 
   const container = {
     hidden: { opacity: 0 },

--- a/src/pages/Community/Entity.tsx
+++ b/src/pages/Community/Entity.tsx
@@ -17,12 +17,12 @@ import { useCommunitySections } from './context';
 export const Entity = () => {
   const { t } = useTranslation('pages');
   const { isReady } = useApi();
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { validators: allValidators } = useValidators();
   const { setActiveSection, activeItem } = useCommunitySections();
 
   const { name, validators: entityAllValidators } = activeItem;
-  const validators = entityAllValidators[networkData.name] ?? [];
+  const validators = entityAllValidators[network] ?? [];
 
   // include validators that exist in `erasStakers`
   const [activeValidators, setActiveValidators] = useState(
@@ -33,12 +33,12 @@ export const Entity = () => {
     setActiveValidators(
       allValidators.filter((v) => validators.includes(v.address))
     );
-  }, [allValidators, networkData]);
+  }, [allValidators, network]);
 
   useEffect(() => {
     const newValidators = [...activeValidators];
     setActiveValidators(newValidators);
-  }, [name, activeItem, networkData]);
+  }, [name, activeItem, network]);
 
   const container = {
     hidden: { opacity: 0 },

--- a/src/pages/Community/Item.tsx
+++ b/src/pages/Community/Item.tsx
@@ -10,8 +10,8 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Suspense, lazy, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { ItemWrapper } from './Wrappers';
 import { useCommunitySections } from './context';
 import type { ItemProps } from './types';
@@ -19,7 +19,7 @@ import type { ItemProps } from './types';
 export const Item = ({ item, actionable }: ItemProps) => {
   const { t } = useTranslation('pages');
   const { openModal } = useOverlay().modal;
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   const {
     bio,
@@ -30,7 +30,7 @@ export const Item = ({ item, actionable }: ItemProps) => {
     thumbnail,
     validators: entityAllValidators,
   } = item;
-  const validatorCount = entityAllValidators[network.name]?.length ?? 0;
+  const validatorCount = entityAllValidators[networkData.name]?.length ?? 0;
 
   const { setActiveSection, setActiveItem, setScrollPos } =
     useCommunitySections();

--- a/src/pages/Community/Item.tsx
+++ b/src/pages/Community/Item.tsx
@@ -19,7 +19,7 @@ import type { ItemProps } from './types';
 export const Item = ({ item, actionable }: ItemProps) => {
   const { t } = useTranslation('pages');
   const { openModal } = useOverlay().modal;
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   const {
     bio,
@@ -30,7 +30,7 @@ export const Item = ({ item, actionable }: ItemProps) => {
     thumbnail,
     validators: entityAllValidators,
   } = item;
-  const validatorCount = entityAllValidators[networkData.name]?.length ?? 0;
+  const validatorCount = entityAllValidators[network]?.length ?? 0;
 
   const { setActiveSection, setActiveItem, setScrollPos } =
     useCommunitySections();

--- a/src/pages/Community/List.tsx
+++ b/src/pages/Community/List.tsx
@@ -10,23 +10,19 @@ import { ItemsWrapper } from './Wrappers';
 import { useCommunitySections } from './context';
 
 export const List = () => {
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { validatorCommunity } = useValidators();
   const { scrollPos } = useCommunitySections();
 
   const [entityItems, setEntityItems] = useState(
-    validatorCommunity.filter(
-      (v) => v.validators[networkData.name] !== undefined
-    )
+    validatorCommunity.filter((v) => v.validators[network] !== undefined)
   );
 
   useEffect(() => {
     setEntityItems(
-      validatorCommunity.filter(
-        (v) => v.validators[networkData.name] !== undefined
-      )
+      validatorCommunity.filter((v) => v.validators[network] !== undefined)
     );
-  }, [networkData]);
+  }, [network]);
 
   useEffect(() => {
     window.scrollTo(0, scrollPos);

--- a/src/pages/Community/List.tsx
+++ b/src/pages/Community/List.tsx
@@ -3,26 +3,30 @@
 
 import { PageRow } from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
-import { useApi } from 'contexts/Api';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
+import { useNetwork } from 'contexts/Network';
 import { Item } from './Item';
 import { ItemsWrapper } from './Wrappers';
 import { useCommunitySections } from './context';
 
 export const List = () => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { validatorCommunity } = useValidators();
   const { scrollPos } = useCommunitySections();
 
   const [entityItems, setEntityItems] = useState(
-    validatorCommunity.filter((v) => v.validators[network.name] !== undefined)
+    validatorCommunity.filter(
+      (v) => v.validators[networkData.name] !== undefined
+    )
   );
 
   useEffect(() => {
     setEntityItems(
-      validatorCommunity.filter((v) => v.validators[network.name] !== undefined)
+      validatorCommunity.filter(
+        (v) => v.validators[networkData.name] !== undefined
+      )
     );
-  }, [network]);
+  }, [networkData]);
 
   useEffect(() => {
     window.scrollTo(0, scrollPos);

--- a/src/pages/Community/context.tsx
+++ b/src/pages/Community/context.tsx
@@ -17,7 +17,7 @@ export const CommunitySectionsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
 
   // store the active section of the community page
   const [activeSection, setActiveSectionState] = useState<number>(0);
@@ -33,7 +33,7 @@ export const CommunitySectionsProvider = ({
   useEffect(() => {
     setActiveSectionState(0);
     setActiveItem(defaults.item);
-  }, [networkData]);
+  }, [network]);
 
   const setActiveSection = (t: any) => {
     setActiveSectionState(t);

--- a/src/pages/Community/context.tsx
+++ b/src/pages/Community/context.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import React, { useEffect, useState } from 'react';
-import { useApi } from 'contexts/Api';
+import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 
 export const CommunitySectionsContext: React.Context<any> = React.createContext(
@@ -17,7 +17,7 @@ export const CommunitySectionsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { network } = useApi();
+  const { networkData } = useNetwork();
 
   // store the active section of the community page
   const [activeSection, setActiveSectionState] = useState<number>(0);
@@ -33,7 +33,7 @@ export const CommunitySectionsProvider = ({
   useEffect(() => {
     setActiveSectionState(0);
     setActiveItem(defaults.item);
-  }, [network]);
+  }, [networkData]);
 
   const setActiveSection = (t: any) => {
     setActiveSectionState(t);

--- a/src/pages/Nominate/Active/ControllerNotStash.tsx
+++ b/src/pages/Nominate/Active/ControllerNotStash.tsx
@@ -20,7 +20,7 @@ import { useNetwork } from 'contexts/Network';
 
 export const ControllerNotStash = () => {
   const { t } = useTranslation('pages');
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { activeAccount, isReadOnlyAccount } = useConnect();
   const { addressDifferentToStash } = useStaking();
   const { getBondedAccount } = useBonded();
@@ -49,8 +49,7 @@ export const ControllerNotStash = () => {
                     &nbsp; {t('nominate.controllerAccountsDeprecated')}
                   </h3>
                   <h4>
-                    {t('nominate.proxyprompt')}{' '}
-                    {stringUpperFirst(networkData.name)}.
+                    {t('nominate.proxyprompt')} {stringUpperFirst(network)}.
                   </h4>
                 </CardHeaderWrapper>
                 <div>

--- a/src/pages/Nominate/Active/ControllerNotStash.tsx
+++ b/src/pages/Nominate/Active/ControllerNotStash.tsx
@@ -10,17 +10,17 @@ import { stringUpperFirst } from '@polkadot/util';
 import { ButtonPrimary, PageRow } from '@polkadot-cloud/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ControllerNotStash = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount, isReadOnlyAccount } = useConnect();
   const { addressDifferentToStash } = useStaking();
   const { getBondedAccount } = useBonded();
@@ -49,8 +49,8 @@ export const ControllerNotStash = () => {
                     &nbsp; {t('nominate.controllerAccountsDeprecated')}
                   </h3>
                   <h4>
-                    {t('nominate.proxyprompt')} {stringUpperFirst(network.name)}
-                    .
+                    {t('nominate.proxyprompt')}{' '}
+                    {stringUpperFirst(networkData.name)}.
                   </h4>
                 </CardHeaderWrapper>
                 <div>

--- a/src/pages/Nominate/Active/ManageBond.tsx
+++ b/src/pages/Nominate/Active/ManageBond.tsx
@@ -11,7 +11,6 @@ import {
 import { minDecimalPlaces, planckToUnit } from '@polkadot-cloud/utils';
 import type BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
 import { useConnect } from 'contexts/Connect';
 import { useHelp } from 'contexts/Help';
@@ -22,10 +21,11 @@ import { CardHeaderWrapper } from 'library/Card/Wrappers';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { BondedChart } from 'library/BarChart/BondedChart';
+import { useNetwork } from 'contexts/Network';
 
 export const ManageBond = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { openModal } = useOverlay().modal;
   const { activeAccount, isReadOnlyAccount } = useConnect();
   const { getStashLedger } = useBalances();
@@ -37,7 +37,7 @@ export const ManageBond = () => {
   const {
     units,
     brand: { token: Token },
-  } = network;
+  } = networkData;
   const ledger = getStashLedger(activeAccount);
   const { active }: { active: BigNumber } = ledger;
   const allTransferOptions = getTransferOptions(activeAccount);

--- a/src/pages/Nominate/Active/ManageBond.tsx
+++ b/src/pages/Nominate/Active/ManageBond.tsx
@@ -25,19 +25,20 @@ import { useNetwork } from 'contexts/Network';
 
 export const ManageBond = () => {
   const { t } = useTranslation('pages');
-  const { networkData } = useNetwork();
-  const { openModal } = useOverlay().modal;
-  const { activeAccount, isReadOnlyAccount } = useConnect();
-  const { getStashLedger } = useBalances();
-  const { getTransferOptions } = useTransferOptions();
-  const { inSetup } = useStaking();
-  const { isSyncing } = useUi();
-  const { isFastUnstaking } = useUnstaking();
-  const { openHelp } = useHelp();
   const {
-    units,
-    brand: { token: Token },
-  } = networkData;
+    networkData: {
+      units,
+      brand: { token: Token },
+    },
+  } = useNetwork();
+  const { isSyncing } = useUi();
+  const { openHelp } = useHelp();
+  const { inSetup } = useStaking();
+  const { openModal } = useOverlay().modal;
+  const { getStashLedger } = useBalances();
+  const { isFastUnstaking } = useUnstaking();
+  const { getTransferOptions } = useTransferOptions();
+  const { activeAccount, isReadOnlyAccount } = useConnect();
   const ledger = getStashLedger(activeAccount);
   const { active }: { active: BigNumber } = ledger;
   const allTransferOptions = getTransferOptions(activeAccount);

--- a/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
+++ b/src/pages/Nominate/Active/Stats/MinimumActiveStake.tsx
@@ -3,21 +3,23 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { Number } from 'library/StatBoxList/Number';
+import { useNetwork } from 'contexts/Network';
 
 export const MinimumActiveStakeStat = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
+  const {
+    networkData: { unit, units },
+  } = useNetwork();
   const { metrics } = useNetworkMetrics();
   const { minimumActiveStake } = metrics;
 
   const params = {
     label: t('nominate.minimumToEarnRewards'),
-    value: planckToUnit(minimumActiveStake, network.units).toNumber(),
+    value: planckToUnit(minimumActiveStake, units).toNumber(),
     decimals: 3,
-    unit: `${network.unit}`,
+    unit: `${unit}`,
     helpKey: 'Bonding',
   };
 

--- a/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
+++ b/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
@@ -3,14 +3,14 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useStaking } from 'contexts/Staking';
 import { Number } from 'library/StatBoxList/Number';
+import { useNetwork } from 'contexts/Network';
 
 export const MinimumNominatorBondStat = () => {
   const { t } = useTranslation('pages');
-  const { unit, units } = useApi().network;
   const { staking } = useStaking();
+  const { unit, units } = useNetwork().networkData;
   const { minNominatorBond } = staking;
 
   const params = {

--- a/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -11,7 +11,7 @@ import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useConnect } from 'contexts/Connect';
 import { useFastUnstake } from 'contexts/FastUnstake';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useSetup } from 'contexts/Setup';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';

--- a/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
+++ b/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
@@ -10,10 +10,12 @@ import { minDecimalPlaces, planckToUnit } from '@polkadot-cloud/utils';
 import { faCircleDown } from '@fortawesome/free-solid-svg-icons';
 import { useConnect } from 'contexts/Connect';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const UnclaimedPayoutsStatus = () => {
   const { t } = useTranslation();
-  const { network, isReady } = useApi();
+  const { isReady } = useApi();
+  const { networkData } = useNetwork();
   const { openModal } = useOverlay().modal;
   const { unclaimedPayouts } = usePayouts();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -33,7 +35,7 @@ export const UnclaimedPayoutsStatus = () => {
       type="odometer"
       stat={{
         value: minDecimalPlaces(
-          planckToUnit(totalUnclaimed, network.units).toFormat(),
+          planckToUnit(totalUnclaimed, networkData.units).toFormat(),
           2
         ),
       }}

--- a/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
+++ b/src/pages/Nominate/Active/Status/UnclaimedPayoutsStatus.tsx
@@ -15,7 +15,9 @@ import { useNetwork } from 'contexts/Network';
 export const UnclaimedPayoutsStatus = () => {
   const { t } = useTranslation();
   const { isReady } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units },
+  } = useNetwork();
   const { openModal } = useOverlay().modal;
   const { unclaimedPayouts } = usePayouts();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -35,7 +37,7 @@ export const UnclaimedPayoutsStatus = () => {
       type="odometer"
       stat={{
         value: minDecimalPlaces(
-          planckToUnit(totalUnclaimed, networkData.units).toFormat(),
+          planckToUnit(totalUnclaimed, units).toFormat(),
           2
         ),
       }}

--- a/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -5,7 +5,6 @@ import { faBolt, faLockOpen } from '@fortawesome/free-solid-svg-icons';
 import { ButtonPrimary, ButtonRow, PageRow } from '@polkadot-cloud/react';
 import { isNotZero } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useTheme } from 'contexts/Themes';
 import { useTransferOptions } from 'contexts/TransferOptions';
@@ -13,10 +12,11 @@ import { useUi } from 'contexts/UI';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { useUnstaking } from 'library/Hooks/useUnstaking';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const UnstakePrompts = () => {
   const { t } = useTranslation('pages');
-  const { unit, colors } = useApi().network;
+  const { unit, colors } = useNetwork().networkData;
   const { activeAccount } = useConnect();
   const { mode } = useTheme();
   const { openModal } = useOverlay().modal;

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ellipsisFn, unitToPlanck } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useSetup } from 'contexts/Setup';
 import { Warning } from 'library/Form/Warning';
@@ -17,14 +16,16 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { SubmitTx } from 'library/SubmitTx';
+import { useNetwork } from 'contexts/Network';
+import { useApi } from 'contexts/Api';
 import { SummaryWrapper } from './Wrapper';
 
 export const Summary = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
+  const { api } = useApi();
   const {
-    api,
-    network: { units, unit },
-  } = useApi();
+    networkData: { units, unit },
+  } = useNetwork();
   const { newBatchCall } = useBatchCall();
   const { getPayeeItems } = usePayeeConfig();
   const { getSetupProgress, removeSetupProgress } = useSetup();

--- a/src/pages/Overview/BalanceChart.tsx
+++ b/src/pages/Overview/BalanceChart.tsx
@@ -10,7 +10,6 @@ import {
 } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBalances } from 'contexts/Balances';
 import { useConnect } from 'contexts/Connect';
 import { usePlugins } from 'contexts/Plugins';
@@ -22,16 +21,17 @@ import { Bar, BarChartWrapper, Legend } from 'library/BarChart/Wrappers';
 import { CardHeaderWrapper } from 'library/Card/Wrappers';
 import { usePrices } from 'library/Hooks/usePrices';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const BalanceChart = () => {
   const { t } = useTranslation('pages');
   const {
-    network: {
+    networkData: {
       units,
       unit,
       brand: { token: Token },
     },
-  } = useApi();
+  } = useNetwork();
   const prices = usePrices();
   const { plugins } = usePlugins();
   const { isNetworkSyncing } = useUi();

--- a/src/pages/Overview/BalanceLinks.tsx
+++ b/src/pages/Overview/BalanceLinks.tsx
@@ -4,13 +4,13 @@
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { ButtonPrimaryInvert, Separator } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
+import { useNetwork } from 'contexts/Network';
 import { MoreWrapper } from './Wrappers';
 
 export const BalanceLinks = () => {
   const { t } = useTranslation('pages');
-  const { name } = useApi().network;
+  const { name } = useNetwork().networkData;
   const { activeAccount } = useConnect();
 
   return (

--- a/src/pages/Overview/BalanceLinks.tsx
+++ b/src/pages/Overview/BalanceLinks.tsx
@@ -9,8 +9,8 @@ import { useNetwork } from 'contexts/Network';
 import { MoreWrapper } from './Wrappers';
 
 export const BalanceLinks = () => {
+  const { network } = useNetwork();
   const { t } = useTranslation('pages');
-  const { name } = useNetwork().networkData;
   const { activeAccount } = useConnect();
 
   return (
@@ -22,7 +22,7 @@ export const BalanceLinks = () => {
           lg
           onClick={() =>
             window.open(
-              `https://${name}.subscan.io/account/${activeAccount}`,
+              `https://${network}.subscan.io/account/${activeAccount}`,
               '_blank'
             )
           }
@@ -36,14 +36,16 @@ export const BalanceLinks = () => {
           lg
           onClick={() =>
             window.open(
-              `https://${name}.polkawatch.app/nomination/${activeAccount}`,
+              `https://${network}.polkawatch.app/nomination/${activeAccount}`,
               '_blank'
             )
           }
           iconRight={faExternalLinkAlt}
           iconTransform="shrink-2"
           text="Polkawatch"
-          disabled={!(activeAccount && ['polkadot', 'kusama'].includes(name))}
+          disabled={
+            !(activeAccount && ['polkadot', 'kusama'].includes(network))
+          }
         />
       </section>
     </MoreWrapper>

--- a/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -12,24 +12,24 @@ import {
 import BigNumber from 'bignumber.js';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import type { BondedPool } from 'contexts/Pools/types';
 import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { Announcement as AnnouncementLoader } from 'library/Loader/Announcement';
+import { useNetwork } from 'contexts/Network';
 import { Item } from './Wrappers';
 
 export const Announcements = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
   const { isSyncing } = useUi();
   const { staking } = useStaking();
   const { stats } = usePoolsConfig();
+  const { networkData } = useNetwork();
   const { bondedPools } = useBondedPools();
 
-  const { units } = network;
+  const { units } = networkData;
   const { totalStaked } = staking;
   const { counterForPoolMembers } = stats;
 
@@ -60,7 +60,7 @@ export const Announcements = () => {
 
   const announcements = [];
 
-  const networkUnit = network.unit;
+  const networkUnit = networkData.unit;
 
   // total staked on the network
   if (!isSyncing) {
@@ -68,11 +68,11 @@ export const Announcements = () => {
       class: 'neutral',
       title: t('overview.networkCurrentlyStaked', {
         total: planckToUnit(totalStaked, units).integerValue().toFormat(),
-        unit: network.unit,
-        network: capitalizeFirstLetter(network.name),
+        unit: networkData.unit,
+        network: capitalizeFirstLetter(networkData.name),
       }),
       subtitle: t('overview.networkCurrentlyStakedSubtitle', {
-        unit: network.unit,
+        unit: networkData.unit,
       }),
     });
   } else {
@@ -84,7 +84,7 @@ export const Announcements = () => {
     announcements.push({
       class: 'neutral',
       title: `${totalPoolPointsUnit.integerValue().toFormat()} ${
-        network.unit
+        networkData.unit
       } ${t('overview.inPools')}`,
       subtitle: `${t('overview.bondedInPools', { networkUnit })}`,
     });

--- a/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -26,10 +26,12 @@ export const Announcements = () => {
   const { isSyncing } = useUi();
   const { staking } = useStaking();
   const { stats } = usePoolsConfig();
-  const { networkData } = useNetwork();
+  const {
+    network,
+    networkData: { units, unit },
+  } = useNetwork();
   const { bondedPools } = useBondedPools();
 
-  const { units } = networkData;
   const { totalStaked } = staking;
   const { counterForPoolMembers } = stats;
 
@@ -60,7 +62,7 @@ export const Announcements = () => {
 
   const announcements = [];
 
-  const networkUnit = networkData.unit;
+  const networkUnit = unit;
 
   // total staked on the network
   if (!isSyncing) {
@@ -68,11 +70,11 @@ export const Announcements = () => {
       class: 'neutral',
       title: t('overview.networkCurrentlyStaked', {
         total: planckToUnit(totalStaked, units).integerValue().toFormat(),
-        unit: networkData.unit,
-        network: capitalizeFirstLetter(networkData.name),
+        unit,
+        network: capitalizeFirstLetter(network),
       }),
       subtitle: t('overview.networkCurrentlyStakedSubtitle', {
-        unit: networkData.unit,
+        unit,
       }),
     });
   } else {
@@ -83,9 +85,9 @@ export const Announcements = () => {
   if (bondedPools.length) {
     announcements.push({
       class: 'neutral',
-      title: `${totalPoolPointsUnit.integerValue().toFormat()} ${
-        networkData.unit
-      } ${t('overview.inPools')}`,
+      title: `${totalPoolPointsUnit.integerValue().toFormat()} ${unit} ${t(
+        'overview.inPools'
+      )}`,
       subtitle: `${t('overview.bondedInPools', { networkUnit })}`,
     });
   } else {

--- a/src/pages/Overview/NetworkSats/index.tsx
+++ b/src/pages/Overview/NetworkSats/index.tsx
@@ -3,7 +3,7 @@
 
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useStaking } from 'contexts/Staking';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';

--- a/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -23,7 +23,7 @@ import { TipsWrapper } from './Wrappers';
 
 export const Tips = () => {
   const { i18n, t } = useTranslation();
-  const { networkData } = useNetwork();
+  const { network } = useNetwork();
   const { activeAccount } = useConnect();
   const { isNetworkSyncing } = useUi();
   const { fillVariables } = useFillVariables();
@@ -85,7 +85,7 @@ export const Tips = () => {
   // re-sync page when active account changes
   useEffect(() => {
     setStateWithRef(getPage(), setPage, pageRef);
-  }, [activeAccount, networkData]);
+  }, [activeAccount, network]);
 
   // resize event listener
   useEffect(() => {

--- a/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -7,7 +7,6 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TipsConfig } from 'config/tips';
 import { DefaultLocale, TipsThresholdMedium, TipsThresholdSmall } from 'consts';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
@@ -16,6 +15,7 @@ import { useTransferOptions } from 'contexts/TransferOptions';
 import { useUi } from 'contexts/UI';
 import { useFillVariables } from 'library/Hooks/useFillVariables';
 import type { AnyJson } from 'types';
+import { useNetwork } from 'contexts/Network';
 import { Items } from './Items';
 import { PageToggle } from './PageToggle';
 import { Syncing } from './Syncing';
@@ -23,7 +23,7 @@ import { TipsWrapper } from './Wrappers';
 
 export const Tips = () => {
   const { i18n, t } = useTranslation();
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { activeAccount } = useConnect();
   const { isNetworkSyncing } = useUi();
   const { fillVariables } = useFillVariables();
@@ -85,7 +85,7 @@ export const Tips = () => {
   // re-sync page when active account changes
   useEffect(() => {
     setStateWithRef(getPage(), setPage, pageRef);
-  }, [activeAccount, network]);
+  }, [activeAccount, networkData]);
 
   // resize event listener
   useEffect(() => {

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -6,7 +6,7 @@ import { fromUnixTime } from 'date-fns';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useEraTimeLeft } from 'library/Hooks/useEraTimeLeft';
 import { useTimeLeft } from 'library/Hooks/useTimeLeft';
 import { fromNow } from 'library/Hooks/useTimeLeft/utils';

--- a/src/pages/Overview/Stats/HistoricalRewardsRate.tsx
+++ b/src/pages/Overview/Stats/HistoricalRewardsRate.tsx
@@ -3,7 +3,7 @@
 
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useInflation } from 'library/Hooks/useInflation';
 import { Text } from 'library/StatBoxList/Text';
 

--- a/src/pages/Overview/Stats/SupplyStaked.tsx
+++ b/src/pages/Overview/Stats/SupplyStaked.tsx
@@ -4,14 +4,14 @@
 import { planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useStaking } from 'contexts/Staking';
 import { Pie } from 'library/StatBoxList/Pie';
+import { useNetwork } from 'contexts/Network';
 
 export const SupplyStakedStat = () => {
   const { t } = useTranslation('pages');
-  const { units, unit } = useApi().network;
+  const { units, unit } = useNetwork().networkData;
   const { metrics } = useNetworkMetrics();
   const { staking } = useStaking();
 

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -33,9 +33,14 @@ import { SupplyStakedStat } from './Stats/SupplyStaked';
 
 export const Overview = () => {
   const { i18n, t } = useTranslation('pages');
-  const { networkData } = useNetwork();
+  const {
+    networkData: {
+      units,
+      brand: { token: Token },
+    },
+  } = useNetwork();
   const { payouts, poolClaims, unclaimedPayouts } = useSubscan();
-  const { units } = networkData;
+
   const { lastReward } = formatRewardsForGraphs(
     new Date(),
     14,
@@ -44,9 +49,7 @@ export const Overview = () => {
     poolClaims,
     unclaimedPayouts
   );
-  const {
-    brand: { token: Token },
-  } = networkData;
+
   const PAYOUTS_HEIGHT = 380;
 
   let formatFrom = new Date();

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -12,7 +12,6 @@ import BigNumber from 'bignumber.js';
 import { formatDistance, fromUnixTime, getUnixTime } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { DefaultLocale } from 'consts';
-import { useApi } from 'contexts/Api';
 import { useSubscan } from 'contexts/Plugins/Subscan';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
 import { formatRewardsForGraphs } from 'library/Graphs/Utils';
@@ -21,6 +20,7 @@ import { locales } from 'locale';
 import { ControllerNotStash } from 'pages/Nominate/Active/ControllerNotStash';
 import { minDecimalPlaces, planckToUnit } from '@polkadot-cloud/utils';
 import { PluginLabel } from 'library/PluginLabel';
+import { useNetwork } from 'contexts/Network';
 import { ActiveAccounts } from './ActiveAccounts';
 import { BalanceChart } from './BalanceChart';
 import { BalanceLinks } from './BalanceLinks';
@@ -33,9 +33,9 @@ import { SupplyStakedStat } from './Stats/SupplyStaked';
 
 export const Overview = () => {
   const { i18n, t } = useTranslation('pages');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { payouts, poolClaims, unclaimedPayouts } = useSubscan();
-  const { units } = network;
+  const { units } = networkData;
   const { lastReward } = formatRewardsForGraphs(
     new Date(),
     14,
@@ -46,7 +46,7 @@ export const Overview = () => {
   );
   const {
     brand: { token: Token },
-  } = network;
+  } = networkData;
   const PAYOUTS_HEIGHT = 380;
 
   let formatFrom = new Date();

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -11,7 +11,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DefaultLocale, ListItemsPerBatch, ListItemsPerPage } from 'consts';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { StakingContext } from 'contexts/Staking';
 import { useTheme } from 'contexts/Themes';
@@ -23,6 +23,7 @@ import { Identity } from 'library/ListItem/Labels/Identity';
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity';
 import { locales } from 'locale';
 import type { AnySubscan } from 'types';
+import { useNetwork } from 'contexts/Network';
 import { ItemWrapper } from '../Wrappers';
 import type { PayoutListProps } from '../types';
 import { PayoutListProvider, usePayoutList } from './context';
@@ -36,10 +37,10 @@ export const PayoutListInner = ({
 }: PayoutListProps) => {
   const { i18n, t } = useTranslation('pages');
   const { mode } = useTheme();
+  const { isReady } = useApi();
   const {
-    isReady,
-    network: { units, unit, colors },
-  } = useApi();
+    networkData: { units, unit, colors },
+  } = useNetwork();
   const { activeEra } = useNetworkMetrics();
   const { listFormat, setListFormat } = usePayoutList();
   const { validators } = useValidators();

--- a/src/pages/Payouts/Stats/LastEraPayout.tsx
+++ b/src/pages/Payouts/Stats/LastEraPayout.tsx
@@ -3,15 +3,14 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useStaking } from 'contexts/Staking';
 import { Number } from 'library/StatBoxList/Number';
+import { useNetwork } from 'contexts/Network';
 
 export const LastEraPayoutStat = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
+  const { unit, units } = useNetwork().networkData;
   const { staking } = useStaking();
-  const { unit, units } = network;
   const { lastReward } = staking;
 
   const lastRewardUnit = planckToUnit(lastReward, units).toNumber();

--- a/src/pages/Pools/Create/Summary/index.tsx
+++ b/src/pages/Pools/Create/Summary/index.tsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { unitToPlanck } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
@@ -19,14 +18,16 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { SubmitTx } from 'library/SubmitTx';
+import { useNetwork } from 'contexts/Network';
+import { useApi } from 'contexts/Api';
 import { SummaryWrapper } from './Wrapper';
 
 export const Summary = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
+  const { api } = useApi();
   const {
-    api,
-    network: { units, unit },
-  } = useApi();
+    networkData: { units, unit },
+  } = useNetwork();
   const { stats } = usePoolsConfig();
   const { newBatchCall } = useBatchCall();
   const { getSetupProgress, removeSetupProgress } = useSetup();

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -4,7 +4,6 @@
 import { faLockOpen } from '@fortawesome/free-solid-svg-icons';
 import { ButtonPrimary, ButtonRow, PageRow } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
@@ -13,10 +12,11 @@ import { useTransferOptions } from 'contexts/TransferOptions';
 import { useUi } from 'contexts/UI';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ClosurePrompts = () => {
   const { t } = useTranslation('pages');
-  const { colors } = useApi().network;
+  const { colors } = useNetwork().networkData;
   const { activeAccount } = useConnect();
   const { mode } = useTheme();
   const { openModal } = useOverlay().modal;

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -23,17 +23,18 @@ import { useNetwork } from 'contexts/Network';
 export const ManageBond = () => {
   const { t } = useTranslation('pages');
 
-  const { networkData } = useNetwork();
+  const {
+    networkData: {
+      units,
+      brand: { token: Token },
+    },
+  } = useNetwork();
   const { openHelp } = useHelp();
   const { isPoolSyncing } = useUi();
   const { openModal } = useOverlay().modal;
   const { getTransferOptions } = useTransferOptions();
   const { activeAccount, isReadOnlyAccount } = useConnect();
   const { isBonding, isMember, selectedActivePool } = useActivePools();
-  const {
-    units,
-    brand: { token: Token },
-  } = networkData;
 
   const allTransferOptions = getTransferOptions(activeAccount);
   const {

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -10,7 +10,6 @@ import {
 } from '@polkadot-cloud/react';
 import { minDecimalPlaces, planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { useHelp } from 'contexts/Help';
 import { useActivePools } from 'contexts/Pools/ActivePools';
@@ -19,11 +18,12 @@ import { useUi } from 'contexts/UI';
 import { BondedChart } from 'library/BarChart/BondedChart';
 import { CardHeaderWrapper } from 'library/Card/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const ManageBond = () => {
   const { t } = useTranslation('pages');
 
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { openHelp } = useHelp();
   const { isPoolSyncing } = useUi();
   const { openModal } = useOverlay().modal;
@@ -33,7 +33,7 @@ export const ManageBond = () => {
   const {
     units,
     brand: { token: Token },
-  } = network;
+  } = networkData;
 
   const allTransferOptions = getTransferOptions(activeAccount);
   const {

--- a/src/pages/Pools/Home/Members.tsx
+++ b/src/pages/Pools/Home/Members.tsx
@@ -5,12 +5,12 @@ import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PageRow } from '@polkadot-cloud/react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { usePlugins } from 'contexts/Plugins';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { useTheme } from 'contexts/Themes';
 import { CardWrapper } from 'library/Card/Wrappers';
+import { useNetwork } from 'contexts/Network';
 import { MembersList as DefaultMemberList } from './MembersList/Default';
 import { MembersList as FetchPageMemberList } from './MembersList/FetchPage';
 
@@ -21,7 +21,7 @@ export const Members = () => {
   const { getMembersOfPoolFromNode } = usePoolMembers();
   const { selectedActivePool, isOwner, isBouncer, selectedPoolMemberCount } =
     useActivePools();
-  const { colors } = useApi().network;
+  const { colors } = useNetwork().networkData;
 
   const listTitle = `${t('pools.poolMember', {
     count: selectedPoolMemberCount,

--- a/src/pages/Pools/Home/MembersList/Default.tsx
+++ b/src/pages/Pools/Home/MembersList/Default.tsx
@@ -9,7 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ListItemsPerBatch, ListItemsPerPage } from 'consts';
 import { useApi } from 'contexts/Api';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import type { PoolMember } from 'contexts/Pools/types';
 import { useTheme } from 'contexts/Themes';
@@ -18,6 +18,7 @@ import { MotionContainer } from 'library/List/MotionContainer';
 import { Pagination } from 'library/List/Pagination';
 import { ListProvider, useList } from 'library/List/context';
 import type { Sync } from 'types';
+import { useNetwork } from 'contexts/Network';
 import { Member } from './Member';
 import type { DefaultMembersListProps } from './types';
 
@@ -30,10 +31,10 @@ export const MembersListInner = ({
   disableThrottle = false,
 }: DefaultMembersListProps) => {
   const { t } = useTranslation('pages');
+  const { isReady } = useApi();
   const {
-    isReady,
-    network: { colors },
-  } = useApi();
+    networkData: { colors },
+  } = useNetwork();
   const provider = useList();
   const { mode } = useTheme();
   const { activeEra } = useNetworkMetrics();

--- a/src/pages/Pools/Home/MembersList/FetchPage.tsx
+++ b/src/pages/Pools/Home/MembersList/FetchPage.tsx
@@ -7,7 +7,6 @@ import { motion } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ListItemsPerBatch, ListItemsPerPage } from 'consts';
-import { useApi } from 'contexts/Api';
 import { useConnect } from 'contexts/Connect';
 import { usePlugins } from 'contexts/Plugins';
 import { useActivePools } from 'contexts/Pools/ActivePools';
@@ -19,6 +18,7 @@ import { Header, List, Wrapper as ListWrapper } from 'library/List';
 import { MotionContainer } from 'library/List/MotionContainer';
 import { Pagination } from 'library/List/Pagination';
 import { ListProvider, useList } from 'library/List/context';
+import { useNetwork } from 'contexts/Network';
 import { Member } from './Member';
 import type { FetchpageMembersListProps } from './types';
 
@@ -32,8 +32,8 @@ export const MembersListInner = ({
 }: FetchpageMembersListProps) => {
   const { t } = useTranslation('pages');
   const {
-    network: { colors, name },
-  } = useApi();
+    networkData: { colors, name },
+  } = useNetwork();
   const provider = useList();
   const { mode } = useTheme();
   const { activeAccount } = useConnect();

--- a/src/pages/Pools/Home/MembersList/FetchPage.tsx
+++ b/src/pages/Pools/Home/MembersList/FetchPage.tsx
@@ -32,7 +32,8 @@ export const MembersListInner = ({
 }: FetchpageMembersListProps) => {
   const { t } = useTranslation('pages');
   const {
-    networkData: { colors, name },
+    network,
+    networkData: { colors },
   } = useNetwork();
   const provider = useList();
   const { mode } = useTheme();
@@ -109,7 +110,7 @@ export const MembersListInner = ({
     setFetchedPoolMembersApi('unsynced');
     setPoolMembersApi([]);
     setPage(1);
-  }, [name]);
+  }, [network]);
 
   // Configure list when network is ready to fetch.
   useEffect(() => {

--- a/src/pages/Pools/Home/MembersList/Member.tsx
+++ b/src/pages/Pools/Home/MembersList/Member.tsx
@@ -10,7 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMenu } from 'contexts/Menu';
-import { useNetworkMetrics } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { useList } from 'library/List/context';

--- a/src/pages/Pools/Home/PoolStats/Announcements.tsx
+++ b/src/pages/Pools/Home/PoolStats/Announcements.tsx
@@ -10,13 +10,15 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { Announcement as AnnouncementLoader } from 'library/Loader/Announcement';
+import { useNetwork } from 'contexts/Network';
 import { Item } from './Wrappers';
 
 export const Announcements = () => {
   const { t } = useTranslation('pages');
-  const { network, consts } = useApi();
+  const { consts } = useApi();
+  const { networkData } = useNetwork();
   const { selectedActivePool } = useActivePools();
-  const { units, unit } = network;
+  const { units, unit } = networkData;
   const { rewardAccountBalance } = selectedActivePool || {};
   const { totalRewardsClaimed } = selectedActivePool?.rewardPool || {};
   const { existentialDeposit } = consts;
@@ -33,7 +35,7 @@ export const Announcements = () => {
     totalRewardsClaimed
       ? new BigNumber(rmCommas(totalRewardsClaimed))
       : new BigNumber(0),
-    network.units
+    networkData.units
   );
 
   const container = {

--- a/src/pages/Pools/Home/PoolStats/Announcements.tsx
+++ b/src/pages/Pools/Home/PoolStats/Announcements.tsx
@@ -16,9 +16,10 @@ import { Item } from './Wrappers';
 export const Announcements = () => {
   const { t } = useTranslation('pages');
   const { consts } = useApi();
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { selectedActivePool } = useActivePools();
-  const { units, unit } = networkData;
   const { rewardAccountBalance } = selectedActivePool || {};
   const { totalRewardsClaimed } = selectedActivePool?.rewardPool || {};
   const { existentialDeposit } = consts;
@@ -35,7 +36,7 @@ export const Announcements = () => {
     totalRewardsClaimed
       ? new BigNumber(rmCommas(totalRewardsClaimed))
       : new BigNumber(0),
-    networkData.units
+    units
   );
 
   const container = {

--- a/src/pages/Pools/Home/PoolStats/index.tsx
+++ b/src/pages/Pools/Home/PoolStats/index.tsx
@@ -4,17 +4,17 @@
 import { planckToUnit, rmCommas } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
 import { usePoolCommission } from 'library/Hooks/usePoolCommission';
 import { StatsHead } from 'library/StatsHead';
+import { useNetwork } from 'contexts/Network';
 import { Announcements } from './Announcements';
 import { Wrapper } from './Wrappers';
 
 export const PoolStats = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
+  const { networkData } = useNetwork();
   const { selectedActivePool, selectedPoolMemberCount } = useActivePools();
   const { getCurrentCommission } = usePoolCommission();
 
@@ -23,7 +23,7 @@ export const PoolStats = () => {
 
   const bonded = planckToUnit(
     new BigNumber(points ? rmCommas(points) : 0),
-    network.units
+    networkData.units
   )
     .decimalPlaces(3)
     .toFormat();
@@ -62,7 +62,7 @@ export const PoolStats = () => {
     },
     {
       label: t('pools.totalBonded'),
-      value: `${bonded} ${network.unit}`,
+      value: `${bonded} ${networkData.unit}`,
     }
   );
 

--- a/src/pages/Pools/Home/PoolStats/index.tsx
+++ b/src/pages/Pools/Home/PoolStats/index.tsx
@@ -14,7 +14,9 @@ import { Wrapper } from './Wrappers';
 
 export const PoolStats = () => {
   const { t } = useTranslation('pages');
-  const { networkData } = useNetwork();
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { selectedActivePool, selectedPoolMemberCount } = useActivePools();
   const { getCurrentCommission } = usePoolCommission();
 
@@ -23,7 +25,7 @@ export const PoolStats = () => {
 
   const bonded = planckToUnit(
     new BigNumber(points ? rmCommas(points) : 0),
-    networkData.units
+    units
   )
     .decimalPlaces(3)
     .toFormat();
@@ -62,7 +64,7 @@ export const PoolStats = () => {
     },
     {
       label: t('pools.totalBonded'),
-      value: `${bonded} ${networkData.unit}`,
+      value: `${bonded} ${unit}`,
     }
   );
 

--- a/src/pages/Pools/Home/Stats/MinCreateBond.tsx
+++ b/src/pages/Pools/Home/Stats/MinCreateBond.tsx
@@ -3,21 +3,21 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { Number } from 'library/StatBoxList/Number';
+import { useNetwork } from 'contexts/Network';
 
 export const MinCreateBondStat = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
-  const { units } = network;
+  const { networkData } = useNetwork();
+  const { units, unit } = networkData;
   const { stats } = usePoolsConfig();
 
   const params = {
     label: t('pools.minimumToCreatePool'),
     value: planckToUnit(stats.minCreateBond, units).toNumber(),
     decimals: 3,
-    unit: network.unit,
+    unit,
     helpKey: 'Minimum To Create Pool',
   };
   return <Number {...params} />;

--- a/src/pages/Pools/Home/Stats/MinCreateBond.tsx
+++ b/src/pages/Pools/Home/Stats/MinCreateBond.tsx
@@ -9,8 +9,9 @@ import { useNetwork } from 'contexts/Network';
 
 export const MinCreateBondStat = () => {
   const { t } = useTranslation('pages');
-  const { networkData } = useNetwork();
-  const { units, unit } = networkData;
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { stats } = usePoolsConfig();
 
   const params = {

--- a/src/pages/Pools/Home/Stats/MinJoinBond.tsx
+++ b/src/pages/Pools/Home/Stats/MinJoinBond.tsx
@@ -9,8 +9,9 @@ import { useNetwork } from 'contexts/Network';
 
 export const MinJoinBondStat = () => {
   const { t } = useTranslation('pages');
-  const { networkData } = useNetwork();
-  const { units, unit } = networkData;
+  const {
+    networkData: { units, unit },
+  } = useNetwork();
   const { stats } = usePoolsConfig();
 
   const params = {

--- a/src/pages/Pools/Home/Stats/MinJoinBond.tsx
+++ b/src/pages/Pools/Home/Stats/MinJoinBond.tsx
@@ -3,21 +3,21 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { Number } from 'library/StatBoxList/Number';
+import { useNetwork } from 'contexts/Network';
 
 export const MinJoinBondStat = () => {
   const { t } = useTranslation('pages');
-  const { network } = useApi();
-  const { units } = network;
+  const { networkData } = useNetwork();
+  const { units, unit } = networkData;
   const { stats } = usePoolsConfig();
 
   const params = {
     label: t('pools.minimumToJoinPool'),
     value: planckToUnit(stats.minJoinBond, units).toNumber(),
     decimals: 3,
-    unit: ` ${network.unit}`,
+    unit: ` ${unit}`,
     helpKey: 'Minimum To Join Pool',
   };
   return <Number {...params} />;

--- a/src/pages/Pools/Home/Status/RewardsStatus.tsx
+++ b/src/pages/Pools/Home/Status/RewardsStatus.tsx
@@ -11,13 +11,14 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useUi } from 'contexts/UI';
 import { Stat } from 'library/Stat';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 
 export const RewardsStatus = () => {
   const { t } = useTranslation('pages');
   const {
-    network: { units },
-    isReady,
-  } = useApi();
+    networkData: { units },
+  } = useNetwork();
+  const { isReady } = useApi();
   const { isPoolSyncing } = useUi();
   const { openModal } = useOverlay().modal;
   const { selectedActivePool } = useActivePools();

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -35,11 +35,11 @@ export const Roles = ({
   listenIsValid = () => {},
 }: RolesProps) => {
   const { t } = useTranslation('pages');
+  const { isReady } = useApi();
   const { openHelp } = useHelp();
+  const { network } = useNetwork();
   const { isPoolSyncing } = useUi();
   const { openModal } = useOverlay().modal;
-  const { isReady } = useApi();
-  const { networkData } = useNetwork();
   const { fetchIdentitiesMetaBatch } = useIdentities();
   const { isOwner, selectedActivePool } = useActivePools();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -77,7 +77,7 @@ export const Roles = ({
     setIsEditing(false);
     setRoleEdits(initialiseEdits);
     setFetched(false);
-  }, [activeAccount, networkData]);
+  }, [activeAccount, network]);
 
   // fetch accounts meta batch
   useEffect(() => {

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -21,6 +21,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useUi } from 'contexts/UI';
 import { CardHeaderWrapper } from 'library/Card/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import { useNetwork } from 'contexts/Network';
 import { RolesWrapper } from '../Home/ManagePool/Wrappers';
 import { PoolAccount } from '../PoolAccount';
 import { RoleEditInput } from './RoleEditInput';
@@ -37,7 +38,8 @@ export const Roles = ({
   const { openHelp } = useHelp();
   const { isPoolSyncing } = useUi();
   const { openModal } = useOverlay().modal;
-  const { isReady, network } = useApi();
+  const { isReady } = useApi();
+  const { networkData } = useNetwork();
   const { fetchIdentitiesMetaBatch } = useIdentities();
   const { isOwner, selectedActivePool } = useActivePools();
   const { activeAccount, isReadOnlyAccount } = useConnect();
@@ -75,7 +77,7 @@ export const Roles = ({
     setIsEditing(false);
     setRoleEdits(initialiseEdits);
     setFetched(false);
-  }, [activeAccount, network]);
+  }, [activeAccount, networkData]);
 
   // fetch accounts meta batch
   useEffect(() => {


### PR DESCRIPTION
Fixes a longstanding issue of having to use `name` as the network name. Now, `network` can be used instead, which is more intuitive.

Also prepares context structure to separate active network from other providers.

- Separates active network from `API` context and improves network API.
- Network metrics context folder renamed to `NetworkMetrics`.