### PR TITLE
Refactor `withProviders` to be pure function

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,8 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { ThemedRouter } from 'Themes';
-import { APIProvider } from 'contexts/Api';
 import { BalancesProvider } from 'contexts/Balances';
 import { BondedProvider } from 'contexts/Bonded';
 import { ConnectProvider } from 'contexts/Connect';
@@ -35,22 +33,21 @@ import { TxMetaProvider } from 'contexts/TxMeta';
 import { UIProvider } from 'contexts/UI';
 import { ValidatorsProvider } from 'contexts/Validators/ValidatorEntries';
 import { FavoriteValidatorsProvider } from 'contexts/Validators/FavoriteValidators';
-import { withProviders } from 'library/Hooks';
 import { PayoutsProvider } from 'contexts/Payouts';
 import { PolkawatchProvider } from 'contexts/Plugins/Polkawatch';
 import { useNetwork } from 'contexts/Network';
+import { APIProvider } from 'contexts/Api';
+import { ThemedRouter } from 'Themes';
+import type { AnyJson } from 'types';
+import type { FC } from 'react';
+import { withProviders } from 'library/Hooks';
 
 // Embed providers from hook.
 export const Providers = () => {
-  const ProvidersJSX = useProviders();
-  return <ProvidersJSX />;
-};
-
-// !! Provider order matters.
-export const useProviders = () => {
   const { network } = useNetwork();
 
-  return withProviders(
+  // !! Provider order matters
+  const providers: Array<FC<AnyJson> | [FC<AnyJson>, AnyJson]> = [
     [APIProvider, { network }],
     FiltersProvider,
     NotificationsProvider,
@@ -86,6 +83,8 @@ export const useProviders = () => {
     ExtrinsicsProvider,
     OverlayProvider,
     PromptProvider,
-    MigrateProvider
-  )(ThemedRouter);
+    MigrateProvider,
+  ];
+
+  return <>{withProviders(providers, ThemedRouter)}</>;
 };

--- a/src/library/Hooks/index.tsx
+++ b/src/library/Hooks/index.tsx
@@ -34,7 +34,7 @@ export const useOutsideAlerter = (
 // A pure function that applies an arbitrary amount of context providers to a wrapped
 // component.
 export const withProviders = (
-  providers: Array<FC<AnyJson> | [FC<AnyJson>, AnyJson]>,
+  providers: (FC<AnyJson> | [FC<AnyJson>, AnyJson])[],
   Wrapped: FC
 ) =>
   providers.reduceRight(

--- a/src/library/Hooks/index.tsx
+++ b/src/library/Hooks/index.tsx
@@ -31,21 +31,20 @@ export const useOutsideAlerter = (
   }, [ref]);
 };
 
-/*
- * A hook that wraps multiple context providers to a component and makes each parent context accessible.
- */
-export const withProviders =
-  (...providers: Array<FC<AnyJson> | [FC<AnyJson>, AnyJson]>) =>
-  (WrappedComponent: FC<AnyJson>) =>
-  (props: AnyJson) =>
-    providers.reduceRight(
-      (acc, prov) => {
-        if (Array.isArray(prov)) {
-          const Provider = prov[0];
-          return <Provider {...prov[1]}>{acc}</Provider>;
-        }
-        const Provider = prov;
-        return <Provider>{acc}</Provider>;
-      },
-      <WrappedComponent {...props} />
-    );
+// A pure function that applies an arbitrary amount of context providers to a wrapped
+// component.
+export const withProviders = (
+  providers: Array<FC<AnyJson> | [FC<AnyJson>, AnyJson]>,
+  Wrapped: FC
+) =>
+  providers.reduceRight(
+    (acc, prov) => {
+      if (Array.isArray(prov)) {
+        const Provider = prov[0];
+        return <Provider {...prov[1]}>{acc}</Provider>;
+      }
+      const Provider = prov;
+      return <Provider>{acc}</Provider>;
+    },
+    <Wrapped />
+  );


### PR DESCRIPTION
Fixes an issue where `withProviders` was resulting in an anonymous component within the hierarchy, which was resulting in unwanted reloads of public assets on network change (Lottie files).