### PR TITLE
Fix Forget read-only account bug

### DIFF
--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -32,7 +32,8 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
   const { openHelp } = useHelp();
   const { accounts } = useImportedAccounts();
   const { setModalResize } = useOverlay().modal;
-  const { forgetExternalAccounts, addExternalAccount } = useOtherAccounts();
+  const { forgetExternalAccounts, addExternalAccount, forgetOtherAccounts } =
+    useOtherAccounts();
 
   // get all external accounts
   const externalAccountsOnly = accounts.filter(
@@ -47,6 +48,7 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
   // forget account
   const forgetAccount = (account: ExternalAccount) => {
     forgetExternalAccounts([account]);
+    forgetOtherAccounts([account]);
     setModalResize();
   };
   return (


### PR DESCRIPTION
There is an existing bug, for read only accounts.
- Once the account is added, and then "Forget" is pressed, the account will be removed on the background and get disconnected (if connected), but will not dissappear from the Connect modal.

This PR fixes this misbehavior