### PR TITLE
feat(refactor): use simple cloud react imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ledgerhq/hw-transport-webhid": "^6.27.19",
     "@polkadot-cloud/assets": "^0.1.16",
     "@polkadot-cloud/core": "^1.0.7",
-    "@polkadot-cloud/react": "^0.1.70",
+    "@polkadot-cloud/react": "^0.1.71",
     "@polkadot-cloud/utils": "^0.0.20",
     "@polkadot/api": "^10.9.1",
     "@polkadot/keyring": "^12.1.1",

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -3,7 +3,10 @@
 
 import { BalancesProvider } from 'contexts/Balances';
 import { BondedProvider } from 'contexts/Bonded';
-import { ExtensionsProvider, OverlayProvider } from '@polkadot-cloud/react';
+import {
+  ExtensionsProvider,
+  OverlayProvider,
+} from '@polkadot-cloud/react/providers';
 import { ExtrinsicsProvider } from 'contexts/Extrinsics';
 import { FastUnstakeProvider } from 'contexts/FastUnstake';
 import { FiltersProvider } from 'contexts/Filters';

--- a/src/contexts/Connect/ExtensionAccounts/index.tsx
+++ b/src/contexts/Connect/ExtensionAccounts/index.tsx
@@ -5,20 +5,18 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import type {
   ExtensionAccountsContextInterface,
   ExtensionAccountsProviderProps,
-} from '@polkadot-cloud/react/connect/ExtensionAccountsProvider/types';
+  ImportedAccount,
+  ExtensionInjected,
+  ExtensionInterface,
+} from '@polkadot-cloud/react/types';
 import {
   useEffectIgnoreInitial,
   useExtensions,
 } from '@polkadot-cloud/react/hooks';
 import type { AnyApi } from 'types';
 import type { VoidFn } from '@polkadot/api/types';
-import type {
-  ExtensionInjected,
-  ExtensionInterface,
-} from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
 import { localStorageOrDefault, setStateWithRef } from '@polkadot-cloud/utils';
 import { defaultExtensionAccountsContext } from '@polkadot-cloud/react/connect/ExtensionAccountsProvider/defaults';
-import type { ImportedAccount } from '@polkadot-cloud/react/connect/types';
 import { useImportExtension } from './useImportExtension';
 // TODO: the functions in this hook need to be moved to the cloud.
 import { extensionIsLocal, removeFromLocalExtensions } from '../Utils';

--- a/src/contexts/Connect/ExtensionAccounts/useImportExtension.tsx
+++ b/src/contexts/Connect/ExtensionAccounts/useImportExtension.tsx
@@ -7,12 +7,12 @@ import { useExtensions } from '@polkadot-cloud/react/hooks';
 import type {
   ExtensionAccount,
   ExtensionInterface,
-} from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
+  ImportedAccount,
+  HandleImportExtension,
+} from '@polkadot-cloud/react/types';
 import type { AnyFunction } from 'types';
 import { useNetwork } from 'contexts/Network';
 import { defaultHandleImportExtension } from '@polkadot-cloud/react/connect/ExtensionAccountsProvider/defaults';
-import type { ImportedAccount } from '@polkadot-cloud/react/connect/types';
-import type { HandleImportExtension } from '@polkadot-cloud/react/connect/ExtensionAccountsProvider/types';
 import {
   addToLocalExtensions,
   getActiveAccountLocal,

--- a/src/contexts/Connect/ImportedAccounts/index.tsx
+++ b/src/contexts/Connect/ImportedAccounts/index.tsx
@@ -4,7 +4,7 @@
 import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';
 import type { MaybeAddress } from 'types';
-import type { ExternalAccount } from '@polkadot-cloud/react/connect/types';
+import type { ExternalAccount } from '@polkadot-cloud/react/types';
 import { defaultImportedAccountsContext } from './defaults';
 import type { ImportedAccountsContextInterface } from './types';
 import { useExtensionAccounts } from '../ExtensionAccounts';

--- a/src/contexts/Connect/ImportedAccounts/types.ts
+++ b/src/contexts/Connect/ImportedAccounts/types.ts
@@ -1,9 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type {
+  ExtensionAccount,
+  ImportedAccount,
+} from '@polkadot-cloud/react/types';
 import type { MaybeAddress } from 'types';
-import type { ExtensionAccount } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
-import type { ImportedAccount } from '@polkadot-cloud/react/connect/types';
 
 export interface ImportedAccountsContextInterface {
   accounts: ImportedAccount[];

--- a/src/contexts/Connect/OtherAccounts/index.tsx
+++ b/src/contexts/Connect/OtherAccounts/index.tsx
@@ -19,7 +19,7 @@ import Keyring from '@polkadot/keyring';
 import type {
   ExternalAccount,
   ImportedAccount,
-} from '@polkadot-cloud/react/connect/types';
+} from '@polkadot-cloud/react/types';
 import { useExtensionAccounts } from '../ExtensionAccounts';
 import {
   getActiveAccountLocal,

--- a/src/contexts/Connect/OtherAccounts/types.ts
+++ b/src/contexts/Connect/OtherAccounts/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { ImportedAccount } from '@polkadot-cloud/react/connect/types';
+import type { ImportedAccount } from '@polkadot-cloud/react/types';
 import type { MaybeAddress, NetworkName } from 'types';
 
 export interface OtherAccountsContextInterface {

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -3,9 +3,11 @@
 
 import Keyring from '@polkadot/keyring';
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
-import type { ExtensionAccount } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
+import type {
+  ExtensionAccount,
+  ExternalAccount,
+} from '@polkadot-cloud/react/types';
 import type { NetworkName } from 'types';
-import type { ExternalAccount } from '@polkadot-cloud/react/connect/types';
 
 // extension utils
 

--- a/src/contexts/Hardware/Ledger.tsx
+++ b/src/contexts/Hardware/Ledger.tsx
@@ -7,7 +7,7 @@ import { localStorageOrDefault, setStateWithRef } from '@polkadot-cloud/utils';
 import { newSubstrateApp } from '@zondax/ledger-substrate';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { LedgerAccount } from '@polkadot-cloud/react/connect/types';
+import type { LedgerAccount } from '@polkadot-cloud/react/types';
 import type { AnyFunction, AnyJson, MaybeString } from 'types';
 import { useNetwork } from 'contexts/Network';
 import {

--- a/src/contexts/Hardware/Utils.tsx
+++ b/src/contexts/Hardware/Utils.tsx
@@ -4,10 +4,7 @@
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
 import { LedgerApps } from 'config/ledger';
 import type { MaybeString } from 'types';
-import type {
-  LedgerAccount,
-  VaultAccount,
-} from '@polkadot-cloud/react/connect/types';
+import type { LedgerAccount, VaultAccount } from '@polkadot-cloud/react/types';
 import type { LedgerAddress } from './types';
 
 // Gets ledger app from local storage, fallback to first entry.

--- a/src/contexts/Hardware/Vault.tsx
+++ b/src/contexts/Hardware/Vault.tsx
@@ -3,7 +3,7 @@
 
 import { ellipsisFn, setStateWithRef } from '@polkadot-cloud/utils';
 import React, { useEffect, useRef, useState } from 'react';
-import type { VaultAccount } from '@polkadot-cloud/react/connect/types';
+import type { VaultAccount } from '@polkadot-cloud/react/types';
 import { useNetwork } from 'contexts/Network';
 import { getLocalVaultAccounts, isLocalNetworkAddress } from './Utils';
 import { defaultVaultHardwareContext } from './defaults';

--- a/src/contexts/Hardware/types.ts
+++ b/src/contexts/Hardware/types.ts
@@ -1,10 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-  LedgerAccount,
-  VaultAccount,
-} from '@polkadot-cloud/react/connect/types';
+import type { LedgerAccount, VaultAccount } from '@polkadot-cloud/react/types';
 import type { FunctionComponent, SVGProps } from 'react';
 import type { AnyJson, MaybeString, NetworkName } from 'types';
 

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -11,7 +11,7 @@ import {
 import BigNumber from 'bignumber.js';
 import React, { useRef, useState } from 'react';
 import { useBalances } from 'contexts/Balances';
-import type { ExternalAccount } from '@polkadot-cloud/react/connect/types';
+import type { ExternalAccount } from '@polkadot-cloud/react/types';
 import type { PayeeConfig, PayeeOptions } from 'contexts/Setup/types';
 import type {
   EraStakers,

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -6,7 +6,7 @@ import BigNumber from 'bignumber.js';
 import React, { useEffect, useRef, useState } from 'react';
 import { SideMenuStickyThreshold } from 'consts';
 import { useBalances } from 'contexts/Balances';
-import type { ImportedAccount } from '@polkadot-cloud/react/connect/types';
+import type { ImportedAccount } from '@polkadot-cloud/react/types';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';

--- a/src/library/Form/types.ts
+++ b/src/library/Form/types.ts
@@ -3,9 +3,11 @@
 
 import type BigNumber from 'bignumber.js';
 import type { Balance } from 'contexts/Balances/types';
-import type { ExtensionAccount } from '@polkadot-cloud/react/connect/ExtensionsProvider/types';
+import type {
+  ExtensionAccount,
+  ExternalAccount,
+} from '@polkadot-cloud/react/types';
 import type { BondFor, MaybeAddress } from 'types';
-import type { ExternalAccount } from '@polkadot-cloud/react/connect/types';
 
 export interface ExtensionAccountItem extends ExtensionAccount {
   active?: boolean;

--- a/src/library/SubmitTx/ManualSign/Ledger.tsx
+++ b/src/library/SubmitTx/ManualSign/Ledger.tsx
@@ -14,7 +14,7 @@ import { useLedgerLoop } from 'library/Hooks/useLedgerLoop';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
-import type { LedgerAccount } from '@polkadot-cloud/react/connect/types';
+import type { LedgerAccount } from '@polkadot-cloud/react/types';
 import type { SubmitProps } from '../types';
 
 export const Ledger = ({

--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -19,7 +19,7 @@ import { AccountInput } from 'library/AccountInput';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
-import type { ExternalAccount } from '@polkadot-cloud/react/connect/types';
+import type { ExternalAccount } from '@polkadot-cloud/react/types';
 import {
   ActionWithButton,
   ManualAccount,

--- a/src/modals/ImportLedger/Reset.tsx
+++ b/src/modals/ImportLedger/Reset.tsx
@@ -11,7 +11,7 @@ import { ConfirmWrapper } from 'library/Import/Wrappers';
 import type { AnyJson } from 'types';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
-import type { LedgerAccount } from '@polkadot-cloud/react/connect/types';
+import type { LedgerAccount } from '@polkadot-cloud/react/types';
 
 export const Reset = ({ removeLedgerAddress }: AnyJson) => {
   const { t } = useTranslation('modals');

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -4,7 +4,7 @@
 import { PageRow, PageTitle, RowSection } from '@polkadot-cloud/react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { PageTitleTabProps } from '@polkadot-cloud/react/base/types';
+import type { PageTitleTabProps } from '@polkadot-cloud/react/types';
 import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { CardWrapper } from 'library/Card/Wrappers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,10 +1453,10 @@
   resolved "https://registry.yarnpkg.com/@polkadot-cloud/core/-/core-1.0.7.tgz#ace2356c524c11553ea125fc1c5f7538ba6fd044"
   integrity sha512-EjlOfMNc+Nh5RzMXNoiwMogeDNyZ+Up7LIEiz1TlbpWuHcnAk3zuNdrGpJC3SHvUnjQ16GKDfELtAzFblTCdIg==
 
-"@polkadot-cloud/react@^0.1.70":
-  version "0.1.70"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/react/-/react-0.1.70.tgz#bf1195464c981235dd04a61e7950e7b0580898d7"
-  integrity sha512-T+budh+dPziEYmdxGIKt4pUKneCorFcgnUBPnmaYGMZJexmmmmfIt3WqkpTjCJHZzrXEJYYQKKf+vvPPAMlTpA==
+"@polkadot-cloud/react@^0.1.71":
+  version "0.1.71"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/react/-/react-0.1.71.tgz#64a80e14865f374cfea08901d0a90a5f345dedd0"
+  integrity sha512-Lcss11THRAYGbOuaq1sTR/cxxC0TeNusFGyhvV8uaMV4QLAfeinoljGbwO4w89pEKvkDYjLeL6G9WpY93CsZjg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.4.2"
     "@fortawesome/free-brands-svg-icons" "^6.4.2"


### PR DESCRIPTION
tidies up imports from `@polkadot-cloud/react`.