### PR TITLE
feat(refactor): don't persist `system` external accounts, remove proxy `delegates` state

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,7 +8,7 @@ import type { Plugin } from 'types';
 /*
  * Global Constants
  */
-export const AppVersion = '1.0.8';
+export const AppVersion = '1.1.2';
 export const DappName = 'Polkadot Staking Dashboard';
 export const PolkadotUrl = 'https://polkadot.network/features/staking/';
 export const DefaultNetwork = 'polkadot';

--- a/src/contexts/Connect/ExternalAccounts/Utils.ts
+++ b/src/contexts/Connect/ExternalAccounts/Utils.ts
@@ -14,7 +14,7 @@ export const externalAccountExistsLocal = (
     (l) => l.address === address && l.network === network
   );
 
-// Gets local external accounts from local storage.
+// Gets local external accounts from local storage. Ensure that only `user` accounts are returned.
 export const getLocalExternalAccounts = (network?: NetworkName) => {
   let localAccounts = localStorageOrDefault(
     'external_accounts',
@@ -22,7 +22,9 @@ export const getLocalExternalAccounts = (network?: NetworkName) => {
     true
   ) as ExternalAccount[];
   if (network)
-    localAccounts = localAccounts.filter((l) => l.network === network);
+    localAccounts = localAccounts.filter(
+      (l) => l.network === network && l.addedBy !== 'system'
+    );
   return localAccounts;
 };
 

--- a/src/contexts/Connect/ExternalAccounts/index.tsx
+++ b/src/contexts/Connect/ExternalAccounts/index.tsx
@@ -20,7 +20,6 @@ import {
   addLocalExternalAccount,
   externalAccountExistsLocal,
   removeLocalExternalAccounts,
-  updateLocalExternalAccount,
 } from './Utils';
 
 export const ExternalAccountsContext =
@@ -65,14 +64,15 @@ export const ExternalAccountsProvider = ({
     let isImported: boolean = true;
     let importType: ExternalAccountImportType = 'new';
 
-    // Add external account if not there already.
     if (!existsLocal) {
-      addLocalExternalAccount(newEntry);
+      // Only add `user` accounts to localStorage.
+      if (addedBy === 'user') addLocalExternalAccount(newEntry);
     } else if (toSystem) {
       // If account is being added by `system`, but is already imported, update it to be a system
-      // account.
+      // account. `system` accounts are not persisted to local storage.
+      //
+      // update the entry to a system account.
       newEntry = { ...newEntry, addedBy: 'system' };
-      updateLocalExternalAccount(newEntry);
       importType = 'replace';
     } else isImported = false;
 

--- a/src/contexts/Proxies/defaults.ts
+++ b/src/contexts/Proxies/defaults.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import type { ProxiesContextInterface } from './type';
+import type { ProxiesContextInterface } from './types';
 
 export const defaultProxiesContext: ProxiesContextInterface = {
   getDelegates: (a) => undefined,
   getProxyDelegate: (x, y) => null,
   getProxiedAccounts: (a) => [],
   handleDeclareDelegate: (a) => new Promise((resolve) => resolve([])),
+  formatProxiesToDelegates: () => ({}),
   proxies: [],
-  delegates: {},
 };

--- a/src/contexts/Proxies/index.tsx
+++ b/src/contexts/Proxies/index.tsx
@@ -30,7 +30,7 @@ import type {
   ProxiesContextInterface,
   Proxy,
   ProxyDelegate,
-} from './type';
+} from './types';
 
 export const ProxiesProvider = ({
   children,
@@ -44,10 +44,40 @@ export const ProxiesProvider = ({
   const { addOrReplaceOtherAccount } = useOtherAccounts();
   const { activeProxy, setActiveProxy, activeAccount } = useActiveAccounts();
 
-  // store the proxy accounts of each imported account.
+  // Store the proxy accounts of each imported account.
   const [proxies, setProxies] = useState<Proxies>([]);
   const proxiesRef = useRef(proxies);
   const unsubs = useRef<Record<string, VoidFn>>({});
+
+  // Reformats proxies into a list of delegates.
+  const formatProxiesToDelegates = () => {
+    // Reformat proxiesRef.current into a list of delegates.
+    const newDelegates: Delegates = {};
+    for (const proxy of proxiesRef.current) {
+      const { delegator } = proxy;
+      // checking if delegator is not null to keep types happy.
+      if (!delegator) continue;
+
+      // get each delegate of this proxy record.
+      for (const { delegate, proxyType } of proxy.delegates) {
+        const item = {
+          delegator,
+          proxyType,
+        };
+        // check if this delegate exists in `newDelegates`.
+        if (Object.keys(newDelegates).includes(delegate)) {
+          // append delegator to the existing delegate record if it exists.
+          newDelegates[delegate].push(item);
+        } else {
+          // create a new delegate record if it does not yet exist in `newDelegates`.
+          newDelegates[delegate] = [item];
+        }
+      }
+    }
+    return newDelegates;
+  };
+
+  const delegates = formatProxiesToDelegates();
 
   // Handle the syncing of accounts on accounts change.
   const handleSyncAccounts = () => {
@@ -60,7 +90,7 @@ export const ProxiesProvider = ({
       removed?.forEach((address) => {
         // if delegates still exist for removed account, re-add the account as a read only system
         // account.
-        if (delegatesRef.current[address]) {
+        if (delegates[address]) {
           const importResult = addExternalAccount(address, 'system');
           if (importResult)
             addOrReplaceOtherAccount(importResult.account, importResult.type);
@@ -92,10 +122,6 @@ export const ProxiesProvider = ({
     handleAddedAccounts();
     handleExistingAccounts();
   };
-
-  // store the delegates and the corresponding delegators
-  const [delegates, setDelegates] = useState<Delegates>({});
-  const delegatesRef = useRef(delegates);
 
   const subscribeToProxies = async (address: string) => {
     if (!api) return undefined;
@@ -140,41 +166,66 @@ export const ProxiesProvider = ({
     return unsub;
   };
 
-  // Gets the delegates of the given account
+  // Gets the delegates of the given account.
   const getDelegates = (address: MaybeAddress): Proxy | undefined =>
     proxiesRef.current.find(({ delegator }) => delegator === address) ||
     undefined;
 
-  // Gets delegators and proxy types for the given delegate address
-  const getProxiedAccounts = (address: MaybeAddress) => {
-    const delegate = delegatesRef.current[address || ''];
-    if (!delegate) {
-      return [];
-    }
-    const proxiedAccounts: ProxiedAccounts = delegate
+  // Gets delegators and proxy types for the given delegate address.
+  const getProxiedAccounts = (address: MaybeAddress): ProxiedAccounts => {
+    const delegate = delegates[address || ''];
+    if (!delegate) return [];
+
+    return delegate
       .filter(({ proxyType }) => isSupportedProxy(proxyType))
       .map(({ delegator, proxyType }) => ({
         address: delegator,
         name: ellipsisFn(delegator),
         proxyType,
       }));
-    return proxiedAccounts;
+  };
+
+  // Queries the chain to check if the given delegator & delegate pair is valid proxy. Used when a
+  // proxy account is being manually declared.
+  const handleDeclareDelegate = async (delegator: string) => {
+    if (!api) return [];
+
+    const result: AnyApi = (await api.query.proxy.proxies(delegator)).toHuman();
+
+    let addDelegatorAsExternal = false;
+    for (const { delegate: newDelegate } of result[0] || []) {
+      if (
+        accounts.find(({ address }) => address === newDelegate) &&
+        !delegates[newDelegate]
+      ) {
+        subscribeToProxies(delegator);
+        addDelegatorAsExternal = true;
+      }
+    }
+    if (addDelegatorAsExternal) {
+      const importResult = addExternalAccount(delegator, 'system');
+      if (importResult)
+        addOrReplaceOtherAccount(importResult.account, importResult.type);
+    }
+
+    return [];
   };
 
   // Gets the delegates and proxy type of an account, if any.
   const getProxyDelegate = (
     delegator: MaybeAddress,
     delegate: MaybeAddress
-  ): ProxyDelegate | null =>
-    proxiesRef.current
-      .find((p) => p.delegator === delegator)
-      ?.delegates.find((d) => d.delegate === delegate) ?? null;
+  ): ProxyDelegate | null => {
+    return (
+      proxiesRef.current
+        .find((p) => p.delegator === delegator)
+        ?.delegates.find((d) => d.delegate === delegate) ?? null
+    );
+  };
 
   // Subscribe new accounts to proxies, and remove accounts that are no longer imported.
   useEffectIgnoreInitial(() => {
-    if (isReady) {
-      handleSyncAccounts();
-    }
+    if (isReady) handleSyncAccounts();
   }, [accounts, isReady, network]);
 
   // If active proxy has not yet been set, check local storage `activeProxy` & set it as active
@@ -225,76 +276,19 @@ export const ProxiesProvider = ({
   }, [network]);
 
   const unsubAll = () => {
-    for (const unsub of Object.values(unsubs.current)) {
-      unsub();
-    }
+    for (const unsub of Object.values(unsubs.current)) unsub();
     unsubs.current = {};
-  };
-
-  // Listens to `proxies` state updates and reformats the data into a list of delegates.
-  useEffectIgnoreInitial(() => {
-    // Reformat proxiesRef.current into a list of delegates.
-    const newDelegates: Delegates = {};
-    for (const proxy of proxiesRef.current) {
-      const { delegator } = proxy;
-
-      // checking if delegator is not null to keep types happy.
-      if (delegator) {
-        // get each delegate of this proxy record.
-        for (const { delegate, proxyType } of proxy.delegates) {
-          const item = {
-            delegator,
-            proxyType,
-          };
-          // check if this delegate exists in `newDelegates`.
-          if (Object.keys(newDelegates).includes(delegate)) {
-            // append delegator to the existing delegate record if it exists.
-            newDelegates[delegate].push(item);
-          } else {
-            // create a new delegate record if it does not yet exist in `newDelegates`.
-            newDelegates[delegate] = [item];
-          }
-        }
-      }
-    }
-
-    setStateWithRef(newDelegates, setDelegates, delegatesRef);
-  }, [proxiesRef.current]);
-
-  // Queries the chain to check if the given delegator & delegate pair is valid proxy.
-  const handleDeclareDelegate = async (delegator: string) => {
-    if (!api) return [];
-
-    const result: AnyApi = (await api.query.proxy.proxies(delegator)).toHuman();
-
-    let addDelegatorAsExternal = false;
-    for (const { delegate: newDelegate } of result[0] || []) {
-      if (
-        accounts.find(({ address }) => address === newDelegate) &&
-        !delegatesRef.current[newDelegate]
-      ) {
-        subscribeToProxies(delegator);
-        addDelegatorAsExternal = true;
-      }
-    }
-    if (addDelegatorAsExternal) {
-      const importResult = addExternalAccount(delegator, 'system');
-      if (importResult)
-        addOrReplaceOtherAccount(importResult.account, importResult.type);
-    }
-
-    return [];
   };
 
   return (
     <ProxiesContext.Provider
       value={{
         proxies: proxiesRef.current,
-        delegates: delegatesRef.current,
         handleDeclareDelegate,
         getDelegates,
         getProxyDelegate,
         getProxiedAccounts,
+        formatProxiesToDelegates,
       }}
     >
       {children}

--- a/src/contexts/Proxies/types.ts
+++ b/src/contexts/Proxies/types.ts
@@ -46,6 +46,6 @@ export interface ProxiesContextInterface {
   getProxyDelegate: (x: MaybeAddress, y: MaybeAddress) => ProxyDelegate | null;
   getProxiedAccounts: (a: MaybeAddress) => ProxiedAccounts;
   handleDeclareDelegate: (delegator: string) => Promise<AnyJson[]>;
+  formatProxiesToDelegates: () => Delegates;
   proxies: Proxies;
-  delegates: Delegates;
 }

--- a/src/modals/Accounts/types.ts
+++ b/src/modals/Accounts/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { PoolMembership } from 'contexts/Pools/types';
-import type { Proxy } from 'contexts/Proxies/type';
+import type { Proxy } from 'contexts/Proxies/types';
 import type { MaybeAddress } from 'types';
 
 export interface AccountItemProps {

--- a/src/modals/Connect/Proxies.tsx
+++ b/src/modals/Connect/Proxies.tsx
@@ -31,9 +31,10 @@ export const Proxies = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
   const { openHelp } = useHelp();
   const { accounts } = useImportedAccounts();
   const { getAccount } = useImportedAccounts();
-  const { delegates, handleDeclareDelegate } = useProxies();
+  const { handleDeclareDelegate, formatProxiesToDelegates } = useProxies();
 
   // Filter delegates to only show those who are imported in the dashboard.
+  const delegates = formatProxiesToDelegates();
   const importedDelegates = Object.fromEntries(
     Object.entries(delegates).filter(([delegate]) =>
       accounts.find((a) => a.address === delegate)

--- a/src/modals/Connect/Proxies.tsx
+++ b/src/modals/Connect/Proxies.tsx
@@ -29,8 +29,7 @@ import type { ListWithInputProps } from './types';
 export const Proxies = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
   const { t } = useTranslation('modals');
   const { openHelp } = useHelp();
-  const { accounts } = useImportedAccounts();
-  const { getAccount } = useImportedAccounts();
+  const { accounts, getAccount } = useImportedAccounts();
   const { handleDeclareDelegate, formatProxiesToDelegates } = useProxies();
 
   // Filter delegates to only show those who are imported in the dashboard.
@@ -40,6 +39,7 @@ export const Proxies = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
       accounts.find((a) => a.address === delegate)
     )
   );
+
   return (
     <>
       <ActionWithButton>

--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -48,7 +48,8 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
 
   const handleForgetAccount = (account: ExternalAccount) => {
     forgetExternalAccounts([account]);
-    forgetOtherAccounts([account]);
+    // forget the account from state only if it has not replaced by a `system` external account.
+    if (account.addedBy === 'user') forgetOtherAccounts([account]);
     setModalResize();
   };
 

--- a/src/modals/Connect/ReadOnly.tsx
+++ b/src/modals/Connect/ReadOnly.tsx
@@ -46,7 +46,7 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
     ({ addedBy }) => addedBy === 'user'
   );
 
-  const handleForgetAccount = (account: ExternalAccount) => {
+  const handleForgetExternalAccount = (account: ExternalAccount) => {
     forgetExternalAccounts([account]);
     // forget the account from state only if it has not replaced by a `system` external account.
     if (account.addedBy === 'user') forgetOtherAccounts([account]);
@@ -103,7 +103,7 @@ export const ReadOnly = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
                   </div>
                   <ButtonSecondary
                     text={t('forget')}
-                    onClick={() => handleForgetAccount(a)}
+                    onClick={() => handleForgetExternalAccount(a)}
                   />
                 </ManualAccount>
               ))}


### PR DESCRIPTION
- [x] No longer stores proxy delegates in a separaste state object, and instead introduces a formatProxiesToDelegates to discover them on the fly. This prevents re-renders.
- [x] `system` external accounts are no longer persisted in local storage.

#### About system external account changes

To prevent edge cases in read only account management, system accounts are no longer persisted in local storage.

System accounts are discovered after the initial account import process, and may replace existing `user` based read only accounts. This is a dynamic process, and the `user` added accounts still need to be persisted in local storage. This update will allow these accounts to be remembered even if they are updated to `system` accounts. 

Includes a migration to remove existing `system` external accounts from local storage.