### PR TITLE
feat: pool context optimisations

### DIFF
--- a/src/canvas/ManageNominations/index.tsx
+++ b/src/canvas/ManageNominations/index.tsx
@@ -25,6 +25,7 @@ import type {
   NominationSelection,
   NominationSelectionWithResetCounter,
 } from 'library/GenerateNominations/types';
+import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { RevertPrompt } from './Prompts/RevertPrompt';
 import { CanvasSubmitTxFooter, ManageNominationsWrapper } from './Wrappers';
 
@@ -42,6 +43,7 @@ export const ManageNominations = () => {
   const { addNotification } = useNotifications();
   const { selectedActivePool } = useActivePools();
   const { openPromptWith, closePrompt } = usePrompt();
+  const { updatePoolNominations } = useBondedPools();
   const controller = getBondedAccount(activeAccount);
   const { maxNominations } = consts;
   const bondFor = options?.bondFor || 'nominator';
@@ -128,7 +130,16 @@ export const ManageNominations = () => {
     callbackSubmit: () => {
       setCanvasStatus('closing');
     },
-    callbackInBlock: () => {},
+    callbackInBlock: () => {
+      if (isPool) {
+        // Upate bonded pool targets if updating pool nominations.
+        if (selectedActivePool?.id)
+          updatePoolNominations(
+            selectedActivePool.id,
+            newNominations.nominations.map((n) => n.address)
+          );
+      }
+    },
   });
 
   // Valid if there are between 1 and `maxNominations` nominations.

--- a/src/contexts/NetworkMetrics/index.tsx
+++ b/src/contexts/NetworkMetrics/index.tsx
@@ -101,7 +101,7 @@ export const NetworkMetricsProvider = ({
 
       // initiate subscription, add to unsubs.
       await Promise.all([subscribeToMetrics(), subscribeToActiveEra()]).then(
-        (u: any) => {
+        (u) => {
           unsubsRef.current = unsubsRef.current.concat(u);
         }
       );

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -91,6 +91,7 @@ export const ActivePoolsProvider = ({
       const p = membership?.poolId ? String(membership.poolId) : '0';
       return String(a.id) === p;
     }) || null;
+
   const getSelectedActivePool = () =>
     activePoolsRef.current.find((a) => a.id === Number(selectedPoolId)) || null;
 

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -19,4 +19,5 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   bondedPools: [],
   poolsMetaData: {},
   poolsNominations: {},
+  updatePoolNominations: (id, nominations) => {},
 };

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -18,5 +18,6 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   replacePoolRoles: (p, e) => {},
   poolSearchFilter: (l, k, v) => {},
   bondedPools: [],
+  poolsMetaData: {},
   meta: {},
 };

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -5,7 +5,6 @@
 import type { BondedPoolsContextState } from '../types';
 
 export const defaultBondedPoolsContext: BondedPoolsContextState = {
-  fetchPoolsMetaBatch: (k, v: [], r) => {},
   queryBondedPool: (p) => {},
   getBondedPool: (p) => null,
   updateBondedPools: (p) => {},
@@ -16,8 +15,8 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   getAccountRoles: (w) => null,
   getAccountPools: (w) => null,
   replacePoolRoles: (p, e) => {},
-  poolSearchFilter: (l, k, v) => {},
+  poolSearchFilter: (l, v) => {},
   bondedPools: [],
   poolsMetaData: {},
-  meta: {},
+  poolsNominations: {},
 };

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -50,7 +50,6 @@ export const BondedPoolsProvider = ({
   >({});
 
   // Fetch all bonded pool entries and their metadata.
-  // TODO: add syncing state to prevent duplicate fetches.
   const fetchBondedPools = async () => {
     if (!api || bondedPoolsSynced.current !== 'unsynced') return;
     bondedPoolsSynced.current = 'syncing';

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -211,13 +211,28 @@ export const BondedPoolsProvider = ({
 
   const updateBondedPools = (updatedPools: BondedPool[]) => {
     if (!updatedPools) return;
-
     setBondedPools(
       bondedPools.map(
         (original) =>
           updatedPools.find((updated) => updated.id === original.id) || original
       )
     );
+  };
+
+  const updatePoolNominations = (id: number, newTargets: string[]) => {
+    const newPoolsNominations = { ...poolsNominations };
+
+    let record = newPoolsNominations?.[id];
+    if (record !== null) {
+      record.targets = newTargets;
+    } else {
+      record = {
+        submittedIn: activeEra.index.toString(),
+        targets: newTargets,
+        suppressed: false,
+      };
+    }
+    setPoolsNominations(newPoolsNominations);
   };
 
   const removeFromBondedPools = (id: number) => {
@@ -361,6 +376,7 @@ export const BondedPoolsProvider = ({
         bondedPools,
         poolsMetaData,
         poolsNominations,
+        updatePoolNominations,
       }}
     >
       {children}

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -2,18 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
-import { setStateWithRef, shuffle } from '@polkadot-cloud/utils';
-import React, { useRef, useState } from 'react';
+import { rmCommas, shuffle } from '@polkadot-cloud/utils';
+import React, { useState } from 'react';
 import type {
   BondedPool,
   BondedPoolsContextState,
   MaybePool,
   NominationStatuses,
+  PoolNominations,
 } from 'contexts/Pools/types';
 import { useStaking } from 'contexts/Staking';
-import type { AnyApi, AnyMetaBatch, Fn, MaybeAddress } from 'types';
+import type { AnyApi, MaybeAddress } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
+import { useNetworkMetrics } from 'contexts/NetworkMetrics';
+import type { AnyJson } from '@polkadot-cloud/react/types';
 import { useApi } from '../../Api';
 import { usePoolsConfig } from '../PoolsConfig';
 import { defaultBondedPoolsContext } from './defaults';
@@ -25,40 +28,33 @@ export const BondedPoolsProvider = ({
 }) => {
   const { network } = useNetwork();
   const { api, isReady } = useApi();
+  const { activeEra } = useNetworkMetrics();
   const { createAccounts, stats } = usePoolsConfig();
   const { getNominationsStatusFromTargets } = useStaking();
   const { lastPoolId } = stats;
 
-  // Stores the meta data batches for pool lists.
-  const [poolMetaBatches, setPoolMetaBatch]: AnyMetaBatch = useState({});
-  const poolMetaBatchesRef = useRef(poolMetaBatches);
-
-  // Stores the meta batch subscriptions for pool lists.
-  const poolSubs = useRef<Record<string, Fn[]>>({});
-
   // Store bonded pools.
   const [bondedPools, setBondedPools] = useState<BondedPool[]>([]);
 
-  // Store bonded pool metadata.
+  // Store bonded pools metadata.
   const [poolsMetaData, setPoolsMetadata] = useState<Record<number, string>>(
     {}
   );
 
-  const unsubscribe = () => {
-    Object.values(poolSubs.current).map((batch: Fn[]) =>
-      Object.entries(batch).map(([, v]) => v())
-    );
-    setBondedPools([]);
-  };
+  // Store bonded pools nominations.
+  const [poolsNominations, setPoolsNominations] = useState<
+    Record<number, PoolNominations>
+  >({});
 
-  // Fetch all bonded pool entries, and then fetch their metadata.
+  // Fetch all bonded pool entries and their metadata.
+  // TODO: add syncing state to prevent duplicate fetches.
   const fetchBondedPools = async () => {
     if (!api) return;
+    const ids: number[] = [];
 
     // Fetch bonded pools entries.
     const bondedPoolsMulti =
       await api.query.nominationPools.bondedPools.entries();
-    const ids: string[] = [];
     let exposures = bondedPoolsMulti.map(([keys, val]: AnyApi) => {
       const id = keys.toHuman()[0];
       ids.push(id);
@@ -72,12 +68,42 @@ export const BondedPoolsProvider = ({
     const metadataMulti = await api.query.nominationPools.metadata.multi(ids);
     setPoolsMetadata(
       Object.fromEntries(
-        metadataMulti.map((m, i) => [Number(ids[i]), String(m.toHuman())])
+        metadataMulti.map((m, i) => [ids[i], String(m.toHuman())])
       )
     );
   };
 
-  // queries a bonded pool and injects ID and addresses to a result.
+  // Fetches pool nominations and updates state.
+  const fetchPoolsNominations = async () => {
+    if (!api) return;
+
+    const ids: number[] = [];
+    const nominationsMulti = await api.query.staking.nominators.multi(
+      bondedPools.map(({ addresses, id }) => {
+        ids.push(id);
+        return addresses.stash;
+      })
+    );
+    setPoolsNominations(formatPoolsNominations(nominationsMulti, ids));
+  };
+
+  // Format raw pool nominations data.
+  const formatPoolsNominations = (raw: AnyJson, ids: number[]) =>
+    Object.fromEntries(
+      raw.map((n: AnyJson, i: number) => {
+        const human = n.toHuman() as PoolNominations;
+        if (!human) return [ids[i], null];
+        return [
+          ids[i],
+          {
+            ...human,
+            submittedIn: rmCommas(human.submittedIn),
+          },
+        ];
+      })
+    );
+
+  // Queries a bonded pool and injects ID and addresses to a result.
   const queryBondedPool = async (id: number) => {
     if (!api) return null;
 
@@ -95,119 +121,23 @@ export const BondedPoolsProvider = ({
     };
   };
 
-  /*
-    Fetches a new batch of pool metadata.
-    Fetches the metadata of a pool that we assume to be a string.
-    structure:
-    {
-      key: {
-        [
-          {
-          metadata: [],
-        }
-      ]
-    },
-  };
-  */
-  const fetchPoolsMetaBatch = async (
-    key: string,
-    p: AnyMetaBatch,
-    refetch = false
-  ) => {
-    if (!isReady || !api || !p.length) return;
-
-    if (!refetch) {
-      // if already exists, do not re-fetch
-      if (poolMetaBatchesRef.current[key] !== undefined) {
-        return;
-      }
-    } else {
-      // tidy up if existing batch exists
-      const updatedPoolMetaBatches: AnyMetaBatch = {
-        ...poolMetaBatchesRef.current,
-      };
-      delete updatedPoolMetaBatches[key];
-      setStateWithRef(
-        updatedPoolMetaBatches,
-        setPoolMetaBatch,
-        poolMetaBatchesRef
-      );
-
-      if (poolSubs.current[key] !== undefined) {
-        for (const unsub of poolSubs.current[key]) {
-          unsub();
-        }
-      }
-    }
-
-    // aggregate pool ids and addresses
-    const ids = [];
-    const addresses = [];
-    for (const pool of p) {
-      ids.push(Number(pool.id));
-
-      if (pool?.addresses?.stash) {
-        addresses.push(pool.addresses.stash);
-      }
-    }
-
-    // store batch ids
-    const batchesUpdated = Object.assign(poolMetaBatchesRef.current);
-    batchesUpdated[key] = {};
-    batchesUpdated[key].ids = ids;
-    setStateWithRef(
-      { ...batchesUpdated },
-      setPoolMetaBatch,
-      poolMetaBatchesRef
-    );
-
-    const subscribeToNominations = async (_addresses: AnyApi) => {
-      const unsub = await api.query.staking.nominators.multi(
-        _addresses,
-        (_nominations: AnyApi) => {
-          const nominations = [];
-          for (let i = 0; i < _nominations.length; i++) {
-            nominations.push(_nominations[i].toHuman());
-          }
-          const updated = Object.assign(poolMetaBatchesRef.current);
-          updated[key].nominations = nominations;
-          setStateWithRef({ ...updated }, setPoolMetaBatch, poolMetaBatchesRef);
-        }
-      );
-      return unsub;
-    };
-
-    // initiate subscriptions
-    await Promise.all([subscribeToNominations(addresses)]).then(
-      (unsubs: Fn[]) => {
-        addMetaBatchUnsubs(key, unsubs);
-      }
-    );
-  };
-
-  /*
-   * Get bonded pool nomination statuses
-   */
+  // Get bonded pool nomination statuses
   const getPoolNominationStatus = (
     nominator: MaybeAddress,
     nomination: MaybeAddress
   ) => {
     const pool = bondedPools.find((p: any) => p.addresses.stash === nominator);
 
-    if (!pool) {
-      return 'waiting';
-    }
-    // get pool targets from nominations metadata
-    const batchIndex = bondedPools.indexOf(pool);
-    const nominations = poolMetaBatches.bonded_pools?.nominations ?? [];
-    const targets = nominations[batchIndex]?.targets ?? [];
+    if (!pool) return 'waiting';
 
-    const target = targets.find((t: string) => t === nomination);
+    // get pool targets from nominations metadata
+    const nominations = poolsNominations[pool.id];
+    const targets = nominations ? nominations.targets : [];
+    const target = targets.find((t) => t === nomination);
 
     const nominationStatus = getNominationsStatusFromTargets(nominator, [
       target,
     ]);
-
     return getPoolNominationStatusCode(nominationStatus);
   };
 
@@ -232,18 +162,6 @@ export const BondedPoolsProvider = ({
   };
 
   /*
-   * Helper: to add mataBatch unsubs by key.
-   */
-  const addMetaBatchUnsubs = (key: string, unsubs: Fn[]) => {
-    const newUnsubs = poolSubs.current;
-    const newUnsubItem = newUnsubs[key] ?? [];
-
-    newUnsubItem.push(...unsubs);
-    newUnsubs[key] = newUnsubItem;
-    poolSubs.current = newUnsubs;
-  };
-
-  /*
    *  Helper: to add addresses to pool record.
    */
   const getPoolWithAddresses = (id: number, pool: BondedPool) => ({
@@ -256,57 +174,31 @@ export const BondedPoolsProvider = ({
     bondedPools.find((p) => p.id === poolId) ?? null;
 
   /*
-   * poolSearchFilter
-   * Iterates through the supplied list and refers to the meta
-   * batch of the list to filter those list items that match
-   * the search term.
-   * Returns the updated filtered list.
+   * poolSearchFilter Iterates through the supplied list and refers to the meta batch of the list to
+   * filter those list items that match the search term. Returns the updated filtered list.
    */
-  const poolSearchFilter = (
-    list: any,
-    batchKey: string,
-    searchTerm: string
-  ) => {
-    const meta = poolMetaBatchesRef.current;
-
-    if (meta[batchKey] === undefined) {
-      return list;
-    }
+  const poolSearchFilter = (list: any, searchTerm: string) => {
     const filteredList: any = [];
 
     for (const pool of list) {
-      const batchIndex = meta[batchKey].ids?.indexOf(Number(pool.id)) ?? -1;
-
-      // if we cannot derive data, fallback to include pool in filtered list
-      if (batchIndex === -1) {
-        filteredList.push(pool);
-        continue;
-      }
-
-      const ids = meta[batchKey].ids ?? false;
-
-      if (!Object.values(poolsMetaData).length || !ids) {
+      // If pool metadata has not yet been synced, include the pool in results.
+      if (!Object.values(poolsMetaData).length) {
         filteredList.push(pool);
         continue;
       }
 
       const address = pool?.addresses?.stash ?? '';
       const metadata = poolsMetaData[pool.id] || '';
-
       const metadataAsBytes = u8aToString(u8aUnwrapBytes(metadata));
       const metadataSearch = (
         metadataAsBytes === '' ? metadata : metadataAsBytes
       ).toLowerCase();
 
-      if (pool.id.includes(searchTerm.toLowerCase())) {
+      if (pool.id.includes(searchTerm.toLowerCase())) filteredList.push(pool);
+      if (address.toLowerCase().includes(searchTerm.toLowerCase()))
         filteredList.push(pool);
-      }
-      if (address.toLowerCase().includes(searchTerm.toLowerCase())) {
+      if (metadataSearch.includes(searchTerm.toLowerCase()))
         filteredList.push(pool);
-      }
-      if (metadataSearch.includes(searchTerm.toLowerCase())) {
-        filteredList.push(pool);
-      }
     }
     return filteredList;
   };
@@ -427,27 +319,24 @@ export const BondedPoolsProvider = ({
   // Clear existing state for network refresh.
   useEffectIgnoreInitial(() => {
     setBondedPools([]);
-    setStateWithRef({}, setPoolMetaBatch, poolMetaBatchesRef);
+    setPoolsMetadata({});
+    setPoolsNominations({});
   }, [network]);
 
   // Initial setup for fetching bonded pools.
   useEffectIgnoreInitial(() => {
     if (isReady) fetchBondedPools();
-    return () => {
-      unsubscribe();
-    };
   }, [network, isReady, lastPoolId]);
 
-  // After bonded pools have synced, fetch metabatch.
+  // Re-fetch bonded pools nominations when active era changes or when `bondedPools` update.
   useEffectIgnoreInitial(() => {
-    if (bondedPools.length)
-      fetchPoolsMetaBatch('bonded_pools', bondedPools, true);
-  }, [bondedPools]);
+    if (!activeEra.index.isZero() && bondedPools.length)
+      fetchPoolsNominations();
+  }, [activeEra.index, bondedPools.length]);
 
   return (
     <BondedPoolsContext.Provider
       value={{
-        fetchPoolsMetaBatch,
         queryBondedPool,
         getBondedPool,
         updateBondedPools,
@@ -461,7 +350,7 @@ export const BondedPoolsProvider = ({
         poolSearchFilter,
         bondedPools,
         poolsMetaData,
-        meta: poolMetaBatchesRef.current,
+        poolsNominations,
       }}
     >
       {children}

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -347,9 +347,7 @@ export const BondedPoolsProvider = ({
 
   // Initial setup for fetching bonded pools.
   useEffectIgnoreInitial(() => {
-    if (isReady && lastPoolId) {
-      fetchBondedPools();
-    }
+    if (isReady && lastPoolId) fetchBondedPools();
   }, [bondedPools, isReady, lastPoolId]);
 
   // Re-fetch bonded pools nominations when active era changes or when `bondedPools` update.

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -97,7 +97,7 @@ export const PoolMembersProvider = ({
   };
 
   const getMembersOfPoolFromNode = (poolId: number) =>
-    poolMembersNode.filter((p: any) => p.poolId === poolId) ?? null;
+    poolMembersNode.filter((p) => p.poolId === poolId) ?? null;
 
   // queries a  pool member and formats to `PoolMember`.
   const queryPoolMember = async (who: MaybeAddress) => {

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -97,7 +97,7 @@ export const PoolMembersProvider = ({
   };
 
   const getMembersOfPoolFromNode = (poolId: number) =>
-    poolMembersNode.filter((p: any) => p.poolId === String(poolId)) ?? null;
+    poolMembersNode.filter((p: any) => p.poolId === poolId) ?? null;
 
   // queries a  pool member and formats to `PoolMember`.
   const queryPoolMember = async (who: MaybeAddress) => {

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -74,6 +74,7 @@ export interface BondedPoolsContextState {
   bondedPools: BondedPool[];
   poolsMetaData: Record<number, string>;
   poolsNominations: Record<number, AnyJson>;
+  updatePoolNominations: (id: number, nominations: string[]) => void;
 }
 
 export interface ActivePool {

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -73,7 +73,7 @@ export interface BondedPoolsContextState {
   poolSearchFilter: (l: any, v: string) => void;
   bondedPools: BondedPool[];
   poolsMetaData: Record<number, string>;
-  poolsNominations: Record<number, AnyJson>;
+  poolsNominations: Record<number, PoolNominations>;
   updatePoolNominations: (id: number, nominations: string[]) => void;
 }
 

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -73,6 +73,7 @@ export interface BondedPoolsContextState {
   replacePoolRoles: (poolId: number, roleEdits: AnyJson) => void;
   poolSearchFilter: (l: any, k: string, v: string) => void;
   bondedPools: BondedPool[];
+  poolsMetaData: Record<number, string>;
   meta: AnyMetaBatch;
 }
 
@@ -87,7 +88,7 @@ export interface ActivePool {
 
 export interface BondedPool {
   addresses: PoolAddresses;
-  id: number | string;
+  id: number;
   memberCounter: string;
   points: string;
   roles: {

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -60,7 +60,6 @@ export interface PoolMembership {
 
 // BondedPool types
 export interface BondedPoolsContextState {
-  fetchPoolsMetaBatch: (k: string, v: [], r?: boolean) => void;
   queryBondedPool: (p: number) => any;
   getBondedPool: (p: number) => BondedPool | null;
   updateBondedPools: (p: BondedPool[]) => void;
@@ -71,10 +70,10 @@ export interface BondedPoolsContextState {
   getAccountRoles: (w: MaybeAddress) => any;
   getAccountPools: (w: MaybeAddress) => any;
   replacePoolRoles: (poolId: number, roleEdits: AnyJson) => void;
-  poolSearchFilter: (l: any, k: string, v: string) => void;
+  poolSearchFilter: (l: any, v: string) => void;
   bondedPools: BondedPool[];
   poolsMetaData: Record<number, string>;
-  meta: AnyMetaBatch;
+  poolsNominations: Record<number, AnyJson>;
 }
 
 export interface ActivePool {
@@ -108,6 +107,12 @@ export interface BondedPool {
     throttleFrom?: AnyJson | null;
   };
 }
+
+export type PoolNominations = {
+  submittedIn: string;
+  suppressed: boolean;
+  targets: string[];
+} | null;
 
 export type NominationStatuses = Record<string, string>;
 

--- a/src/library/Account/Pool.tsx
+++ b/src/library/Account/Pool.tsx
@@ -22,7 +22,7 @@ export const Account = ({
   const { t } = useTranslation('library');
   const { isReady } = useApi();
   const { activeAccount } = useActiveAccounts();
-  const { fetchPoolsMetaBatch, meta } = useBondedPools();
+  const { fetchPoolsMetaBatch, poolsMetaData } = useBondedPools();
 
   // is this the initial fetch
   const [fetched, setFetched] = useState(false);
@@ -51,13 +51,13 @@ export const Account = ({
     fetchPoolsMetaBatch(batchKey, pools, true);
   };
 
-  const metaBatch = meta[batchKey];
-  const metaData = metaBatch?.metadata?.[0];
-  const syncing = metaData === undefined;
+  const syncing = !Object.values(poolsMetaData).length;
 
   // display value
   const defaultDisplay = ellipsisFn(pool.addresses.stash);
-  let display = syncing ? t('syncing') : metaData ?? defaultDisplay;
+  let display = syncing
+    ? t('syncing')
+    : poolsMetaData[pool.id] ?? defaultDisplay;
 
   // check if super identity has been byte encoded
   const displayAsBytes = u8aToString(u8aUnwrapBytes(display));

--- a/src/library/Account/Pool.tsx
+++ b/src/library/Account/Pool.tsx
@@ -3,12 +3,9 @@
 
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
 import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { Polkicon } from '@polkadot-cloud/react';
-import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { Wrapper } from './Wrapper';
 import type { AccountProps } from './types';
 
@@ -20,36 +17,7 @@ export const Account = ({
   fontSize = '1.05rem',
 }: AccountProps) => {
   const { t } = useTranslation('library');
-  const { isReady } = useApi();
-  const { activeAccount } = useActiveAccounts();
-  const { fetchPoolsMetaBatch, poolsMetaData } = useBondedPools();
-
-  // is this the initial fetch
-  const [fetched, setFetched] = useState(false);
-
-  const batchKey = 'pool_header';
-
-  // refetch when pool or active account changes
-  useEffect(() => {
-    setFetched(false);
-  }, [activeAccount, pool]);
-
-  // configure pool list when network is ready to fetch
-  useEffect(() => {
-    if (isReady) {
-      setFetched(true);
-
-      if (!fetched) {
-        getPoolMeta();
-      }
-    }
-  }, [isReady, fetched]);
-
-  // handle pool list bootstrapping
-  const getPoolMeta = () => {
-    const pools: any = [{ id: pool.id }];
-    fetchPoolsMetaBatch(batchKey, pools, true);
-  };
+  const { poolsMetaData } = useBondedPools();
 
   const syncing = !Object.values(poolsMetaData).length;
 

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -15,26 +15,18 @@ import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
 import type { Pool } from 'library/Pool/types';
 import { useNetwork } from 'contexts/Network';
 
-export const PoolBonded = ({
-  pool,
-  batchKey,
-  batchIndex,
-}: {
-  pool: Pool;
-  batchKey: string;
-  batchIndex: number;
-}) => {
+export const PoolBonded = ({ pool }: { pool: Pool }) => {
   const { t } = useTranslation('library');
   const {
     networkData: { units, unit },
   } = useNetwork();
-  const { meta, getPoolNominationStatusCode } = useBondedPools();
+  const { getPoolNominationStatusCode, poolsNominations } = useBondedPools();
   const { eraStakers, getNominationsStatusFromTargets } = useStaking();
   const { addresses, points } = pool;
 
   // get pool targets from nominations meta batch
-  const nominations = meta[batchKey]?.nominations ?? [];
-  const targets = nominations[batchIndex]?.targets ?? [];
+  const nominations = poolsNominations[pool.id];
+  const targets = nominations?.targets || [];
 
   // store nomination status in state
   const [nominationsStatus, setNominationsStatus] =
@@ -65,7 +57,7 @@ export const PoolBonded = ({
   // recalculate nominations status
   useEffect(() => {
     handleNominationsStatus();
-  }, [meta, pool, eraStakers.stakers.length]);
+  }, [pool, eraStakers.stakers.length, Object.keys(poolsNominations).length]);
 
   // calculate total bonded pool amount
   const poolBonded = planckToUnit(new BigNumber(rmCommas(points)), units);

--- a/src/library/ListItem/Labels/PoolIdentity.tsx
+++ b/src/library/ListItem/Labels/PoolIdentity.tsx
@@ -8,21 +8,15 @@ import { IdentityWrapper } from 'library/ListItem/Wrappers';
 import type { PoolIdentityProps } from '../types';
 
 export const PoolIdentity = ({
-  pool,
-  batchKey,
-  batchIndex,
+  pool: { addresses, id },
 }: PoolIdentityProps) => {
-  const { meta } = useBondedPools();
-  const { addresses } = pool;
+  const { poolsMetaData } = useBondedPools();
+  const metadataSynced = Object.values(poolsMetaData).length > 0 ?? false;
 
-  // get metadata from pools metabatch
-  const metadata = meta[batchKey]?.metadata ?? [];
-
-  // aggregate synced status
-  const metadataSynced = metadata.length > 0 ?? false;
-
-  // pool display name
-  const display = determinePoolDisplay(addresses.stash, metadata[batchIndex]);
+  const display = determinePoolDisplay(
+    addresses.stash,
+    poolsMetaData[Number(id)]
+  );
 
   return (
     <IdentityWrapper className="identity">

--- a/src/library/ListItem/types.ts
+++ b/src/library/ListItem/types.ts
@@ -25,8 +25,6 @@ export interface IdentityProps {
 }
 
 export interface PoolIdentityProps {
-  batchIndex: number;
-  batchKey: string;
   pool: BondedPool;
 }
 

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -34,15 +34,15 @@ import { PoolId } from '../ListItem/Labels/PoolId';
 import type { PoolProps } from './types';
 import { Rewards } from './Rewards';
 
-export const Pool = ({ pool, batchKey, batchIndex }: PoolProps) => {
+export const Pool = ({ pool }: PoolProps) => {
   const { t } = useTranslation('library');
   const { memberCounter, addresses, id, state } = pool;
   const { isPoolSyncing } = useUi();
-  const { meta } = useBondedPools();
   const { validators } = useValidators();
   const { setActiveTab } = usePoolsTabs();
   const { openModal } = useOverlay().modal;
   const { membership } = usePoolMemberships();
+  const { poolsNominations } = useBondedPools();
   const { activeAccount } = useActiveAccounts();
   const { addNotification } = useNotifications();
   const { isReadOnlyAccount } = useImportedAccounts();
@@ -52,10 +52,10 @@ export const Pool = ({ pool, batchKey, batchIndex }: PoolProps) => {
   const currentCommission = getCurrentCommission(id);
 
   // get metadata from pools metabatch
-  const nominations = meta[batchKey]?.nominations ?? [];
+  const nominations = poolsNominations[pool.id];
 
   // get pool targets from nominations metadata
-  const targets = nominations[batchIndex]?.targets ?? [];
+  const targets = nominations?.targets || [];
 
   // extract validator entries from pool targets
   const targetValidators = validators.filter(({ address }) =>
@@ -151,11 +151,7 @@ export const Pool = ({ pool, batchKey, batchIndex }: PoolProps) => {
               <PoolId id={id} />
               <Members members={memberCounter} />
             </Labels>
-            <PoolBonded
-              pool={pool}
-              batchIndex={batchIndex}
-              batchKey={batchKey}
-            />
+            <PoolBonded pool={pool} />
             {displayJoin && (
               <Labels style={{ marginTop: '1rem' }}>
                 <JoinPool id={id} setActiveTab={setActiveTab} />

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -126,11 +126,7 @@ export const Pool = ({ pool, batchKey, batchIndex }: PoolProps) => {
       <div className="inner">
         <MenuPosition ref={posRef} />
         <div className="row top">
-          <PoolIdentity
-            batchKey={batchKey}
-            batchIndex={batchIndex}
-            pool={pool}
-          />
+          <PoolIdentity pool={pool} />
           <div>
             <Labels>
               <FavoritePool address={addresses.stash} />

--- a/src/library/Pool/types.ts
+++ b/src/library/Pool/types.ts
@@ -6,8 +6,6 @@ import type { DisplayFor } from 'types';
 
 export interface PoolProps {
   pool: Pool;
-  batchKey: string;
-  batchIndex: number;
 }
 
 export interface Pool {

--- a/src/library/PoolList/Default.tsx
+++ b/src/library/PoolList/Default.tsx
@@ -33,7 +33,6 @@ import type { PoolListProps } from './types';
 export const PoolList = ({
   allowMoreCols,
   pagination,
-  batchKey = '',
   disableThrottle,
   allowSearch,
   pools,
@@ -52,7 +51,7 @@ export const PoolList = ({
   const { listFormat, setListFormat } = usePoolList();
   const { getFilters, setMultiFilters, getSearchTerm, setSearchTerm } =
     useFilters();
-  const { fetchPoolsMetaBatch, poolSearchFilter, meta } = useBondedPools();
+  const { poolSearchFilter, poolsNominations } = useBondedPools();
 
   const includes = getFilters('include', 'pools');
   const excludes = getFilters('exclude', 'pools');
@@ -101,16 +100,15 @@ export const PoolList = ({
     setPoolsDefault(pools);
     setListPools(pools);
     setFetched(true);
-    fetchPoolsMetaBatch(batchKey, pools, true);
   };
 
   // handle filter / order update
   const handlePoolsFilterUpdate = (
     filteredPools: any = Object.assign(poolsDefault)
   ) => {
-    filteredPools = applyFilter(includes, excludes, filteredPools, batchKey);
+    filteredPools = applyFilter(includes, excludes, filteredPools);
     if (searchTerm) {
-      filteredPools = poolSearchFilter(filteredPools, batchKey, searchTerm);
+      filteredPools = poolSearchFilter(filteredPools, searchTerm);
     }
     setListPools(filteredPools);
     setPage(1);
@@ -120,8 +118,8 @@ export const PoolList = ({
   const handleSearchChange = (e: React.FormEvent<HTMLInputElement>) => {
     const newValue = e.currentTarget.value;
     let filteredPools = Object.assign(poolsDefault);
-    filteredPools = applyFilter(includes, excludes, filteredPools, batchKey);
-    filteredPools = poolSearchFilter(filteredPools, batchKey, newValue);
+    filteredPools = applyFilter(includes, excludes, filteredPools);
+    filteredPools = poolSearchFilter(filteredPools, newValue);
 
     // ensure no duplicates
     filteredPools = filteredPools.filter(
@@ -160,10 +158,10 @@ export const PoolList = ({
   // List ui changes / validator changes trigger re-render of list.
   useEffect(() => {
     // only filter when pool nominations have been synced.
-    if (!isSyncing && meta[batchKey]?.nominations) {
+    if (!isSyncing && Object.keys(poolsNominations).length) {
       handlePoolsFilterUpdate();
     }
-  }, [isSyncing, includes, excludes, meta]);
+  }, [isSyncing, includes, excludes, Object.keys(poolsNominations).length]);
 
   // Scroll to top of the window on every filter.
   useEffect(() => {
@@ -262,11 +260,7 @@ export const PoolList = ({
                     },
                   }}
                 >
-                  <Pool
-                    pool={pool}
-                    batchKey={batchKey}
-                    batchIndex={poolsDefault.indexOf(pool)}
-                  />
+                  <Pool pool={pool} />
                 </motion.div>
               ))}
             </>

--- a/src/library/PoolList/types.ts
+++ b/src/library/PoolList/types.ts
@@ -11,7 +11,6 @@ export interface PoolListProps {
   allowMoreCols?: boolean;
   allowSearch?: boolean;
   pagination?: boolean;
-  batchKey?: string;
   disableThrottle?: boolean;
   refetchOnListUpdate?: string;
   allowListFormat?: boolean;

--- a/src/modals/ManagePool/Forms/SetMetadata.tsx
+++ b/src/modals/ManagePool/Forms/SetMetadata.tsx
@@ -26,7 +26,7 @@ export const SetMetadata = ({ setSection, section }: any) => {
   const { setModalStatus } = useOverlay().modal;
   const { activeAccount } = useActiveAccounts();
   const { isOwner, selectedActivePool } = useActivePools();
-  const { bondedPools, meta } = useBondedPools();
+  const { bondedPools, poolsMetaData } = useBondedPools();
   const { getSignerWarnings } = useSignerWarnings();
 
   const poolId = selectedActivePool?.id;
@@ -43,9 +43,7 @@ export const SetMetadata = ({ setSection, section }: any) => {
       ({ addresses }) => addresses.stash === selectedActivePool?.addresses.stash
     );
     if (pool) {
-      const metadataBatch = meta.bonded_pools?.metadata ?? [];
-      const batchIndex = bondedPools.indexOf(pool);
-      setMetadata(u8aToString(u8aUnwrapBytes(metadataBatch[batchIndex])));
+      setMetadata(u8aToString(u8aUnwrapBytes(poolsMetaData[Number(pool.id)])));
     }
   }, [section]);
 

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -159,9 +159,7 @@ export const PayoutListInner = ({
             );
 
             // get pool if it exists
-            const pool = bondedPools.find(
-              ({ id }) => String(id) === String(p.pool_id)
-            );
+            const pool = bondedPools.find(({ id }) => id === p.pool_id);
 
             const batchIndex = validator
               ? validators.indexOf(validator)
@@ -220,11 +218,7 @@ export const PayoutListInner = ({
                           {label === t('payouts.poolClaim') && (
                             <>
                               {pool ? (
-                                <PoolIdentity
-                                  batchKey="bonded_pools"
-                                  batchIndex={batchIndex}
-                                  pool={pool}
-                                />
+                                <PoolIdentity pool={pool} />
                               ) : (
                                 <h4>
                                   {t('payouts.fromPool')} {p.pool_id}

--- a/src/pages/Pools/Home/Favorites/index.tsx
+++ b/src/pages/Pools/Home/Favorites/index.tsx
@@ -49,12 +49,7 @@ export const PoolFavorites = () => {
             isReady &&
             (favoritesList.length > 0 ? (
               <PoolListProvider>
-                <PoolList
-                  batchKey="favorite_pools"
-                  pools={favoritesList}
-                  allowMoreCols
-                  pagination
-                />
+                <PoolList pools={favoritesList} allowMoreCols pagination />
               </PoolListProvider>
             ) : (
               <ListStatusHeader>{t('pools.noFavorites')}</ListStatusHeader>

--- a/src/pages/Pools/Home/Status/MembershipStatus.tsx
+++ b/src/pages/Pools/Home/Status/MembershipStatus.tsx
@@ -28,9 +28,9 @@ export const MembershipStatus = ({
   const { openModal } = useOverlay().modal;
   const { activeAccount } = useActiveAccounts();
   const { label, buttons } = useStatusButtons();
-  const { bondedPools, meta } = useBondedPools();
   const { isReadOnlyAccount } = useImportedAccounts();
   const { getTransferOptions } = useTransferOptions();
+  const { bondedPools, poolsMetaData } = useBondedPools();
   const { selectedActivePool, isOwner, isBouncer, isMember } = useActivePools();
 
   const { active } = getTransferOptions(activeAccount).pool;
@@ -41,15 +41,13 @@ export const MembershipStatus = ({
 
   if (selectedActivePool) {
     const pool = bondedPools.find(
-      (p: any) => p.addresses.stash === selectedActivePool.addresses.stash
+      (p) => p.addresses.stash === selectedActivePool.addresses.stash
     );
     if (pool) {
       // Determine pool membership display.
-      const metadata = meta.bonded_pools?.metadata ?? [];
-      const batchIndex = bondedPools.indexOf(pool);
       membershipDisplay = determinePoolDisplay(
         selectedActivePool.addresses.stash,
-        metadata[batchIndex]
+        poolsMetaData[Number(pool.id)]
       );
     }
 

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -146,7 +146,6 @@ export const HomeInner = () => {
             <CardWrapper>
               <PoolListProvider>
                 <PoolList
-                  batchKey="bonded_pools"
                   pools={bondedPools}
                   defaultFilters={{
                     includes: ['active'],


### PR DESCRIPTION
This PR cuts down on pool subscriptions and deprecates the poolsMetaBatch structure, improving app performance and sync speed.

- [x] Adds syncing state for bonded pools to prevent duplicate fetches.
- [x] Adds state for pool metadata and fetches them once rather than subscribe.
- [x] Adds state for pool nominations and fetches them once rather than subscribe.
- [x] Updates pool nominations upon submissions to `ManageNominations`.