### PR TITLE
feat(ux): min non-zero bar segment width

### DIFF
--- a/src/library/BarChart/BondedChart.tsx
+++ b/src/library/BarChart/BondedChart.tsx
@@ -23,18 +23,27 @@ export const BondedChart = ({
   } = useNetwork();
   const totalUnlocking = unlocking.plus(unlocked);
 
+  const MinimumNoNZeroPercent = 13;
+
   // graph percentages
   const graphTotal = active.plus(totalUnlocking).plus(free);
   const graphActive = greaterThanZero(active)
-    ? active.dividedBy(graphTotal.multipliedBy(0.01))
+    ? BigNumber.max(
+        active.dividedBy(graphTotal.multipliedBy(0.01)),
+        MinimumNoNZeroPercent
+      )
     : new BigNumber(0);
 
   const graphUnlocking = greaterThanZero(totalUnlocking)
-    ? totalUnlocking.dividedBy(graphTotal.multipliedBy(0.01))
+    ? BigNumber.max(
+        totalUnlocking.dividedBy(graphTotal.multipliedBy(0.01)),
+        MinimumNoNZeroPercent
+      )
     : new BigNumber(0);
 
-  const graphFree = greaterThanZero(graphTotal)
-    ? new BigNumber(100).minus(graphActive).minus(graphUnlocking)
+  const remaining = new BigNumber(100).minus(graphActive).minus(graphUnlocking);
+  const graphFree = greaterThanZero(remaining)
+    ? BigNumber.max(remaining, MinimumNoNZeroPercent)
     : new BigNumber(0);
 
   return (

--- a/src/library/BarChart/Wrappers.ts
+++ b/src/library/BarChart/Wrappers.ts
@@ -4,14 +4,15 @@
 import styled from 'styled-components';
 
 export const BarChartWrapper = styled.div<{ $lessPadding?: boolean }>`
-  width: 100%;
   padding: ${(props) => (props.$lessPadding ? '0' : '0 0.5rem')};
   margin-top: 1rem;
+  width: 100%;
 
   .available {
-    width: 100%;
     display: flex;
     margin-top: 2.7rem;
+    width: 100%;
+
     > div {
       display: flex;
       flex-flow: row wrap;
@@ -80,11 +81,11 @@ export const Legend = styled.div`
 
 export const Bar = styled.div`
   background: var(--button-secondary-background);
-  display: flex;
-  width: 100%;
-  height: 3.75rem;
   border-radius: 0.65rem;
+  display: flex;
   overflow: hidden;
+  height: 3.75rem;
+  width: 100%;
 
   > div {
     position: relative;

--- a/src/modals/ValidatorGeo/index.tsx
+++ b/src/modals/ValidatorGeo/index.tsx
@@ -17,7 +17,7 @@ import type { ValidatorDetail } from '@polkawatch/ddp-client';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { PluginLabel } from 'library/PluginLabel';
 import { usePolkawatchApi } from 'contexts/Plugins/Polkawatch';
-import { usePlugins } from '../../contexts/Plugins';
+import { usePlugins } from 'contexts/Plugins';
 
 export const ValidatorGeo = () => {
   const { t } = useTranslation('modals');


### PR DESCRIPTION
Forces a min-width for `ManageBond` graphs when there is small non-zero bar value. 