### PR TITLE
Providers to hook, provide `network` to providers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { DefaultNetwork } from 'consts';
 import { ThemesProvider } from 'contexts/Themes';
 import { i18next } from 'locale';
 import { Providers } from 'Providers';
+import { NetworkProvider } from 'contexts/Network';
 
 export const App: React.FC = () => {
   let network = localStorage.getItem('network');
@@ -19,7 +20,9 @@ export const App: React.FC = () => {
   return (
     <I18nextProvider i18n={i18next}>
       <ThemesProvider>
-        <Providers />
+        <NetworkProvider>
+          <Providers />
+        </NetworkProvider>
       </ThemesProvider>
     </I18nextProvider>
   );

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -37,46 +37,55 @@ import { ValidatorsProvider } from 'contexts/Validators/ValidatorEntries';
 import { FavoriteValidatorsProvider } from 'contexts/Validators/FavoriteValidators';
 import { withProviders } from 'library/Hooks';
 import { PayoutsProvider } from 'contexts/Payouts';
-import { NetworkProvider } from 'contexts/Network';
 import { PolkawatchProvider } from 'contexts/Plugins/Polkawatch';
+import { useNetwork } from 'contexts/Network';
+
+// Embed providers from hook.
+export const Providers = () => {
+  const ProvidersJSX = useProviders();
+  return <ProvidersJSX />;
+};
 
 // !! Provider order matters.
-export const Providers = withProviders(
-  NetworkProvider,
-  APIProvider,
-  FiltersProvider,
-  NotificationsProvider,
-  PluginsProvider,
-  VaultHardwareProvider,
-  LedgerHardwareProvider,
-  ExtensionsProvider,
-  ConnectProvider,
-  HelpProvider,
-  NetworkMetricsProvider,
-  SubscanProvider,
-  PolkawatchProvider,
-  IdentitiesProvider,
-  ProxiesProvider,
-  BalancesProvider,
-  BondedProvider,
-  StakingProvider,
-  PoolsConfigProvider,
-  BondedPoolsProvider,
-  PoolMembershipsProvider,
-  PoolMembersProvider,
-  ActivePoolsProvider,
-  TransferOptionsProvider,
-  ValidatorsProvider,
-  FavoriteValidatorsProvider,
-  FastUnstakeProvider,
-  PayoutsProvider,
-  UIProvider,
-  SetupProvider,
-  MenuProvider,
-  TooltipProvider,
-  TxMetaProvider,
-  ExtrinsicsProvider,
-  OverlayProvider,
-  PromptProvider,
-  MigrateProvider
-)(ThemedRouter);
+export const useProviders = () => {
+  const { network } = useNetwork();
+
+  return withProviders(
+    [APIProvider, { network }],
+    FiltersProvider,
+    NotificationsProvider,
+    PluginsProvider,
+    VaultHardwareProvider,
+    LedgerHardwareProvider,
+    ExtensionsProvider,
+    ConnectProvider,
+    HelpProvider,
+    NetworkMetricsProvider,
+    SubscanProvider,
+    PolkawatchProvider,
+    IdentitiesProvider,
+    ProxiesProvider,
+    BalancesProvider,
+    BondedProvider,
+    StakingProvider,
+    PoolsConfigProvider,
+    BondedPoolsProvider,
+    PoolMembershipsProvider,
+    PoolMembersProvider,
+    ActivePoolsProvider,
+    TransferOptionsProvider,
+    ValidatorsProvider,
+    FavoriteValidatorsProvider,
+    FastUnstakeProvider,
+    PayoutsProvider,
+    UIProvider,
+    SetupProvider,
+    MenuProvider,
+    TooltipProvider,
+    TxMetaProvider,
+    ExtrinsicsProvider,
+    OverlayProvider,
+    PromptProvider,
+    MigrateProvider
+  )(ThemedRouter);
+};

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -24,12 +24,15 @@ import type {
 } from 'contexts/Api/types';
 import type { AnyApi, NetworkName } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
-import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
 
-export const APIProvider = ({ children }: { children: React.ReactNode }) => {
-  const { network } = useNetwork();
-
+export const APIProvider = ({
+  children,
+  network,
+}: {
+  children: React.ReactNode;
+  network: NetworkName;
+}) => {
   // Store povider instance.
   const [provider, setProvider] = useState<WsProvider | ScProvider | null>(
     null

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -5,7 +5,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 import { ScProvider } from '@polkadot/rpc-provider/substrate-connect';
 import { makeCancelable, rmCommas } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
-import React, { useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { NetworkList } from 'config/networks';
 import {
   FallbackBondingDuration,
@@ -20,19 +20,14 @@ import type {
   APIChainState,
   APIConstants,
   APIContextInterface,
+  APIProviderProps,
   ApiStatus,
 } from 'contexts/Api/types';
 import type { AnyApi, NetworkName } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import * as defaults from './defaults';
 
-export const APIProvider = ({
-  children,
-  network,
-}: {
-  children: React.ReactNode;
-  network: NetworkName;
-}) => {
+export const APIProvider = ({ children, network }: APIProviderProps) => {
   // Store povider instance.
   const [provider, setProvider] = useState<WsProvider | ScProvider | null>(
     null
@@ -274,8 +269,8 @@ export const APIProvider = ({
   );
 };
 
-export const APIContext = React.createContext<APIContextInterface>(
+export const APIContext = createContext<APIContextInterface>(
   defaults.defaultApiContext
 );
 
-export const useApi = () => React.useContext(APIContext);
+export const useApi = () => useContext(APIContext);

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -4,9 +4,15 @@
 import type { ApiPromise } from '@polkadot/api';
 import type { U8aLike } from '@polkadot/util/types';
 import type BigNumber from 'bignumber.js';
+import type { ReactNode } from 'react';
 import type { Network, NetworkName } from '../../types';
 
 export type ApiStatus = 'connecting' | 'connected' | 'disconnected';
+
+export interface APIProviderProps {
+  children: ReactNode;
+  network: NetworkName;
+}
 
 export interface NetworkState {
   name: NetworkName;

--- a/src/contexts/Connect/Hooks/useImportExtension.tsx
+++ b/src/contexts/Connect/Hooks/useImportExtension.tsx
@@ -84,7 +84,7 @@ export const useImportExtension = () => {
       .filter((j) => !newAccounts.find((i) => i.address === j.address));
     // check whether active account is present in forgotten accounts
     const activeGoneFromExtension = goneFromExtension.find(
-      (i) => i.address === getActiveAccountLocal(networkData)
+      (i) => i.address === getActiveAccountLocal(network, networkData.ss58)
     );
     // commit remove forgotten accounts
     forget(goneFromExtension);
@@ -117,8 +117,9 @@ export const useImportExtension = () => {
   //
   // checks if the local active account is in the extension.
   const getActiveExtensionAccount = (accounts: ImportedAccount[]) =>
-    accounts.find((a) => a.address === getActiveAccountLocal(networkData)) ??
-    null;
+    accounts.find(
+      (a) => a.address === getActiveAccountLocal(network, networkData.ss58)
+    ) ?? null;
 
   // Connect active extension account.
   //

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -4,7 +4,7 @@
 import Keyring from '@polkadot/keyring';
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
 import type { ExtensionAccount } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
-import type { Network, NetworkName } from 'types';
+import type { NetworkName } from 'types';
 import type { ExternalAccount } from './types';
 
 // extension utils
@@ -60,10 +60,10 @@ export const extensionIsLocal = (id: string) => {
 // account utils
 
 // gets local `activeAccount` for a network
-export const getActiveAccountLocal = (network: Network) => {
+export const getActiveAccountLocal = (network: NetworkName, ss58: number) => {
   const keyring = new Keyring();
-  keyring.setSS58Format(network.ss58);
-  let account = localStorageOrDefault(`${network.name}_active_account`, null);
+  keyring.setSS58Format(ss58);
+  let account = localStorageOrDefault(`${network}_active_account`, null);
   if (account !== null) {
     account = keyring.addFromAddress(account).address;
   }
@@ -100,15 +100,14 @@ export const getInExternalAccounts = (
 
 // removes supplied accounts from local `external_accounts`.
 export const removeLocalExternalAccounts = (
-  network: Network,
+  network: NetworkName,
   accounts: ExternalAccount[]
 ) => {
-  let localExternalAccounts = getLocalExternalAccounts(network.name);
+  let localExternalAccounts = getLocalExternalAccounts(network);
   localExternalAccounts = localExternalAccounts.filter(
     (a) =>
-      accounts.find(
-        (b) => b.address === a.address && a.network === network.name
-      ) === undefined
+      accounts.find((b) => b.address === a.address && a.network === network) ===
+      undefined
   );
   localStorage.setItem(
     'external_accounts',

--- a/src/contexts/Connect/index.tsx
+++ b/src/contexts/Connect/index.tsx
@@ -199,7 +199,7 @@ export const ConnectProvider = ({
     const externalToForget = forget.filter((i) => 'network' in i);
     if (externalToForget.length) {
       removeLocalExternalAccounts(
-        networkData,
+        network,
         externalToForget as ExternalAccount[]
       );
     }
@@ -243,7 +243,8 @@ export const ConnectProvider = ({
     if (localAccounts.length) {
       const activeAccountInSet =
         localAccounts.find(
-          ({ address }) => address === getActiveAccountLocal(networkData)
+          ({ address }) =>
+            address === getActiveAccountLocal(network, networkData.ss58)
         ) ?? null;
 
       // remove already-imported accounts.

--- a/src/library/Hooks/index.tsx
+++ b/src/library/Hooks/index.tsx
@@ -1,7 +1,9 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { FC } from 'react';
 import { useEffect } from 'react';
+import type { AnyJson } from 'types';
 
 /*
  * A hook that alerts clicks outside of the passed ref.
@@ -33,17 +35,16 @@ export const useOutsideAlerter = (
  * A hook that wraps multiple context providers to a component and makes each parent context accessible.
  */
 export const withProviders =
-  (...providers: any) =>
-  (WrappedComponent: any) =>
-  (props: any) =>
+  (...providers: Array<FC<AnyJson> | [FC<AnyJson>, AnyJson]>) =>
+  (WrappedComponent: FC<AnyJson>) =>
+  (props: AnyJson) =>
     providers.reduceRight(
-      (acc: any, prov: any) => {
-        let Provider = prov;
+      (acc, prov) => {
         if (Array.isArray(prov)) {
-          Provider = prov[0];
+          const Provider = prov[0];
           return <Provider {...prov[1]}>{acc}</Provider>;
         }
-
+        const Provider = prov;
         return <Provider>{acc}</Provider>;
       },
       <WrappedComponent {...props} />


### PR DESCRIPTION
This PR expands `Providers`, which are now provided via a hook, which allows state from the `Network` context to be passed into the providers as props.

This refactored component structure is required to abstract `Connect` provider functionality into Polkadot Cloud providers.

Also removes `any` types from `withProviders` hook.