### PR TITLE
refactor: revise external account logic, add `ExternalAccountsProvider` context.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ledgerhq/hw-transport-webhid": "^6.27.20",
     "@polkadot-cloud/assets": "^0.1.34",
     "@polkadot-cloud/core": "^1.0.45",
-    "@polkadot-cloud/react": "^0.1.127",
+    "@polkadot-cloud/react": "^0.1.128",
     "@polkadot-cloud/utils": "^0.0.25",
     "@polkadot/api": "^10.10.1",
     "@polkadot/keyring": "^12.1.1",

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -50,6 +50,7 @@ import { DappName } from 'consts';
 import { ImportedAccountsProvider } from 'contexts/Connect/ImportedAccounts';
 import { PoolPerformanceProvider } from 'contexts/Pools/PoolPerformance';
 import { LedgerAccountsProvider } from 'contexts/Hardware/Ledger/LedgerAccounts';
+import { ExternalAccountsProvider } from 'contexts/Connect/ExternalAccounts';
 
 // Embed providers from hook.
 export const Providers = () => {
@@ -72,8 +73,9 @@ export const Providers = () => {
       ExtensionAccountsProvider,
       { dappName: DappName, network, ss58, activeAccount, setActiveAccount },
     ],
-    OtherAccountsProvider,
     LedgerAccountsProvider,
+    ExternalAccountsProvider,
+    OtherAccountsProvider,
     ImportedAccountsProvider,
     ProxiesProvider,
     NetworkMetricsProvider,

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -16,6 +16,7 @@ import type { AnyApi, MaybeAddress } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
+import { useExternalAccounts } from 'contexts/Connect/ExternalAccounts';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
 import { getLedger } from './Utils';
 import * as defaults from './defaults';
@@ -37,9 +38,9 @@ export const BalancesProvider = ({
 }) => {
   const { api, isReady } = useApi();
   const { network } = useNetwork();
-  const { accounts } = useImportedAccounts();
-  const { getAccount } = useImportedAccounts();
-  const { addExternalAccount } = useOtherAccounts();
+  const { accounts, getAccount } = useImportedAccounts();
+  const { addOrReplaceOtherAccount } = useOtherAccounts();
+  const { addExternalAccount } = useExternalAccounts();
 
   const [balances, setBalances] = useState<Balances[]>([]);
   const balancesRef = useRef(balances);
@@ -101,8 +102,10 @@ export const BalancesProvider = ({
             const { stash, total, active, unlocking } = newLedger;
 
             // add stash as external account if not present
-            if (!getAccount(stash.toString()))
-              addExternalAccount(stash.toString(), 'system');
+            if (!getAccount(stash.toString())) {
+              const result = addExternalAccount(stash.toString(), 'system');
+              if (result) addOrReplaceOtherAccount(result.account, result.type);
+            }
 
             setStateWithRef(
               Object.values([...ledgersRef.current])

--- a/src/contexts/Bonded/index.tsx
+++ b/src/contexts/Bonded/index.tsx
@@ -15,6 +15,7 @@ import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
+import { useExternalAccounts } from 'contexts/Connect/ExternalAccounts';
 import * as defaults from './defaults';
 import type { BondedAccount, BondedContextInterface } from './types';
 
@@ -22,7 +23,8 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
   const { network } = useNetwork();
   const { api, isReady } = useApi();
   const { accounts } = useImportedAccounts();
-  const { addExternalAccount } = useOtherAccounts();
+  const { addExternalAccount } = useExternalAccounts();
+  const { addOrReplaceOtherAccount } = useOtherAccounts();
 
   // Balance accounts state.
   const [bondedAccounts, setBondedAccounts] = useState<BondedAccount[]>([]);
@@ -107,7 +109,8 @@ export const BondedProvider = ({ children }: { children: React.ReactNode }) => {
         // add bonded (controller) account as external account if not presently imported
         if (newController) {
           if (accounts.find((s) => s.address === newController) === undefined) {
-            addExternalAccount(newController, 'system');
+            const result = addExternalAccount(newController, 'system');
+            if (result) addOrReplaceOtherAccount(result.account, result.type);
           }
         }
 

--- a/src/contexts/Connect/ExternalAccounts/Utils.ts
+++ b/src/contexts/Connect/ExternalAccounts/Utils.ts
@@ -1,0 +1,62 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ExternalAccount } from '@polkadot-cloud/react/types';
+import { localStorageOrDefault } from '@polkadot-cloud/utils';
+import type { NetworkName } from 'types';
+
+// Check whether an external account exists in local storage.
+export const externalAccountExistsLocal = (
+  address: string,
+  network: NetworkName
+) =>
+  getLocalExternalAccounts().find(
+    (l) => l.address === address && l.network === network
+  );
+
+// Gets local external accounts from local storage.
+export const getLocalExternalAccounts = (network?: NetworkName) => {
+  let localAccounts = localStorageOrDefault(
+    'external_accounts',
+    [],
+    true
+  ) as ExternalAccount[];
+  if (network)
+    localAccounts = localAccounts.filter((l) => l.network === network);
+  return localAccounts;
+};
+
+// Adds a local external account to local storage.
+export const addLocalExternalAccount = (account: ExternalAccount) => {
+  localStorage.setItem(
+    'external_accounts',
+    JSON.stringify(getLocalExternalAccounts().concat(account))
+  );
+};
+
+// Updates a local external account with the provided `addedBy` property.
+export const updateLocalExternalAccount = (entry: ExternalAccount) => {
+  localStorage.setItem(
+    'external_accounts',
+    JSON.stringify(
+      getLocalExternalAccounts().map((a) =>
+        a.address === entry.address ? entry : a
+      )
+    )
+  );
+};
+
+// Removes supplied external cccounts from local storage.
+export const removeLocalExternalAccounts = (
+  network: NetworkName,
+  accounts: ExternalAccount[]
+) => {
+  if (!accounts.length) return;
+
+  const updatedAccounts = getLocalExternalAccounts(network).filter(
+    (a) =>
+      accounts.find((b) => b.address === a.address && a.network === network) ===
+      undefined
+  );
+  localStorage.setItem('external_accounts', JSON.stringify(updatedAccounts));
+};

--- a/src/contexts/Connect/ExternalAccounts/defaults.ts
+++ b/src/contexts/Connect/ExternalAccounts/defaults.ts
@@ -1,0 +1,11 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import type { ExternalAccountsContextInterface } from './types';
+
+export const defaultExternalAccountsContext: ExternalAccountsContextInterface =
+  {
+    addExternalAccount: (a, b) => null,
+    forgetExternalAccounts: (a) => {},
+  };

--- a/src/contexts/Connect/ExternalAccounts/index.tsx
+++ b/src/contexts/Connect/ExternalAccounts/index.tsx
@@ -62,23 +62,19 @@ export const ExternalAccountsProvider = ({
     const toSystem =
       existsLocal && addedBy === 'system' && existsLocal.addedBy !== 'system';
 
-    let isImported = true;
+    let isImported: boolean = true;
     let importType: ExternalAccountImportType = 'new';
 
     // Add external account if not there already.
     if (!existsLocal) {
       addLocalExternalAccount(newEntry);
-      // addOtherAccounts([newEntry]);
     } else if (toSystem) {
       // If account is being added by `system`, but is already imported, update it to be a system
       // account.
       newEntry = { ...newEntry, addedBy: 'system' };
       updateLocalExternalAccount(newEntry);
       importType = 'replace';
-      // replaceOtherAccount(newEntry);
-    } else {
-      isImported = false;
-    }
+    } else isImported = false;
 
     return isImported
       ? {

--- a/src/contexts/Connect/ExternalAccounts/index.tsx
+++ b/src/contexts/Connect/ExternalAccounts/index.tsx
@@ -1,0 +1,113 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useContext, type ReactNode, createContext } from 'react';
+import Keyring from '@polkadot/keyring';
+import { useNetwork } from 'contexts/Network';
+import { ellipsisFn } from '@polkadot-cloud/utils';
+import type {
+  ExternalAccount,
+  ExternalAccountAddedBy,
+} from '@polkadot-cloud/react/types';
+import { useActiveAccounts } from 'contexts/ActiveAccounts';
+import type {
+  AddExternalAccountResult,
+  ExternalAccountImportType,
+  ExternalAccountsContextInterface,
+} from './types';
+import { defaultExternalAccountsContext } from './defaults';
+import {
+  addLocalExternalAccount,
+  externalAccountExistsLocal,
+  removeLocalExternalAccounts,
+  updateLocalExternalAccount,
+} from './Utils';
+
+export const ExternalAccountsContext =
+  createContext<ExternalAccountsContextInterface>(
+    defaultExternalAccountsContext
+  );
+
+export const ExternalAccountsProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const {
+    network,
+    networkData: { ss58 },
+  } = useNetwork();
+  const { activeAccount, setActiveAccount } = useActiveAccounts();
+
+  // Adds an external account (non-wallet) to accounts.
+  const addExternalAccount = (
+    address: string,
+    addedBy: ExternalAccountAddedBy
+  ): AddExternalAccountResult | null => {
+    // ensure account is formatted correctly.
+    const keyring = new Keyring();
+    keyring.setSS58Format(ss58);
+
+    let newEntry = {
+      address: keyring.addFromAddress(address).address,
+      network,
+      name: ellipsisFn(address),
+      source: 'external',
+      addedBy,
+    };
+
+    const existsLocal = externalAccountExistsLocal(newEntry.address, network);
+
+    // Whether the account needs to remain imported as a system account.
+    const toSystem =
+      existsLocal && addedBy === 'system' && existsLocal.addedBy !== 'system';
+
+    let isImported = true;
+    let importType: ExternalAccountImportType = 'new';
+
+    // Add external account if not there already.
+    if (!existsLocal) {
+      addLocalExternalAccount(newEntry);
+      // addOtherAccounts([newEntry]);
+    } else if (toSystem) {
+      // If account is being added by `system`, but is already imported, update it to be a system
+      // account.
+      newEntry = { ...newEntry, addedBy: 'system' };
+      updateLocalExternalAccount(newEntry);
+      importType = 'replace';
+      // replaceOtherAccount(newEntry);
+    } else {
+      isImported = false;
+    }
+
+    return isImported
+      ? {
+          type: importType,
+          account: newEntry,
+        }
+      : null;
+  };
+
+  // Get any external accounts and remove from localStorage.
+  const forgetExternalAccounts = (forget: ExternalAccount[]) => {
+    if (!forget.length) return;
+    removeLocalExternalAccounts(
+      network,
+      forget.filter((i) => 'network' in i) as ExternalAccount[]
+    );
+
+    // If the currently active account is being forgotten, disconnect.
+    if (forget.find((a) => a.address === activeAccount) !== undefined)
+      setActiveAccount(null);
+  };
+
+  return (
+    <ExternalAccountsContext.Provider
+      value={{ addExternalAccount, forgetExternalAccounts }}
+    >
+      {children}
+    </ExternalAccountsContext.Provider>
+  );
+};
+
+export const useExternalAccounts = () => useContext(ExternalAccountsContext);

--- a/src/contexts/Connect/ExternalAccounts/types.ts
+++ b/src/contexts/Connect/ExternalAccounts/types.ts
@@ -1,0 +1,25 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type {
+  ExternalAccount,
+  ExternalAccountAddedBy,
+} from '@polkadot-cloud/react/types';
+
+export interface ExternalAccountsContextInterface {
+  addExternalAccount: (
+    a: string,
+    addedBy: ExternalAccountAddedBy
+  ) => AddExternalAccountResult | null;
+  forgetExternalAccounts: (a: ExternalAccount[]) => void;
+}
+
+export interface AddExternalAccountResult {
+  account: ExternalAccount;
+  type: ExternalAccountImportType;
+}
+
+export type ExternalAccountImportType = 'new' | 'replace';

--- a/src/contexts/Connect/OtherAccounts/defaults.ts
+++ b/src/contexts/Connect/OtherAccounts/defaults.ts
@@ -5,12 +5,11 @@
 import type { OtherAccountsContextInterface } from './types';
 
 export const defaultOtherAccountsContext: OtherAccountsContextInterface = {
-  addExternalAccount: (a, b) => {},
   addOtherAccounts: (a) => {},
+  addOrReplaceOtherAccount: (account, type) => {},
   renameOtherAccount: (a, n) => {},
   importLocalOtherAccounts: (n) => {},
   forgetOtherAccounts: (a) => {},
-  forgetExternalAccounts: (a) => {},
   otherAccounts: [],
   accountsInitialised: false,
 };

--- a/src/contexts/Connect/OtherAccounts/index.tsx
+++ b/src/contexts/Connect/OtherAccounts/index.tsx
@@ -21,6 +21,7 @@ import { getActiveAccountLocal } from '../Utils';
 import type { OtherAccountsContextInterface } from './types';
 import { defaultOtherAccountsContext } from './defaults';
 import { getLocalExternalAccounts } from '../ExternalAccounts/Utils';
+import type { ExternalAccountImportType } from '../ExternalAccounts/types';
 
 export const OtherAccountsContext =
   createContext<OtherAccountsContextInterface>(defaultOtherAccountsContext);
@@ -159,7 +160,7 @@ export const OtherAccountsProvider = ({
   // Add or replace other account with an entry.
   const addOrReplaceOtherAccount = (
     account: ImportedAccount,
-    type: 'new' | 'replace' | null
+    type: ExternalAccountImportType
   ) => {
     if (type === 'new') {
       addOtherAccounts([account]);

--- a/src/contexts/Connect/OtherAccounts/types.ts
+++ b/src/contexts/Connect/OtherAccounts/types.ts
@@ -5,12 +5,14 @@ import type { ImportedAccount } from '@polkadot-cloud/react/types';
 import type { MaybeAddress, NetworkName } from 'types';
 
 export interface OtherAccountsContextInterface {
-  addExternalAccount: (a: string, addedBy: string) => void;
   addOtherAccounts: (a: ImportedAccount[]) => void;
+  addOrReplaceOtherAccount: (
+    a: ImportedAccount,
+    type: 'new' | 'replace' | null
+  ) => void;
   renameOtherAccount: (a: MaybeAddress, n: string) => void;
   importLocalOtherAccounts: (g: (n: NetworkName) => ImportedAccount[]) => void;
   forgetOtherAccounts: (a: ImportedAccount[]) => void;
-  forgetExternalAccounts: (a: ImportedAccount[]) => void;
   accountsInitialised: boolean;
   otherAccounts: ImportedAccount[];
 }

--- a/src/contexts/Connect/OtherAccounts/types.ts
+++ b/src/contexts/Connect/OtherAccounts/types.ts
@@ -3,12 +3,13 @@
 
 import type { ImportedAccount } from '@polkadot-cloud/react/types';
 import type { MaybeAddress, NetworkName } from 'types';
+import type { ExternalAccountImportType } from '../ExternalAccounts/types';
 
 export interface OtherAccountsContextInterface {
   addOtherAccounts: (a: ImportedAccount[]) => void;
   addOrReplaceOtherAccount: (
     a: ImportedAccount,
-    type: 'new' | 'replace' | null
+    type: ExternalAccountImportType
   ) => void;
   renameOtherAccount: (a: MaybeAddress, n: string) => void;
   importLocalOtherAccounts: (g: (n: NetworkName) => ImportedAccount[]) => void;

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -5,7 +5,7 @@ import Keyring from '@polkadot/keyring';
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
 import type { NetworkName } from 'types';
 
-// gets local `activeAccount` for a network
+// Gets local `activeAccount` for a network.
 export const getActiveAccountLocal = (network: NetworkName, ss58: number) => {
   const keyring = new Keyring();
   keyring.setSS58Format(ss58);

--- a/src/contexts/Connect/Utils.ts
+++ b/src/contexts/Connect/Utils.ts
@@ -3,7 +3,6 @@
 
 import Keyring from '@polkadot/keyring';
 import { localStorageOrDefault } from '@polkadot-cloud/utils';
-import type { ExternalAccount } from '@polkadot-cloud/react/types';
 import type { NetworkName } from 'types';
 
 // gets local `activeAccount` for a network
@@ -15,53 +14,6 @@ export const getActiveAccountLocal = (network: NetworkName, ss58: number) => {
     account = keyring.addFromAddress(account).address;
   }
   return account;
-};
-
-// Adds a local external account to local storage.
-export const addLocalExternalAccount = (account: ExternalAccount) => {
-  localStorage.setItem(
-    'external_accounts',
-    JSON.stringify(getLocalExternalAccounts().concat(account))
-  );
-};
-
-// Updates a local external account with the provided `addedBy` property.
-export const updateLocalExternalAccount = (entry: ExternalAccount) => {
-  localStorage.setItem(
-    'external_accounts',
-    JSON.stringify(
-      getLocalExternalAccounts().map((a) =>
-        a.address === entry.address ? entry : a
-      )
-    )
-  );
-};
-
-// Gets local external accounts from local storage.
-export const getLocalExternalAccounts = (network?: NetworkName) => {
-  let localAccounts = localStorageOrDefault(
-    'external_accounts',
-    [],
-    true
-  ) as ExternalAccount[];
-  if (network)
-    localAccounts = localAccounts.filter((l) => l.network === network);
-  return localAccounts;
-};
-
-// Removes supplied external cccounts from local storage.
-export const removeLocalExternalAccounts = (
-  network: NetworkName,
-  accounts: ExternalAccount[]
-) => {
-  if (!accounts.length) return;
-
-  const updatedAccounts = getLocalExternalAccounts(network).filter(
-    (a) =>
-      accounts.find((b) => b.address === a.address && a.network === network) ===
-      undefined
-  );
-  localStorage.setItem('external_accounts', JSON.stringify(updatedAccounts));
 };
 
 // Formats an address with the supplied ss58 prefix.

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -21,6 +21,7 @@ import { useNetwork } from 'contexts/Network';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
+import { useExternalAccounts } from 'contexts/Connect/ExternalAccounts';
 import * as defaults from './defaults';
 import type {
   Delegates,
@@ -39,7 +40,8 @@ export const ProxiesProvider = ({
   const { network } = useNetwork();
   const { api, isReady } = useApi();
   const { accounts } = useImportedAccounts();
-  const { addExternalAccount } = useOtherAccounts();
+  const { addExternalAccount } = useExternalAccounts();
+  const { addOrReplaceOtherAccount } = useOtherAccounts();
   const { activeProxy, setActiveProxy, activeAccount } = useActiveAccounts();
 
   // store the proxy accounts of each imported account.
@@ -59,7 +61,9 @@ export const ProxiesProvider = ({
         // if delegates still exist for removed account, re-add the account as a read only system
         // account.
         if (delegatesRef.current[address]) {
-          addExternalAccount(address, 'system');
+          const importResult = addExternalAccount(address, 'system');
+          if (importResult)
+            addOrReplaceOtherAccount(importResult.account, importResult.type);
         } else {
           const unsub = unsubs.current[address];
           if (unsub) unsub();
@@ -193,7 +197,9 @@ export const ProxiesProvider = ({
         const { address, proxyType } = JSON.parse(localActiveProxy);
         // Add proxy address as external account if not imported.
         if (!accounts.find((a) => a.address === address)) {
-          addExternalAccount(address, 'system');
+          const importResult = addExternalAccount(address, 'system');
+          if (importResult)
+            addOrReplaceOtherAccount(importResult.account, importResult.type);
         }
 
         const isActive = (
@@ -271,7 +277,11 @@ export const ProxiesProvider = ({
         addDelegatorAsExternal = true;
       }
     }
-    if (addDelegatorAsExternal) addExternalAccount(delegator, 'system');
+    if (addDelegatorAsExternal) {
+      const importResult = addExternalAccount(delegator, 'system');
+      if (importResult)
+        addOrReplaceOtherAccount(importResult.account, importResult.type);
+    }
 
     return [];
   };

--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -20,6 +20,7 @@ import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
 import { useOtherAccounts } from 'contexts/Connect/OtherAccounts';
 import type { ExternalAccount } from '@polkadot-cloud/react/types';
+import { useExternalAccounts } from 'contexts/Connect/ExternalAccounts';
 import {
   ActionWithButton,
   ManualAccount,
@@ -32,8 +33,8 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
   const { openHelp } = useHelp();
   const { accounts } = useImportedAccounts();
   const { setModalResize } = useOverlay().modal;
-  const { forgetExternalAccounts, addExternalAccount, forgetOtherAccounts } =
-    useOtherAccounts();
+  const { addExternalAccount, forgetExternalAccounts } = useExternalAccounts();
+  const { forgetOtherAccounts, addOrReplaceOtherAccount } = useOtherAccounts();
 
   // get all external accounts
   const externalAccountsOnly = accounts.filter(
@@ -79,7 +80,10 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
               resetOnSuccess
               defaultLabel={t('inputAddress')}
               successCallback={async (value: string) => {
-                addExternalAccount(value, 'user');
+                const result = addExternalAccount(value, 'user');
+                if (result)
+                  addOrReplaceOtherAccount(result.account, result.type);
+
                 return true;
               }}
             />

--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -45,12 +45,12 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
     ({ addedBy }) => addedBy === 'user'
   );
 
-  // forget account
-  const forgetAccount = (account: ExternalAccount) => {
+  const handleForgetAccount = (account: ExternalAccount) => {
     forgetExternalAccounts([account]);
     forgetOtherAccounts([account]);
     setModalResize();
   };
+
   return (
     <>
       <ActionWithButton>
@@ -98,9 +98,7 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
                   </div>
                   <ButtonSecondary
                     text={t('forget')}
-                    onClick={() => {
-                      forgetAccount(a);
-                    }}
+                    onClick={() => handleForgetAccount(a)}
                   />
                 </ManualAccount>
               ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,10 +701,10 @@
   resolved "https://registry.yarnpkg.com/@polkadot-cloud/core/-/core-1.0.45.tgz#7617e7803f64a4c933fa2b63038acfc9f8f9597d"
   integrity sha512-rtVQlaVnvqHiMW4CreowspZG+JXZQYMLjMXY3i9vRRnBcVa09D7ahNRbj6RixmUSSNADtQJS9AaQNMz6nJuyAQ==
 
-"@polkadot-cloud/react@^0.1.127":
-  version "0.1.127"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/react/-/react-0.1.127.tgz#142a6bbc0bb62958a11391121f342ba29a9422ce"
-  integrity sha512-1jUmMCl7Kw2XsCAadU5xEzNNIs5L2Lf2PelgMQhmoYW35Hug6XW81iaOYqKJQRZv5JnnnxCWgmfkq7QLsQCaRQ==
+"@polkadot-cloud/react@^0.1.128":
+  version "0.1.128"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/react/-/react-0.1.128.tgz#eef5982e48af1c1d848f3d7025f1c91c5b9121a6"
+  integrity sha512-4RfenxbAcbE1gFpzqMStdHkou6DuQrHhPqHlj8GX/ahCQvXwqNDlgLS5rMtMPLxcgsn/EXzqV8MxyNwmSHPcZQ==
   dependencies:
     "@chainsafe/metamask-polkadot-adapter" "^0.5.1"
     "@chainsafe/metamask-polkadot-types" "^0.6.0"
@@ -1882,7 +1882,6 @@ binary-extensions@^2.0.0:
 
 "bip32-ed25519@https://github.com/Zondax/bip32-ed25519":
   version "0.0.4"
-  uid "0949df01b5c93885339bc28116690292088f6134"
   resolved "https://github.com/Zondax/bip32-ed25519#0949df01b5c93885339bc28116690292088f6134"
   dependencies:
     bn.js "^5.1.1"


### PR DESCRIPTION
This PR refactors how external accounts are handled, bringing conventions inline with how hardware wallet accounts are handled.

- [x] Separates external accounts from other accounts by introducing a new `ExternalAccountsProvider` context.
- [x] External accounts are updated in `otherAccounts` the same way as other sources are.
