### PR TITLE
feat(refactor): useless fragments, linting tidy up

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,4 @@ build
 vite.config.ts
 public/lottie/player.js
 CHANGELOG.md
+.yarn/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,6 @@
     "react/no-array-index-key": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
-    "react/jsx-no-useless-fragment": "off",
     "react/static-property-placement": "off",
     "no-unused-vars": "off",
     "no-param-reassign": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,22 +27,8 @@
     "unused-imports"
   ],
   "rules": {
-    // NOTE: These rules are being reviewed and comments justifying their deactivation will be
-    // added.
-    "react/require-default-props": "off",
-    "react/no-access-state-in-setstate": "off",
-    "react/destructuring-assignment": "off",
-    "react/jsx-no-constructed-context-values": "off",
-    "react/no-array-index-key": "off",
     "react/react-in-jsx-scope": "off",
-    "react/jsx-props-no-spreading": "off",
-    "react/static-property-placement": "off",
-    "no-restricted-syntax": "off",
-    "no-use-before-define": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "no-promise-executor-return": "off",
-    "prefer-destructuring": "off",
-    "no-nested-ternary": "off",
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/consistent-type-imports": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
     "plugin:import/recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    // "airbnb-typescript",
     "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",
@@ -31,31 +30,19 @@
     // NOTE: These rules are being reviewed and comments justifying their deactivation will be
     // added.
     "react/require-default-props": "off",
-    "jsx-a11y/control-has-associated-label": "off",
     "react/no-access-state-in-setstate": "off",
     "react/destructuring-assignment": "off",
-    "react/function-component-definition": "off",
     "react/jsx-no-constructed-context-values": "off",
     "react/no-array-index-key": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
     "react/static-property-placement": "off",
-    "no-param-reassign": "off",
     "no-restricted-syntax": "off",
-    "@typescript-eslint/no-empty-function": "off",
     "no-use-before-define": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "no-promise-executor-return": "off",
     "prefer-destructuring": "off",
     "no-nested-ternary": "off",
-    // `continue` statements cut down on conditional nesting and improve readability where it is
-    // used in this project. Conditionals would further bloat the code.
-    "no-continue": "off",
-    // Unary operators are not impacting code as semi-colons are currently enforced.
-    "no-plusplus": "off",
-    // Default imports cause naming inconsistencies to imports when component names are changed.
-    "import/prefer-default-export": "off",
-
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/consistent-type-imports": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,10 @@
   ],
   "rules": {
     "react/react-in-jsx-scope": "off",
+    // The following rules need to be revised, or the codebase needs to be fixed to enable them.
     "@typescript-eslint/no-explicit-any": "off",
+    // "@typescript-eslint/no-unnecessary-condition": "error",
+    // --------------------------------------------
     "react/jsx-no-useless-fragment": "error",
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/consistent-type-imports": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
     "plugin:import/recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    "airbnb",
     // "airbnb-typescript",
     "plugin:prettier/recommended"
   ],
@@ -41,7 +40,6 @@
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
     "react/static-property-placement": "off",
-    "no-unused-vars": "off",
     "no-param-reassign": "off",
     "no-restricted-syntax": "off",
     "@typescript-eslint/no-empty-function": "off",
@@ -94,6 +92,9 @@
     "react/prop-types": "off"
   },
   "settings": {
+    "react": {
+      "version": "detect"
+    },
     "import/resolver": {
       "typescript": {}
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "react/jsx-no-useless-fragment": "error",
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/consistent-type-imports": [
       "error",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,6 @@
     "@typescript-eslint/parser": "^6.15.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "eslint": "^8.55.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prefer-arrow-functions": "^3.2.4",
     "eslint-plugin-prettier": "^5.0.1",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -74,11 +74,11 @@ export const RouterInner = () => {
       if (aUrl) {
         const account = accounts.find((a) => a.address === aUrl);
         if (account && aUrl !== activeAccount) {
-          setActiveAccount(account?.address || null);
+          setActiveAccount(account.address || null);
           addNotification({
             title: t('accountConnected', { ns: 'library' }),
             subtitle: `${t('connectedTo', { ns: 'library' })} ${
-              account?.name || aUrl
+              account.name || aUrl
             }.`,
           });
         }

--- a/src/contexts/FastUnstake/index.tsx
+++ b/src/contexts/FastUnstake/index.tsx
@@ -285,7 +285,7 @@ export const FastUnstakeProvider = ({
       subscribeQueue(activeAccount),
       subscribeHead(),
       subscribeCounterForQueue(),
-    ]).then((u: any) => {
+    ]).then((u) => {
       unsubs.current = u;
     });
   };

--- a/src/contexts/Help/types.ts
+++ b/src/contexts/Help/types.ts
@@ -46,4 +46,4 @@ export interface HelpContextProps {
   children: ReactNode;
 }
 
-export type HelpConfig = Record<string, string | any>;
+export type HelpConfig = Record<string, string | string[]>;

--- a/src/contexts/Migrate/index.tsx
+++ b/src/contexts/Migrate/index.tsx
@@ -107,8 +107,8 @@ export const MigrateProvider = ({
   }, [isReady, isNetworkSyncing]);
 
   return (
-    <MigrateContext.Provider value={{}}>{children}</MigrateContext.Provider>
+    <MigrateContext.Provider value={null}>{children}</MigrateContext.Provider>
   );
 };
 
-export const MigrateContext = React.createContext<any>(null);
+export const MigrateContext = React.createContext<null>(null);

--- a/src/contexts/Plugins/Subscan/types.ts
+++ b/src/contexts/Plugins/Subscan/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { AnyJson } from '@polkadot-cloud/react/types';
 import type { AnySubscan } from 'types';
 
 export interface SubscanContextInterface {
@@ -10,7 +11,7 @@ export interface SubscanContextInterface {
   unclaimedPayouts: AnySubscan;
   payoutsFromDate: string | undefined;
   payoutsToDate: string | undefined;
-  fetchPoolDetails: (poolId: number) => Promise<any>;
-  fetchPoolMembers: (poolId: number, page: number) => Promise<any[]>;
+  fetchPoolDetails: (poolId: number) => Promise<AnyJson>;
+  fetchPoolMembers: (poolId: number, page: number) => Promise<AnyJson[]>;
   setUnclaimedPayouts: (payouts: AnySubscan) => void;
 }

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -212,7 +212,7 @@ export const ActivePoolsProvider = ({
     };
 
     // initiate subscription, add to unsubs.
-    await Promise.all([subscribeActivePool(poolId)]).then((unsubs: any) => {
+    await Promise.all([subscribeActivePool(poolId)]).then((unsubs) => {
       unsubActivePools.current = unsubActivePools.current.concat(unsubs);
     });
   };
@@ -290,7 +290,7 @@ export const ActivePoolsProvider = ({
    * setTargets
    * Sets currently selected pool's target validators in storage.
    */
-  const setTargets = (newTargets: any) => {
+  const setTargets = (newTargets: AnyJson) => {
     if (!selectedPoolId) {
       return;
     }

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -132,7 +132,7 @@ export const BondedPoolsProvider = ({
     nominator: MaybeAddress,
     nomination: MaybeAddress
   ) => {
-    const pool = bondedPools.find((p: any) => p.addresses.stash === nominator);
+    const pool = bondedPools.find((p) => p.addresses.stash === nominator);
 
     if (!pool) return 'waiting';
 
@@ -289,10 +289,12 @@ export const BondedPoolsProvider = ({
     const roles = getAccountRoles(who);
     // format new list has pool => roles
     const pools: any = {};
-    Object.entries(roles).forEach(([key, poolIds]: any) => {
+    Object.entries(roles).forEach(([key, poolIds]) => {
       // now looping through a role
-      poolIds.forEach((poolId: string) => {
-        const exists = Object.keys(pools).find((k) => k === poolId);
+      poolIds.forEach((poolId) => {
+        const exists = Object.keys(pools).find(
+          (k) => String(k) === String(poolId)
+        );
         if (!exists) {
           pools[poolId] = [key];
         } else {

--- a/src/library/Account/Pool.tsx
+++ b/src/library/Account/Pool.tsx
@@ -27,7 +27,7 @@ export const Account = ({
     ? t('syncing')
     : poolsMetaData[pool.id] ?? defaultDisplay;
 
-  // check if super identity has been byte encoded
+  // check if super identity has been byte encoded.
   const displayAsBytes = u8aToString(u8aUnwrapBytes(display));
   if (displayAsBytes !== '') {
     display = displayAsBytes;

--- a/src/library/AccountInput/index.tsx
+++ b/src/library/AccountInput/index.tsx
@@ -190,9 +190,7 @@ export const AccountInput = ({
         </section>
         <section>
           {successLock ? (
-            <>
-              <ButtonSecondary onClick={() => resetInput()} text={t('reset')} />
-            </>
+            <ButtonSecondary onClick={() => resetInput()} text={t('reset')} />
           ) : (
             <>
               {!reformatted ? (

--- a/src/library/AccountInput/index.tsx
+++ b/src/library/AccountInput/index.tsx
@@ -191,21 +191,17 @@ export const AccountInput = ({
         <section>
           {successLock ? (
             <ButtonSecondary onClick={() => resetInput()} text={t('reset')} />
+          ) : !reformatted ? (
+            <ButtonSecondary
+              onClick={() => handleImport()}
+              text={submitting ? t('importing') : t('import')}
+              disabled={valid !== 'valid' || submitting}
+            />
           ) : (
-            <>
-              {!reformatted ? (
-                <ButtonSecondary
-                  onClick={() => handleImport()}
-                  text={submitting ? t('importing') : t('import')}
-                  disabled={valid !== 'valid' || submitting}
-                />
-              ) : (
-                <ButtonSecondary
-                  onClick={() => handleConfirm()}
-                  text={t('confirm')}
-                />
-              )}
-            </>
+            <ButtonSecondary
+              onClick={() => handleConfirm()}
+              text={t('confirm')}
+            />
           )}
         </section>
       </div>

--- a/src/library/BarChart/BondedChart.tsx
+++ b/src/library/BarChart/BondedChart.tsx
@@ -56,48 +56,46 @@ export const BondedChart = ({
     : new BigNumber(0);
 
   return (
-    <>
-      <BarChartWrapper
-        $lessPadding
-        style={{ marginTop: '2rem', marginBottom: '2rem' }}
-      >
-        <Legend>
-          {totalUnlocking.plus(active).isZero() ? (
-            <LegendItem dataClass="d4" label={t('available')} />
-          ) : greaterThanZero(active) ? (
-            <LegendItem dataClass="d1" label={t('bonded')} />
-          ) : null}
+    <BarChartWrapper
+      $lessPadding
+      style={{ marginTop: '2rem', marginBottom: '2rem' }}
+    >
+      <Legend>
+        {totalUnlocking.plus(active).isZero() ? (
+          <LegendItem dataClass="d4" label={t('available')} />
+        ) : greaterThanZero(active) ? (
+          <LegendItem dataClass="d1" label={t('bonded')} />
+        ) : null}
 
-          {greaterThanZero(totalUnlocking) ? (
-            <LegendItem dataClass="d3" label={t('unlocking')} />
-          ) : null}
+        {greaterThanZero(totalUnlocking) ? (
+          <LegendItem dataClass="d3" label={t('unlocking')} />
+        ) : null}
 
-          {greaterThanZero(totalUnlocking.plus(active)) ? (
-            <LegendItem dataClass="d4" label={t('free')} />
-          ) : null}
-        </Legend>
-        <Bar>
-          <BarSegment
-            dataClass="d1"
-            widthPercent={Number(graphActive.toFixed(2))}
-            flexGrow={0}
-            label={`${active.decimalPlaces(3).toFormat()} ${unit}`}
-          />
-          <BarSegment
-            dataClass="d3"
-            widthPercent={Number(graphUnlocking.toFixed(2))}
-            flexGrow={0}
-            label={`${totalUnlocking.decimalPlaces(3).toFormat()} ${unit}`}
-          />
-          <BarSegment
-            dataClass="d4"
-            widthPercent={Number(graphFree.toFixed(2))}
-            flexGrow={0}
-            label={`${freeToBond.toFormat()} ${unit}`}
-            forceShow={inactive && totalUnlocking.isZero()}
-          />
-        </Bar>
-      </BarChartWrapper>
-    </>
+        {greaterThanZero(totalUnlocking.plus(active)) ? (
+          <LegendItem dataClass="d4" label={t('free')} />
+        ) : null}
+      </Legend>
+      <Bar>
+        <BarSegment
+          dataClass="d1"
+          widthPercent={Number(graphActive.toFixed(2))}
+          flexGrow={0}
+          label={`${active.decimalPlaces(3).toFormat()} ${unit}`}
+        />
+        <BarSegment
+          dataClass="d3"
+          widthPercent={Number(graphUnlocking.toFixed(2))}
+          flexGrow={0}
+          label={`${totalUnlocking.decimalPlaces(3).toFormat()} ${unit}`}
+        />
+        <BarSegment
+          dataClass="d4"
+          widthPercent={Number(graphFree.toFixed(2))}
+          flexGrow={0}
+          label={`${freeToBond.toFormat()} ${unit}`}
+          forceShow={inactive && totalUnlocking.isZero()}
+        />
+      </Bar>
+    </BarChartWrapper>
   );
 };

--- a/src/library/EstimatedTxFee/index.tsx
+++ b/src/library/EstimatedTxFee/index.tsx
@@ -20,22 +20,18 @@ export const EstimatedTxFeeInner = ({ format }: EstimatedTxFeeProps) => {
 
   const txFeesUnit = planckToUnit(txFees, units).toFormat();
 
-  return (
+  return format === 'table' ? (
     <>
-      {format === 'table' ? (
-        <>
-          <div>{t('estimatedFee')}:</div>
-          <div>{txFees.isZero() ? `...` : `${txFeesUnit} ${unit}`}</div>
-        </>
-      ) : (
-        <Wrapper>
-          <p>
-            <span>{t('estimatedFee')}:</span>
-            {txFees.isZero() ? `...` : `${txFeesUnit} ${unit}`}
-          </p>
-        </Wrapper>
-      )}
+      <div>{t('estimatedFee')}:</div>
+      <div>{txFees.isZero() ? `...` : `${txFeesUnit} ${unit}`}</div>
     </>
+  ) : (
+    <Wrapper>
+      <p>
+        <span>{t('estimatedFee')}:</span>
+        {txFees.isZero() ? `...` : `${txFeesUnit} ${unit}`}
+      </p>
+    </Wrapper>
   );
 };
 

--- a/src/library/GenerateNominations/index.tsx
+++ b/src/library/GenerateNominations/index.tsx
@@ -336,11 +336,10 @@ export const GenerateNominations = ({
           )}
         </div>
 
-        {fetching ? (
-          <></>
-        ) : (
-          <>
-            {isReady && method !== null && (
+        {fetching
+          ? null
+          : isReady &&
+            method !== null && (
               <div
                 ref={heightRef}
                 style={{
@@ -358,8 +357,6 @@ export const GenerateNominations = ({
                 />
               </div>
             )}
-          </>
-        )}
       </Wrapper>
     </>
   );

--- a/src/library/GenerateNominations/index.tsx
+++ b/src/library/GenerateNominations/index.tsx
@@ -51,7 +51,7 @@ export const GenerateNominations = ({
     available: availableToNominate,
   } = useFetchMehods();
   const { maxNominations } = consts;
-  const defaultNominationsCount = defaultNominations.nominations?.length || 0;
+  const defaultNominationsCount = defaultNominations.nominations.length || 0;
 
   // store the method of fetching validators
   const [method, setMethod] = useState<string | null>(
@@ -78,7 +78,7 @@ export const GenerateNominations = ({
       nominations !== defaultNominations.nominations &&
       defaultNominationsCount > 0
     ) {
-      setNominations([...(defaultNominations?.nominations || [])]);
+      setNominations([...(defaultNominations.nominations || [])]);
       if (defaultNominationsCount) setMethod('manual');
     }
   }, [activeAccount, defaultNominations]);
@@ -291,7 +291,7 @@ export const GenerateNominations = ({
               text={t('reGenerate')}
               onClick={() => {
                 // set a temporary height to prevent height snapping on re-renders.
-                setHeight(heightRef?.current?.clientHeight || null);
+                setHeight(heightRef.current?.clientHeight || null);
                 setTimeout(() => setHeight(null), 200);
                 setFetching(true);
               }}

--- a/src/library/Headers/Connected.tsx
+++ b/src/library/Headers/Connected.tsx
@@ -26,54 +26,52 @@ export const Connected = () => {
   }
 
   return (
-    <>
-      {activeAccount && (
-        <>
-          {/* default account display / stash label if actively nominating */}
+    activeAccount && (
+      <>
+        {/* default account display / stash label if actively nominating */}
+        <HeadingWrapper>
+          <Account
+            canClick={false}
+            value={activeAccount}
+            readOnly={!accountHasSigner(activeAccount)}
+            label={
+              isNetworkSyncing
+                ? undefined
+                : isNominating()
+                  ? 'Nominator'
+                  : undefined
+            }
+            format="name"
+          />
+        </HeadingWrapper>
+
+        {/* pool account display / hide if not in pool */}
+        {selectedActivePool !== null && !isNetworkSyncing && (
+          <HeadingWrapper>
+            <PoolAccount
+              format="name"
+              value={poolAddress}
+              pool={selectedActivePool}
+              label={t('pool')}
+              canClick={false}
+              onClick={() => {}}
+            />
+          </HeadingWrapper>
+        )}
+
+        {/* proxy account display / hide if no proxy */}
+        {activeProxy && (
           <HeadingWrapper>
             <Account
               canClick={false}
-              value={activeAccount}
-              readOnly={!accountHasSigner(activeAccount)}
-              label={
-                isNetworkSyncing
-                  ? undefined
-                  : isNominating()
-                    ? 'Nominator'
-                    : undefined
-              }
+              value={activeProxy}
+              readOnly={!accountHasSigner(activeProxy)}
+              label={t('proxy')}
               format="name"
             />
           </HeadingWrapper>
-
-          {/* pool account display / hide if not in pool */}
-          {selectedActivePool !== null && !isNetworkSyncing && (
-            <HeadingWrapper>
-              <PoolAccount
-                format="name"
-                value={poolAddress}
-                pool={selectedActivePool}
-                label={t('pool')}
-                canClick={false}
-                onClick={() => {}}
-              />
-            </HeadingWrapper>
-          )}
-
-          {/* proxy account display / hide if no proxy */}
-          {activeProxy && (
-            <HeadingWrapper>
-              <Account
-                canClick={false}
-                value={activeProxy}
-                readOnly={!accountHasSigner(activeProxy)}
-                label={t('proxy')}
-                format="name"
-              />
-            </HeadingWrapper>
-          )}
-        </>
-      )}
-    </>
+        )}
+      </>
+    )
   );
 };

--- a/src/library/Headers/index.tsx
+++ b/src/library/Headers/index.tsx
@@ -62,22 +62,20 @@ export const Headers = () => {
     onPoolsSyncing();
 
   return (
-    <>
-      <Wrapper>
-        {/* side menu toggle: shows on small screens */}
-        <SideMenuToggle />
+    <Wrapper>
+      {/* side menu toggle: shows on small screens */}
+      <SideMenuToggle />
 
-        {/* spinner to show app syncing */}
-        {syncing || pending.length > 0 ? <Spinner /> : null}
+      {/* spinner to show app syncing */}
+      {syncing || pending.length > 0 ? <Spinner /> : null}
 
-        {/* connected accounts */}
-        <LargeScreensOnly>
-          <Connected />
-        </LargeScreensOnly>
+      {/* connected accounts */}
+      <LargeScreensOnly>
+        <Connected />
+      </LargeScreensOnly>
 
-        {/* connect button */}
-        <Connect />
-      </Wrapper>
-    </>
+      {/* connect button */}
+      <Connect />
+    </Wrapper>
   );
 };

--- a/src/library/Help/index.tsx
+++ b/src/library/Help/index.tsx
@@ -47,7 +47,7 @@ export const Help = () => {
   }, [status]);
 
   // render early if help not open
-  if (status === 'closed') return <></>;
+  if (status === 'closed') return null;
 
   let meta: HelpItem | undefined;
 

--- a/src/library/ListItem/Labels/Blocked.tsx
+++ b/src/library/ListItem/Labels/Blocked.tsx
@@ -18,20 +18,18 @@ export const Blocked = ({ prefs }: BlockedProps) => {
   return (
     <>
       {blocked && (
-        <>
-          <div className="label">
-            <TooltipTrigger
-              className="tooltip-trigger-element"
-              data-tooltip-text={tooltipText}
-              onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
-            />
-            <FontAwesomeIcon
-              icon={faUserSlash}
-              color="#d2545d"
-              transform="shrink-1"
-            />
-          </div>
-        </>
+        <div className="label">
+          <TooltipTrigger
+            className="tooltip-trigger-element"
+            data-tooltip-text={tooltipText}
+            onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
+          />
+          <FontAwesomeIcon
+            icon={faUserSlash}
+            color="#d2545d"
+            transform="shrink-1"
+          />
+        </div>
       )}
     </>
   );

--- a/src/library/ListItem/Labels/Blocked.tsx
+++ b/src/library/ListItem/Labels/Blocked.tsx
@@ -16,21 +16,19 @@ export const Blocked = ({ prefs }: BlockedProps) => {
   const tooltipText = t('blockingNominations');
 
   return (
-    <>
-      {blocked && (
-        <div className="label">
-          <TooltipTrigger
-            className="tooltip-trigger-element"
-            data-tooltip-text={tooltipText}
-            onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
-          />
-          <FontAwesomeIcon
-            icon={faUserSlash}
-            color="#d2545d"
-            transform="shrink-1"
-          />
-        </div>
-      )}
-    </>
+    blocked && (
+      <div className="label">
+        <TooltipTrigger
+          className="tooltip-trigger-element"
+          data-tooltip-text={tooltipText}
+          onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
+        />
+        <FontAwesomeIcon
+          icon={faUserSlash}
+          color="#d2545d"
+          transform="shrink-1"
+        />
+      </div>
+    )
   );
 };

--- a/src/library/ListItem/Labels/Oversubscribed.tsx
+++ b/src/library/ListItem/Labels/Oversubscribed.tsx
@@ -36,32 +36,30 @@ export const Oversubscribed = ({ address }: OversubscribedProps) => {
   )} ${lowestRewardFormatted} ${unit}`;
 
   return (
-    <>
-      {displayOversubscribed && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.1 }}
-        >
-          <div className="label warning">
-            <TooltipTrigger
-              className="tooltip-trigger-element"
-              data-tooltip-text={tooltipText}
-              onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
-            />
-            <OverSubscribedWrapper>
-              <span className="warning">
-                <FontAwesomeIcon
-                  icon={faExclamationTriangle}
-                  transform="shrink-2"
-                  className="warning"
-                />
-              </span>
-              {lowestRewardFormatted} {unit}
-            </OverSubscribedWrapper>
-          </div>
-        </motion.div>
-      )}
-    </>
+    displayOversubscribed && (
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.1 }}
+      >
+        <div className="label warning">
+          <TooltipTrigger
+            className="tooltip-trigger-element"
+            data-tooltip-text={tooltipText}
+            onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
+          />
+          <OverSubscribedWrapper>
+            <span className="warning">
+              <FontAwesomeIcon
+                icon={faExclamationTriangle}
+                transform="shrink-2"
+                className="warning"
+              />
+            </span>
+            {lowestRewardFormatted} {unit}
+          </OverSubscribedWrapper>
+        </div>
+      </motion.div>
+    )
   );
 };

--- a/src/library/ListItem/Labels/ParaValidator.tsx
+++ b/src/library/ListItem/Labels/ParaValidator.tsx
@@ -17,7 +17,7 @@ export const ParaValidator = ({ address }: ParaValidatorProps) => {
   const tooltipText = t('validatingParachainBlocks');
 
   if (!sessionParaValidators?.includes(address || '')) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -67,18 +67,16 @@ export const PoolBonded = ({ pool }: { pool: Pool }) => {
   );
 
   return (
-    <>
-      <ValidatorStatusWrapper $status={nominationStatus} $noMargin>
-        <h5>
-          {nominationStatus === null || !eraStakers.stakers.length
-            ? `${t('syncing')}...`
-            : targets.length
-              ? capitalizeFirstLetter(t(`${nominationStatus}`) ?? '')
-              : t('notNominating')}
-          {' / '}
-          {t('bonded')}: {poolBonded.decimalPlaces(3).toFormat()} {unit}
-        </h5>
-      </ValidatorStatusWrapper>
-    </>
+    <ValidatorStatusWrapper $status={nominationStatus} $noMargin>
+      <h5>
+        {nominationStatus === null || !eraStakers.stakers.length
+          ? `${t('syncing')}...`
+          : targets.length
+            ? capitalizeFirstLetter(t(`${nominationStatus}`) ?? '')
+            : t('notNominating')}
+        {' / '}
+        {t('bonded')}: {poolBonded.decimalPlaces(3).toFormat()} {unit}
+      </h5>
+    </ValidatorStatusWrapper>
   );
 };

--- a/src/library/ListItem/Labels/PoolMemberBonded.tsx
+++ b/src/library/ListItem/Labels/PoolMemberBonded.tsx
@@ -40,15 +40,13 @@ export const PoolMemberBonded = ({ meta, batchKey, batchIndex }: any) => {
           <h5>{t('syncing')}...</h5>
         </ValidatorStatusWrapper>
       ) : (
-        <>
-          {greaterThanZero(bonded) && (
-            <ValidatorStatusWrapper $status={status}>
-              <h5>
-                {t('bonded')}: {bonded.decimalPlaces(3).toFormat()} {unit}
-              </h5>
-            </ValidatorStatusWrapper>
-          )}
-        </>
+        greaterThanZero(bonded) && (
+          <ValidatorStatusWrapper $status={status}>
+            <h5>
+              {t('bonded')}: {bonded.decimalPlaces(3).toFormat()} {unit}
+            </h5>
+          </ValidatorStatusWrapper>
+        )
       )}
 
       {poolMember && greaterThanZero(totalUnbonding) && (

--- a/src/library/Menu/index.tsx
+++ b/src/library/Menu/index.tsx
@@ -39,36 +39,34 @@ export const Menu = () => {
   );
 
   return (
-    <>
-      {menu.open === 1 && (
-        <Wrapper
-          ref={ref}
-          style={{
-            position: 'absolute',
-            left: `${position[0]}px`,
-            top: `${position[1]}px`,
-            zIndex: 99,
-            opacity: menu.show === 1 ? 1 : 0,
-          }}
-        >
-          {menu.items.map((item: any, i: number) => {
-            const { icon, title, cb } = item;
+    menu.open === 1 && (
+      <Wrapper
+        ref={ref}
+        style={{
+          position: 'absolute',
+          left: `${position[0]}px`,
+          top: `${position[1]}px`,
+          zIndex: 99,
+          opacity: menu.show === 1 ? 1 : 0,
+        }}
+      >
+        {menu.items.map((item: any, i: number) => {
+          const { icon, title, cb } = item;
 
-            return (
-              <ItemWrapper
-                key={`menu_item_${i}`}
-                onClick={() => {
-                  cb();
-                  menu.closeMenu();
-                }}
-              >
-                {icon}
-                <div className="title">{title}</div>
-              </ItemWrapper>
-            );
-          })}
-        </Wrapper>
-      )}
-    </>
+          return (
+            <ItemWrapper
+              key={`menu_item_${i}`}
+              onClick={() => {
+                cb();
+                menu.closeMenu();
+              }}
+            >
+              {icon}
+              <div className="title">{title}</div>
+            </ItemWrapper>
+          );
+        })}
+      </Wrapper>
+    )
   );
 };

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -49,26 +49,18 @@ export const NetworkBar = () => {
             <Status />
           )}
           {DISCLAIMER_URL !== undefined && (
-            <>
-              <p>
-                <a href={DISCLAIMER_URL} target="_blank" rel="noreferrer">
-                  {t('disclaimer')}
-                </a>
-              </p>
-            </>
+            <p>
+              <a href={DISCLAIMER_URL} target="_blank" rel="noreferrer">
+                {t('disclaimer')}
+              </a>
+            </p>
           )}
           {LEGAL_DISCLOSURES_URL !== undefined && (
-            <>
-              <p>
-                <a
-                  href={LEGAL_DISCLOSURES_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {t('legalDisclosures')}
-                </a>
-              </p>
-            </>
+            <p>
+              <a href={LEGAL_DISCLOSURES_URL} target="_blank" rel="noreferrer">
+                {t('legalDisclosures')}
+              </a>
+            </p>
           )}
         </section>
         <section>

--- a/src/library/PayeeInput/index.tsx
+++ b/src/library/PayeeInput/index.tsx
@@ -95,61 +95,57 @@ export const PayeeInput = ({
     payee.destination === 'None' ? t('noPayoutAddress') : t('payoutAddress');
 
   return (
-    <>
-      <Wrapper $activeInput={inputActive}>
-        <div className="inner">
-          <h4>{t('payoutAccount')}:</h4>
-          <div className="account">
-            {showEmpty ? (
-              <div className="emptyIcon" />
-            ) : (
-              <Polkicon
-                address={accountDisplay || ''}
-                size={remToUnit('2.5rem')}
-              />
-            )}
-            <div className="input" ref={showingRef}>
-              <input
-                type="text"
-                placeholder={placeholderDisplay}
-                disabled={payee.destination !== 'Account'}
-                value={accountDisplay || ''}
-                onFocus={() => setInputActive(true)}
-                onBlur={() => setInputActive(false)}
-                onChange={handleChangeAccount}
-              />
-              <div ref={hiddenRef} className="hidden">
-                {payee.destination === 'Account'
-                  ? activeAccount
-                  : accountDisplay}
-              </div>
+    <Wrapper $activeInput={inputActive}>
+      <div className="inner">
+        <h4>{t('payoutAccount')}:</h4>
+        <div className="account">
+          {showEmpty ? (
+            <div className="emptyIcon" />
+          ) : (
+            <Polkicon
+              address={accountDisplay || ''}
+              size={remToUnit('2.5rem')}
+            />
+          )}
+          <div className="input" ref={showingRef}>
+            <input
+              type="text"
+              placeholder={placeholderDisplay}
+              disabled={payee.destination !== 'Account'}
+              value={accountDisplay || ''}
+              onFocus={() => setInputActive(true)}
+              onBlur={() => setInputActive(false)}
+              onChange={handleChangeAccount}
+            />
+            <div ref={hiddenRef} className="hidden">
+              {payee.destination === 'Account' ? activeAccount : accountDisplay}
             </div>
           </div>
         </div>
-        <div className="label">
-          <h5>
-            {payee.destination === 'Account' ? (
-              <>
-                {account === '' ? (
-                  t('insertPayoutAddress')
-                ) : !valid ? (
-                  t('notValidAddress')
-                ) : (
-                  <>
-                    <FontAwesomeIcon icon={faCheck} />
-                    {t('validAddress')}
-                  </>
-                )}
-              </>
-            ) : payee.destination === 'None' ? null : (
-              <>
-                <FontAwesomeIcon icon={faCheck} />
-                {accountMeta?.name || ''}
-              </>
-            )}
-          </h5>
-        </div>
-      </Wrapper>
-    </>
+      </div>
+      <div className="label">
+        <h5>
+          {payee.destination === 'Account' ? (
+            <>
+              {account === '' ? (
+                t('insertPayoutAddress')
+              ) : !valid ? (
+                t('notValidAddress')
+              ) : (
+                <>
+                  <FontAwesomeIcon icon={faCheck} />
+                  {t('validAddress')}
+                </>
+              )}
+            </>
+          ) : payee.destination === 'None' ? null : (
+            <>
+              <FontAwesomeIcon icon={faCheck} />
+              {accountMeta?.name || ''}
+            </>
+          )}
+        </h5>
+      </div>
+    </Wrapper>
   );
 };

--- a/src/library/PayeeInput/index.tsx
+++ b/src/library/PayeeInput/index.tsx
@@ -126,18 +126,16 @@ export const PayeeInput = ({
       <div className="label">
         <h5>
           {payee.destination === 'Account' ? (
-            <>
-              {account === '' ? (
-                t('insertPayoutAddress')
-              ) : !valid ? (
-                t('notValidAddress')
-              ) : (
-                <>
-                  <FontAwesomeIcon icon={faCheck} />
-                  {t('validAddress')}
-                </>
-              )}
-            </>
+            account === '' ? (
+              t('insertPayoutAddress')
+            ) : !valid ? (
+              t('notValidAddress')
+            ) : (
+              <>
+                <FontAwesomeIcon icon={faCheck} />
+                {t('validAddress')}
+              </>
+            )
           ) : payee.destination === 'None' ? null : (
             <>
               <FontAwesomeIcon icon={faCheck} />

--- a/src/library/Prompt/index.tsx
+++ b/src/library/Prompt/index.tsx
@@ -8,7 +8,7 @@ export const Prompt = () => {
   const { closePrompt, size, status, Prompt: PromptInner } = usePrompt();
 
   if (status === 0) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/src/library/SideMenu/Main.tsx
+++ b/src/library/SideMenu/Main.tsx
@@ -147,15 +147,13 @@ export const Main = () => {
             style={{ maxHeight: '100%', width: '2rem' }}
           />
         ) : (
-          <>
-            <networkData.brand.logo.svg
-              style={{
-                maxHeight: '100%',
-                height: '100%',
-                width: networkData.brand.logo.width,
-              }}
-            />
-          </>
+          <networkData.brand.logo.svg
+            style={{
+              maxHeight: '100%',
+              height: '100%',
+              width: networkData.brand.logo.width,
+            }}
+          />
         )}
       </LogoWrapper>
 

--- a/src/library/StatBoxList/Number.tsx
+++ b/src/library/StatBoxList/Number.tsx
@@ -27,7 +27,7 @@ export const Number = ({
                 .decimalPlaces(decimals || 0)
                 .toFormat()}
             />
-            {unit ? <>{unit}</> : null}
+            {unit || null}
           </h3>
           <h4>
             {label}

--- a/src/library/StatBoxList/Pie.tsx
+++ b/src/library/StatBoxList/Pie.tsx
@@ -53,7 +53,7 @@ export const Pie = ({ label, stat, graph, tooltip, helpKey }: PieProps) => {
         <div className="labels">
           <h3>
             <Odometer value={new BigNumber(values.value).toFormat()} />
-            {stat?.unit && <>{stat?.unit}</>}
+            {stat?.unit && stat?.unit}
 
             {showTotal ? (
               <span className="total">

--- a/src/library/StatusLabel/index.tsx
+++ b/src/library/StatusLabel/index.tsx
@@ -29,13 +29,13 @@ export const StatusLabel = ({
   // syncing or not staking
   if (status === 'sync_or_setup') {
     if (isSyncing || !inSetup() || membership !== null) {
-      return <></>;
+      return null;
     }
   }
 
   if (status === 'active_service' && statusFor)
     if (plugins.includes(statusFor)) {
-      return <></>;
+      return null;
     }
 
   return (

--- a/src/library/SubmitTx/ManualSign/Ledger/index.tsx
+++ b/src/library/SubmitTx/ManualSign/Ledger/index.tsx
@@ -132,33 +132,31 @@ export const Ledger = ({
       <div className="inner msg">
         <div>
           {valid ? (
-            <>
-              <p className="prompt">
-                {!valid ? (
-                  '...'
-                ) : (
-                  <>
-                    <FontAwesomeIcon
-                      icon={faCircleExclamation}
-                      className="icon"
-                    />
-                    {feedback?.message
-                      ? feedback.message
-                      : !integrityChecked
-                        ? t('ledgerConnectAndConfirm')
-                        : `${t('deviceVerified')}. ${t('submitTransaction')}`}
-                  </>
-                )}
-                {feedback?.helpKey && (
-                  <ButtonHelp
-                    marginLeft
-                    onClick={() => {
-                      if (feedback?.helpKey) openHelp(feedback.helpKey);
-                    }}
+            <p className="prompt">
+              {!valid ? (
+                '...'
+              ) : (
+                <>
+                  <FontAwesomeIcon
+                    icon={faCircleExclamation}
+                    className="icon"
                   />
-                )}
-              </p>
-            </>
+                  {feedback?.message
+                    ? feedback.message
+                    : !integrityChecked
+                      ? t('ledgerConnectAndConfirm')
+                      : `${t('deviceVerified')}. ${t('submitTransaction')}`}
+                </>
+              )}
+              {feedback?.helpKey && (
+                <ButtonHelp
+                  marginLeft
+                  onClick={() => {
+                    if (feedback?.helpKey) openHelp(feedback.helpKey);
+                  }}
+                />
+              )}
+            </p>
           ) : (
             <p className="prompt">...</p>
           )}

--- a/src/library/Tips/Tip.tsx
+++ b/src/library/Tips/Tip.tsx
@@ -22,67 +22,63 @@ export const Tip = ({ title, description, page }: any) => {
 
   const [disabling, setDisabling] = useState<boolean>(false);
 
-  return (
+  return disabling ? (
     <>
-      {disabling ? (
-        <>
-          <Title title={t('module.dismissTips', { ns: 'tips' })} hideDone />
-          <div className="body">
-            <h4>{t('module.dismissResult', { ns: 'tips' })}</h4>
-            <h4>{t('module.reEnable', { ns: 'tips' })}</h4>
+      <Title title={t('module.dismissTips', { ns: 'tips' })} hideDone />
+      <div className="body">
+        <h4>{t('module.dismissResult', { ns: 'tips' })}</h4>
+        <h4>{t('module.reEnable', { ns: 'tips' })}</h4>
 
-            <div style={{ display: 'flex', marginTop: '1.5rem' }}>
-              <ButtonPrimary
-                marginRight
-                text={t('module.disableTips', { ns: 'tips' })}
-                onClick={() => {
-                  togglePlugin('tips');
-                  closePrompt();
-                }}
-              />
-              <ButtonPrimaryInvert
-                text={t('module.cancel', { ns: 'tips' })}
-                onClick={() => setDisabling(false)}
-                style={{ marginLeft: '0.5rem' }}
-              />
-            </div>
-          </div>
-        </>
-      ) : (
-        <>
-          <Title title={title} />
-          <div className="body">
-            {description.map((item: any, index: number) => (
-              <h4 key={`inner_def_${index}`} className="definition">
-                {item}
-              </h4>
-            ))}
-            <div style={{ marginTop: '1.75rem', display: 'flex' }}>
-              {!!page && (
-                <ButtonPrimary
-                  marginRight
-                  text={`${t('goTo', { ns: 'base' })} ${t(page, {
-                    ns: 'base',
-                  })}`}
-                  onClick={() => {
-                    closePrompt();
-                    navigate(`/${page}`);
-                  }}
-                  iconRight={faAngleRight}
-                  iconTransform="shrink-1"
-                />
-              )}
-              <ButtonSecondary
-                marginRight
-                text={t('module.disableTips', { ns: 'tips' })}
-                onClick={() => {
-                  setDisabling(true);
-                }}
-              />
-            </div>
-          </div>
-        </>
-      )}
+        <div style={{ display: 'flex', marginTop: '1.5rem' }}>
+          <ButtonPrimary
+            marginRight
+            text={t('module.disableTips', { ns: 'tips' })}
+            onClick={() => {
+              togglePlugin('tips');
+              closePrompt();
+            }}
+          />
+          <ButtonPrimaryInvert
+            text={t('module.cancel', { ns: 'tips' })}
+            onClick={() => setDisabling(false)}
+            style={{ marginLeft: '0.5rem' }}
+          />
+        </div>
+      </div>
+    </>
+  ) : (
+    <>
+      <Title title={title} />
+      <div className="body">
+        {description.map((item: any, index: number) => (
+          <h4 key={`inner_def_${index}`} className="definition">
+            {item}
+          </h4>
+        ))}
+        <div style={{ marginTop: '1.75rem', display: 'flex' }}>
+          {!!page && (
+            <ButtonPrimary
+              marginRight
+              text={`${t('goTo', { ns: 'base' })} ${t(page, {
+                ns: 'base',
+              })}`}
+              onClick={() => {
+                closePrompt();
+                navigate(`/${page}`);
+              }}
+              iconRight={faAngleRight}
+              iconTransform="shrink-1"
+            />
+          )}
+          <ButtonSecondary
+            marginRight
+            text={t('module.disableTips', { ns: 'tips' })}
+            onClick={() => {
+              setDisabling(true);
+            }}
+          />
+        </div>
+      </div>
     </>
   );
 };

--- a/src/library/Tooltip/index.tsx
+++ b/src/library/Tooltip/index.tsx
@@ -50,22 +50,20 @@ export const Tooltip = () => {
   };
 
   return (
-    <>
-      {open === 1 && (
-        <Wrapper
-          className="tooltip-trigger-element"
-          ref={tooltipRef}
-          style={{
-            position: 'absolute',
-            left: `${position[0]}px`,
-            top: `${position[1]}px`,
-            zIndex: 99,
-            opacity: show === 1 ? 1 : 0,
-          }}
-        >
-          <h3 className="tooltip-trigger-element">{text}</h3>
-        </Wrapper>
-      )}
-    </>
+    open === 1 && (
+      <Wrapper
+        className="tooltip-trigger-element"
+        ref={tooltipRef}
+        style={{
+          position: 'absolute',
+          left: `${position[0]}px`,
+          top: `${position[1]}px`,
+          zIndex: 99,
+          opacity: show === 1 ? 1 : 0,
+        }}
+      >
+        <h3 className="tooltip-trigger-element">{text}</h3>
+      </Wrapper>
+    )
   );
 };

--- a/src/modals/Accounts/Account.tsx
+++ b/src/modals/Accounts/Account.tsx
@@ -89,11 +89,9 @@ export const AccountButton = ({
             </div>
             <span className="name">
               {delegator && (
-                <>
-                  <span>
-                    {proxyType} {t('proxy')}
-                  </span>
-                </>
+                <span>
+                  {proxyType} {t('proxy')}
+                </span>
               )}
               {meta?.name ?? ellipsisFn(address ?? '')}
             </span>

--- a/src/modals/Accounts/Delegates/index.tsx
+++ b/src/modals/Accounts/Delegates/index.tsx
@@ -21,20 +21,16 @@ export const Delegates = ({ delegates, delegator }: DelegatesProps) => {
         getAccount(delegate || null)?.source !== 'external'
     ) || [];
 
-  return (
-    <>
-      {delegatesList.length ? (
-        <DelegatesWrapper>
-          {delegatesList.map(({ delegate, proxyType }, i) => (
-            <AccountButton
-              key={`_del_${i}`}
-              address={delegate}
-              delegator={delegator}
-              proxyType={proxyType}
-            />
-          ))}
-        </DelegatesWrapper>
-      ) : null}
-    </>
-  );
+  return delegatesList.length ? (
+    <DelegatesWrapper>
+      {delegatesList.map(({ delegate, proxyType }, i) => (
+        <AccountButton
+          key={`_del_${i}`}
+          address={delegate}
+          delegator={delegator}
+          proxyType={proxyType}
+        />
+      ))}
+    </DelegatesWrapper>
+  ) : null;
 };

--- a/src/modals/ClaimPayouts/Forms.tsx
+++ b/src/modals/ClaimPayouts/Forms.tsx
@@ -180,3 +180,5 @@ export const Forms = forwardRef(
     );
   }
 );
+
+Forms.displayName = 'Forms';

--- a/src/modals/ClaimPayouts/Overview.tsx
+++ b/src/modals/ClaimPayouts/Overview.tsx
@@ -42,3 +42,5 @@ export const Overview = forwardRef(
     );
   }
 );
+
+Overview.displayName = 'Overview';

--- a/src/modals/Connect/Ledger.tsx
+++ b/src/modals/Connect/Ledger.tsx
@@ -15,13 +15,12 @@ import {
   ModalHardwareItem,
 } from '@polkadot-cloud/react';
 import { inChrome } from '@polkadot-cloud/utils';
-import React from 'react';
 import { useHelp } from 'contexts/Help';
 import LedgerLogoSVG from '@polkadot-cloud/assets/extensions/svg/ledger.svg?react';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 
-export const Ledger = (): React.ReactElement => {
+export const Ledger = () => {
   const { openHelp } = useHelp();
   const { replaceModal } = useOverlay().modal;
   const { network } = useNetwork();
@@ -29,7 +28,7 @@ export const Ledger = (): React.ReactElement => {
 
   // Only render on Polkadot and Kusama networks.
   if (!['polkadot', 'kusama'].includes(network)) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/src/modals/Connect/Proxies.tsx
+++ b/src/modals/Connect/Proxies.tsx
@@ -61,16 +61,14 @@ export const Proxies = ({ setInputOpen, inputOpen }: ListWithInputProps) => {
       <ManualAccountsWrapper>
         <div className="content">
           {inputOpen && (
-            <>
-              <AccountInput
-                resetOnSuccess
-                defaultLabel={t('inputDelegatorAddress')}
-                successCallback={async (delegator) => {
-                  const result = await handleDeclareDelegate(delegator);
-                  return result;
-                }}
-              />
-            </>
+            <AccountInput
+              resetOnSuccess
+              defaultLabel={t('inputDelegatorAddress')}
+              successCallback={async (delegator) => {
+                const result = await handleDeclareDelegate(delegator);
+                return result;
+              }}
+            />
           )}
           {Object.entries(importedDelegates).length ? (
             <div className="accounts">

--- a/src/modals/Connect/index.tsx
+++ b/src/modals/Connect/index.tsx
@@ -129,105 +129,97 @@ export const Connect = () => {
   );
 
   return (
-    <>
-      <ModalSection type="carousel">
-        <Close />
-        <ModalFixedTitle ref={headerRef} withStyle>
-          <ModalCustomHeader>
-            <div className="first">
-              <h1>{t('connect')}</h1>
-              <ButtonPrimaryInvert
-                text={t('goToAccounts')}
-                iconRight={faChevronRight}
-                iconTransform="shrink-3"
-                onClick={() => replaceModal({ key: 'Accounts' })}
-                marginLeft
-              />
-            </div>
-            <ModalSection type="tab">
-              <ButtonTab
-                title={t('extensions')}
-                onClick={() => setSection(0)}
-                active={section === 0}
-              />
-              <ButtonTab
-                title={t('readOnly')}
-                onClick={() => setSection(1)}
-                active={section === 1}
-              />
-              <ButtonTab
-                title={t('proxies')}
-                onClick={() => setSection(2)}
-                active={section === 2}
-              />
-            </ModalSection>
-          </ModalCustomHeader>
-        </ModalFixedTitle>
+    <ModalSection type="carousel">
+      <Close />
+      <ModalFixedTitle ref={headerRef} withStyle>
+        <ModalCustomHeader>
+          <div className="first">
+            <h1>{t('connect')}</h1>
+            <ButtonPrimaryInvert
+              text={t('goToAccounts')}
+              iconRight={faChevronRight}
+              iconTransform="shrink-3"
+              onClick={() => replaceModal({ key: 'Accounts' })}
+              marginLeft
+            />
+          </div>
+          <ModalSection type="tab">
+            <ButtonTab
+              title={t('extensions')}
+              onClick={() => setSection(0)}
+              active={section === 0}
+            />
+            <ButtonTab
+              title={t('readOnly')}
+              onClick={() => setSection(1)}
+              active={section === 1}
+            />
+            <ButtonTab
+              title={t('proxies')}
+              onClick={() => setSection(2)}
+              active={section === 2}
+            />
+          </ModalSection>
+        </ModalCustomHeader>
+      </ModalFixedTitle>
 
-        <ModalMotionThreeSection
-          style={{
-            maxHeight: modalMaxHeight - (headerRef.current?.clientHeight || 0),
-          }}
-          animate={
-            section === 0 ? 'home' : section === 1 ? 'readOnly' : 'proxies'
-          }
-          transition={{
-            duration: 0.5,
-            type: 'spring',
-            bounce: 0.1,
-          }}
-          variants={{
-            home: {
-              left: 0,
-            },
-            readOnly: {
-              left: '-100%',
-            },
-            proxies: {
-              left: '-200%',
-            },
-          }}
-        >
-          <div className="section">
-            <ModalPadding horizontalOnly ref={homeRef}>
-              {ConnectCombinedJSX}
-              {!inNova && (
-                <>
-                  <ActionItem text={t('developerTools')} />
-                  <ExtensionsWrapper>
-                    <SelectItems layout="two-col">
-                      {ExtensionsArray.filter(
-                        (a) => a.id === 'polkadot-js'
-                      ).map((extension, i) => (
+      <ModalMotionThreeSection
+        style={{
+          maxHeight: modalMaxHeight - (headerRef.current?.clientHeight || 0),
+        }}
+        animate={
+          section === 0 ? 'home' : section === 1 ? 'readOnly' : 'proxies'
+        }
+        transition={{
+          duration: 0.5,
+          type: 'spring',
+          bounce: 0.1,
+        }}
+        variants={{
+          home: {
+            left: 0,
+          },
+          readOnly: {
+            left: '-100%',
+          },
+          proxies: {
+            left: '-200%',
+          },
+        }}
+      >
+        <div className="section">
+          <ModalPadding horizontalOnly ref={homeRef}>
+            {ConnectCombinedJSX}
+            {!inNova && (
+              <>
+                <ActionItem text={t('developerTools')} />
+                <ExtensionsWrapper>
+                  <SelectItems layout="two-col">
+                    {ExtensionsArray.filter((a) => a.id === 'polkadot-js').map(
+                      (extension, i) => (
                         <Extension
                           key={`extension_item_${i}`}
                           meta={extension}
                         />
-                      ))}
-                    </SelectItems>
-                  </ExtensionsWrapper>
-                </>
-              )}
-            </ModalPadding>
-          </div>
-          <div className="section">
-            <ModalPadding horizontalOnly ref={readOnlyRef}>
-              <ReadOnly
-                setInputOpen={setReadOnlyOpen}
-                inputOpen={readOnlyOpen}
-              />
-            </ModalPadding>
-          </div>
-          <div className="section">
-            <ModalPadding horizontalOnly ref={proxiesRef}>
-              <Proxies
-                setInputOpen={setNewProxyOpen}
-                inputOpen={newProxyOpen}
-              />
-            </ModalPadding>
-          </div>
-        </ModalMotionThreeSection>
-      </ModalSection>
-    </>
+                      )
+                    )}
+                  </SelectItems>
+                </ExtensionsWrapper>
+              </>
+            )}
+          </ModalPadding>
+        </div>
+        <div className="section">
+          <ModalPadding horizontalOnly ref={readOnlyRef}>
+            <ReadOnly setInputOpen={setReadOnlyOpen} inputOpen={readOnlyOpen} />
+          </ModalPadding>
+        </div>
+        <div className="section">
+          <ModalPadding horizontalOnly ref={proxiesRef}>
+            <Proxies setInputOpen={setNewProxyOpen} inputOpen={newProxyOpen} />
+          </ModalPadding>
+        </div>
+      </ModalMotionThreeSection>
+    </ModalSection>
   );
 };

--- a/src/modals/ImportLedger/Addresses.tsx
+++ b/src/modals/ImportLedger/Addresses.tsx
@@ -56,49 +56,47 @@ export const Addresess = ({ addresses, onGetAddress }: AnyJson) => {
   };
 
   return (
-    <>
-      <AddressesWrapper>
-        <div className="items">
-          {addresses.map(({ address, index }: AnyJson, i: number) => {
-            const initialName = (() => {
-              const localAddress = getLocalLedgerAddresses().find(
-                (a) => a.address === address && a.network === network
-              );
-              return localAddress?.name
-                ? unescape(localAddress.name)
-                : ellipsisFn(address);
-            })();
-
-            return (
-              <HardwareAddress
-                key={i}
-                address={address}
-                index={index}
-                initial={initialName}
-                Identicon={<Polkicon address={address} size={40} />}
-                existsHandler={ledgerAccountExists}
-                renameHandler={renameHandler}
-                openRemoveHandler={openRemoveHandler}
-                openConfirmHandler={openConfirmHandler}
-                t={{
-                  tRemove: t('remove'),
-                  tImport: t('import'),
-                }}
-              />
+    <AddressesWrapper>
+      <div className="items">
+        {addresses.map(({ address, index }: AnyJson, i: number) => {
+          const initialName = (() => {
+            const localAddress = getLocalLedgerAddresses().find(
+              (a) => a.address === address && a.network === network
             );
-          })}
-        </div>
-        <div className="more">
-          <ButtonText
-            iconLeft={faArrowDown}
-            text={isExecuting ? t('gettingAccount') : t('getAnotherAccount')}
-            disabled={isExecuting}
-            onClick={async () => {
-              await onGetAddress();
-            }}
-          />
-        </div>
-      </AddressesWrapper>
-    </>
+            return localAddress?.name
+              ? unescape(localAddress.name)
+              : ellipsisFn(address);
+          })();
+
+          return (
+            <HardwareAddress
+              key={i}
+              address={address}
+              index={index}
+              initial={initialName}
+              Identicon={<Polkicon address={address} size={40} />}
+              existsHandler={ledgerAccountExists}
+              renameHandler={renameHandler}
+              openRemoveHandler={openRemoveHandler}
+              openConfirmHandler={openConfirmHandler}
+              t={{
+                tRemove: t('remove'),
+                tImport: t('import'),
+              }}
+            />
+          );
+        })}
+      </div>
+      <div className="more">
+        <ButtonText
+          iconLeft={faArrowDown}
+          text={isExecuting ? t('gettingAccount') : t('getAnotherAccount')}
+          disabled={isExecuting}
+          onClick={async () => {
+            await onGetAddress();
+          }}
+        />
+      </div>
+    </AddressesWrapper>
   );
 };

--- a/src/modals/ImportLedger/index.tsx
+++ b/src/modals/ImportLedger/index.tsx
@@ -145,17 +145,13 @@ export const ImportLedger: FC = () => {
     };
   }, []);
 
-  return (
-    <>
-      {!addressesRef.current.length ? (
-        <Splash onGetAddress={onGetAddress} />
-      ) : (
-        <Manage
-          addresses={addressesRef.current}
-          removeLedgerAddress={removeLedgerAddress}
-          onGetAddress={onGetAddress}
-        />
-      )}
-    </>
+  return !addressesRef.current.length ? (
+    <Splash onGetAddress={onGetAddress} />
+  ) : (
+    <Manage
+      addresses={addressesRef.current}
+      removeLedgerAddress={removeLedgerAddress}
+      onGetAddress={onGetAddress}
+    />
   );
 };

--- a/src/modals/ImportVault/index.tsx
+++ b/src/modals/ImportVault/index.tsx
@@ -67,77 +67,73 @@ export const ImportVault = () => {
     setModalResize();
   }, [vaultAccounts]);
 
-  return (
+  return vaultAccounts.length === 0 ? (
+    <NoAccounts
+      Icon={PolkadotVaultSVG}
+      text={t('noVaultAccountsImported', { ns: 'modals' })}
+    >
+      <div>
+        <ButtonPrimary
+          lg
+          iconLeft={faQrcode}
+          text={t('importAccount', { ns: 'modals' })}
+          disabled={promptStatus !== 0}
+          onClick={() => {
+            openPromptWith(<Reader />, 'small');
+          }}
+        />
+      </div>
+    </NoAccounts>
+  ) : (
     <>
-      {vaultAccounts.length === 0 ? (
-        <NoAccounts
-          Icon={PolkadotVaultSVG}
-          text={t('noVaultAccountsImported', { ns: 'modals' })}
-        >
-          <div>
-            <ButtonPrimary
-              lg
-              iconLeft={faQrcode}
-              text={t('importAccount', { ns: 'modals' })}
-              disabled={promptStatus !== 0}
-              onClick={() => {
-                openPromptWith(<Reader />, 'small');
+      <Heading title={vaultAccounts.length ? 'Polkadot Vault' : ''} />
+      <AddressesWrapper>
+        <div className="items">
+          {vaultAccounts.map(({ address, name, index }: AnyJson, i) => (
+            <HardwareAddress
+              key={i}
+              address={address}
+              index={index}
+              initial={name}
+              Identicon={<Polkicon address={address} size={40} />}
+              existsHandler={vaultAccountExists}
+              renameHandler={renameHandler}
+              openRemoveHandler={openRemoveHandler}
+              openConfirmHandler={openConfirmHandler}
+              t={{
+                tRemove: t('remove', { ns: 'modals' }),
+                tImport: t('import', { ns: 'modals' }),
               }}
             />
-          </div>
-        </NoAccounts>
-      ) : (
-        <>
-          <Heading title={vaultAccounts.length ? 'Polkadot Vault' : ''} />
-          <AddressesWrapper>
-            <div className="items">
-              {vaultAccounts.map(({ address, name, index }: AnyJson, i) => (
-                <HardwareAddress
-                  key={i}
-                  address={address}
-                  index={index}
-                  initial={name}
-                  Identicon={<Polkicon address={address} size={40} />}
-                  existsHandler={vaultAccountExists}
-                  renameHandler={renameHandler}
-                  openRemoveHandler={openRemoveHandler}
-                  openConfirmHandler={openConfirmHandler}
-                  t={{
-                    tRemove: t('remove', { ns: 'modals' }),
-                    tImport: t('import', { ns: 'modals' }),
-                  }}
-                />
-              ))}
-            </div>
-            <div className="more">
-              <ButtonText
-                iconLeft={faQrcode}
-                text={t('importAnotherAccount', { ns: 'modals' })}
-                disabled={promptStatus !== 0}
-                onClick={() => {
-                  openPromptWith(<Reader />, 'small');
-                }}
-              />
-            </div>
-          </AddressesWrapper>
-          <HardwareStatusBar
-            show
-            Icon={PolkadotVaultSVG}
-            text={t('vaultAccounts', {
-              ns: 'modals',
-              count: vaultAccounts.length,
-            })}
-            inProgress={false}
-            handleDone={() =>
-              replaceModal({ key: 'Connect', options: { disableScroll: true } })
-            }
-            t={{
-              tDone: t('done', { ns: 'library' }),
-              tCancel: t('cancel', { ns: 'library' }),
+          ))}
+        </div>
+        <div className="more">
+          <ButtonText
+            iconLeft={faQrcode}
+            text={t('importAnotherAccount', { ns: 'modals' })}
+            disabled={promptStatus !== 0}
+            onClick={() => {
+              openPromptWith(<Reader />, 'small');
             }}
           />
-        </>
-      )}
+        </div>
+      </AddressesWrapper>
+      <HardwareStatusBar
+        show
+        Icon={PolkadotVaultSVG}
+        text={t('vaultAccounts', {
+          ns: 'modals',
+          count: vaultAccounts.length,
+        })}
+        inProgress={false}
+        handleDone={() =>
+          replaceModal({ key: 'Connect', options: { disableScroll: true } })
+        }
+        t={{
+          tDone: t('done', { ns: 'library' }),
+          tCancel: t('cancel', { ns: 'library' }),
+        }}
+      />
     </>
   );
 };

--- a/src/modals/ManageFastUnstake/index.tsx
+++ b/src/modals/ManageFastUnstake/index.tsx
@@ -171,33 +171,29 @@ export const ManageFastUnstake = () => {
               </p>
             </ModalNotes>
           </>
+        ) : !isFastUnstaking ? (
+          <>
+            <ActionItem text={t('fastUnstake', { context: 'register' })} />
+            <ModalNotes>
+              <p>
+                {t('registerFastUnstake')}{' '}
+                {planckToUnit(fastUnstakeDeposit, units).toString()} {unit}.{' '}
+                {t('fastUnstakeOnceRegistered')}
+              </p>
+              <p>
+                {t('fastUnstakeCurrentQueue')}: <b>{counterForQueue}</b>
+              </p>
+            </ModalNotes>
+          </>
         ) : (
           <>
-            {!isFastUnstaking ? (
-              <>
-                <ActionItem text={t('fastUnstake', { context: 'register' })} />
-                <ModalNotes>
-                  <p>
-                    {t('registerFastUnstake')}{' '}
-                    {planckToUnit(fastUnstakeDeposit, units).toString()} {unit}.{' '}
-                    {t('fastUnstakeOnceRegistered')}
-                  </p>
-                  <p>
-                    {t('fastUnstakeCurrentQueue')}: <b>{counterForQueue}</b>
-                  </p>
-                </ModalNotes>
-              </>
-            ) : (
-              <>
-                <ActionItem text={t('fastUnstakeRegistered')} />
-                <ModalNotes>
-                  <p>
-                    {t('fastUnstakeCurrentQueue')}: <b>{counterForQueue}</b>
-                  </p>
-                  <p>{t('fastUnstakeUnorderedNote')}</p>
-                </ModalNotes>
-              </>
-            )}
+            <ActionItem text={t('fastUnstakeRegistered')} />
+            <ModalNotes>
+              <p>
+                {t('fastUnstakeCurrentQueue')}: <b>{counterForQueue}</b>
+              </p>
+              <p>{t('fastUnstakeUnorderedNote')}</p>
+            </ModalNotes>
           </>
         )}
       </ModalPadding>

--- a/src/modals/ManageFastUnstake/index.tsx
+++ b/src/modals/ManageFastUnstake/index.tsx
@@ -178,11 +178,9 @@ export const ManageFastUnstake = () => {
                 <ActionItem text={t('fastUnstake', { context: 'register' })} />
                 <ModalNotes>
                   <p>
-                    <>
-                      {t('registerFastUnstake')}{' '}
-                      {planckToUnit(fastUnstakeDeposit, units).toString()}{' '}
-                      {unit}. {t('fastUnstakeOnceRegistered')}
-                    </>
+                    {t('registerFastUnstake')}{' '}
+                    {planckToUnit(fastUnstakeDeposit, units).toString()} {unit}.{' '}
+                    {t('fastUnstakeOnceRegistered')}
                   </p>
                   <p>
                     {t('fastUnstakeCurrentQueue')}: <b>{counterForQueue}</b>

--- a/src/modals/ManagePool/Forms/ManageCommission/ChangeRate.tsx
+++ b/src/modals/ManagePool/Forms/ManageCommission/ChangeRate.tsx
@@ -131,76 +131,74 @@ export const ChangeRate = ({
   })();
 
   return (
-    <>
-      {getEnabled('change_rate') && (
-        <SliderWrapper>
-          <div>
-            <h2>{changeRate.maxIncrease}% </h2>
-            <h5 className={maxIncreaseFeedback?.label || 'neutral'}>
-              {!!maxIncreaseFeedback && maxIncreaseFeedback.text}
-            </h5>
-          </div>
-
-          <StyledSlider
-            value={changeRate.maxIncrease}
-            step={0.1}
-            onChange={(val) => {
-              if (typeof val === 'number') {
-                setChangeRate({
-                  ...changeRate,
-                  maxIncrease: val,
-                });
-              }
-            }}
-          />
-
-          <h5 style={{ marginTop: '1rem' }}>
-            {t('minDelayBetweenUpdates')}
-            {minDelayFeedback && (
-              <span className={minDelayFeedback?.label || 'neutral'}>
-                {minDelayFeedback.text}
-              </span>
-            )}
+    getEnabled('change_rate') && (
+      <SliderWrapper>
+        <div>
+          <h2>{changeRate.maxIncrease}% </h2>
+          <h5 className={maxIncreaseFeedback?.label || 'neutral'}>
+            {!!maxIncreaseFeedback && maxIncreaseFeedback.text}
           </h5>
-          <div className="changeRate">
-            <MinDelayInput
-              initial={changeRateInput.years}
-              field="years"
-              label={t('years')}
-              handleChange={handleChangeRateInput}
-            />
-            <MinDelayInput
-              initial={changeRateInput.months}
-              field="months"
-              label={t('months')}
-              handleChange={handleChangeRateInput}
-            />
-            <MinDelayInput
-              initial={changeRateInput.days}
-              field="days"
-              label={t('days')}
-              handleChange={handleChangeRateInput}
-            />
-            <MinDelayInput
-              initial={changeRateInput.hours}
-              field="hours"
-              label={t('hours')}
-              handleChange={handleChangeRateInput}
-            />
-            <MinDelayInput
-              initial={changeRateInput.minutes}
-              field="minutes"
-              label={t('minutes')}
-              handleChange={handleChangeRateInput}
-            />
-          </div>
-          <p>
-            {t('thisMinimumDelay', {
-              count: changeRate.minDelay,
-            })}
-          </p>
-        </SliderWrapper>
-      )}
-    </>
+        </div>
+
+        <StyledSlider
+          value={changeRate.maxIncrease}
+          step={0.1}
+          onChange={(val) => {
+            if (typeof val === 'number') {
+              setChangeRate({
+                ...changeRate,
+                maxIncrease: val,
+              });
+            }
+          }}
+        />
+
+        <h5 style={{ marginTop: '1rem' }}>
+          {t('minDelayBetweenUpdates')}
+          {minDelayFeedback && (
+            <span className={minDelayFeedback?.label || 'neutral'}>
+              {minDelayFeedback.text}
+            </span>
+          )}
+        </h5>
+        <div className="changeRate">
+          <MinDelayInput
+            initial={changeRateInput.years}
+            field="years"
+            label={t('years')}
+            handleChange={handleChangeRateInput}
+          />
+          <MinDelayInput
+            initial={changeRateInput.months}
+            field="months"
+            label={t('months')}
+            handleChange={handleChangeRateInput}
+          />
+          <MinDelayInput
+            initial={changeRateInput.days}
+            field="days"
+            label={t('days')}
+            handleChange={handleChangeRateInput}
+          />
+          <MinDelayInput
+            initial={changeRateInput.hours}
+            field="hours"
+            label={t('hours')}
+            handleChange={handleChangeRateInput}
+          />
+          <MinDelayInput
+            initial={changeRateInput.minutes}
+            field="minutes"
+            label={t('minutes')}
+            handleChange={handleChangeRateInput}
+          />
+        </div>
+        <p>
+          {t('thisMinimumDelay', {
+            count: changeRate.minDelay,
+          })}
+        </p>
+      </SliderWrapper>
+    )
   );
 };

--- a/src/modals/ManagePool/Forms/ManageCommission/MaxCommission.tsx
+++ b/src/modals/ManagePool/Forms/ManageCommission/MaxCommission.tsx
@@ -46,30 +46,28 @@ export const MaxCommission = ({
   })();
 
   return (
-    <>
-      {getEnabled('max_commission') && (
-        <SliderWrapper>
-          <div>
-            <h2>{maxCommission}% </h2>
-            <h5 className={maxCommissionFeedback?.label || 'neutral'}>
-              {!!maxCommissionFeedback && maxCommissionFeedback.text}
-            </h5>
-          </div>
+    getEnabled('max_commission') && (
+      <SliderWrapper>
+        <div>
+          <h2>{maxCommission}% </h2>
+          <h5 className={maxCommissionFeedback?.label || 'neutral'}>
+            {!!maxCommissionFeedback && maxCommissionFeedback.text}
+          </h5>
+        </div>
 
-          <StyledSlider
-            value={maxCommission}
-            step={0.1}
-            onChange={(val) => {
-              if (typeof val === 'number') {
-                setMaxCommission(val);
-                if (val < commission) {
-                  setCommission(val);
-                }
+        <StyledSlider
+          value={maxCommission}
+          step={0.1}
+          onChange={(val) => {
+            if (typeof val === 'number') {
+              setMaxCommission(val);
+              if (val < commission) {
+                setCommission(val);
               }
-            }}
-          />
-        </SliderWrapper>
-      )}
-    </>
+            }
+          }}
+        />
+      </SliderWrapper>
+    )
   );
 };

--- a/src/modals/ManagePool/Forms/index.tsx
+++ b/src/modals/ManagePool/Forms/index.tsx
@@ -38,3 +38,5 @@ export const Forms = forwardRef(
     </PoolCommissionProvider>
   )
 );
+
+Forms.displayName = 'Forms';

--- a/src/modals/ManagePool/Tasks.tsx
+++ b/src/modals/ManagePool/Tasks.tsx
@@ -31,34 +31,30 @@ export const Tasks = forwardRef(({ setSection, setTask }: any, ref: any) => {
         <div style={{ paddingBottom: '0.75rem' }}>
           {poolDestroying && <Warning text={t('beingDestroyed')} />}
         </div>
-        {isOwner() && (
+        {isOwner() && globalMaxCommission > 0 && (
           <>
-            {globalMaxCommission > 0 && (
-              <>
-                <ButtonOption
-                  onClick={() => {
-                    setSection(1);
-                    setTask('claim_commission');
-                  }}
-                >
-                  <div>
-                    <h3>{t('claimCommission')}</h3>
-                    <p>{t('claimOutstandingCommission')}</p>
-                  </div>
-                </ButtonOption>
-                <ButtonOption
-                  onClick={() => {
-                    setSection(1);
-                    setTask('manage_commission');
-                  }}
-                >
-                  <div>
-                    <h3>{t('manageCommission')}</h3>
-                    <p>{t('updatePoolCommission')}</p>
-                  </div>
-                </ButtonOption>
-              </>
-            )}
+            <ButtonOption
+              onClick={() => {
+                setSection(1);
+                setTask('claim_commission');
+              }}
+            >
+              <div>
+                <h3>{t('claimCommission')}</h3>
+                <p>{t('claimOutstandingCommission')}</p>
+              </div>
+            </ButtonOption>
+            <ButtonOption
+              onClick={() => {
+                setSection(1);
+                setTask('manage_commission');
+              }}
+            >
+              <div>
+                <h3>{t('manageCommission')}</h3>
+                <p>{t('updatePoolCommission')}</p>
+              </div>
+            </ButtonOption>
           </>
         )}
         <ButtonOption

--- a/src/modals/ManagePool/Tasks.tsx
+++ b/src/modals/ManagePool/Tasks.tsx
@@ -143,3 +143,5 @@ export const Tasks = forwardRef(({ setSection, setTask }: any, ref: any) => {
     </ContentWrapper>
   );
 });
+
+Tasks.displayName = 'Tasks';

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -207,25 +207,23 @@ export const Unbond = () => {
         />
         <ModalNotes withPadding>
           {bondFor === 'pool' ? (
-            <>
-              {isDepositor() ? (
-                <p>
-                  {t('notePoolDepositorMinBond', {
-                    context: 'depositor',
-                    bond: minCreateBond,
-                    unit,
-                  })}
-                </p>
-              ) : (
-                <p>
-                  {t('notePoolDepositorMinBond', {
-                    context: 'member',
-                    bond: minJoinBond,
-                    unit,
-                  })}
-                </p>
-              )}
-            </>
+            isDepositor() ? (
+              <p>
+                {t('notePoolDepositorMinBond', {
+                  context: 'depositor',
+                  bond: minCreateBond,
+                  unit,
+                })}
+              </p>
+            ) : (
+              <p>
+                {t('notePoolDepositorMinBond', {
+                  context: 'member',
+                  bond: minJoinBond,
+                  unit,
+                })}
+              </p>
+            )
           ) : null}
           <StaticNote
             value={bondDurationFormatted}

--- a/src/modals/UnlockChunks/Forms.tsx
+++ b/src/modals/UnlockChunks/Forms.tsx
@@ -178,3 +178,5 @@ export const Forms = forwardRef(
     );
   }
 );
+
+Forms.displayName = 'Forms';

--- a/src/modals/UnlockChunks/Overview.tsx
+++ b/src/modals/UnlockChunks/Overview.tsx
@@ -145,3 +145,5 @@ export const Overview = forwardRef(
     );
   }
 );
+
+Overview.displayName = 'Overview';

--- a/src/pages/Nominate/Active/ControllerNotStash.tsx
+++ b/src/pages/Nominate/Active/ControllerNotStash.tsx
@@ -38,33 +38,28 @@ export const ControllerNotStash = () => {
     setShowPrompt(addressDifferentToStash(controller));
   }, [controller]);
 
-  return (
-    <>
-      {showPrompt
-        ? !isSyncing &&
-          !isReadOnlyAccount(activeAccount) && (
-            <PageRow>
-              <CardWrapper className="warning">
-                <CardHeaderWrapper>
-                  <h3 style={{ marginBottom: '0.75rem' }}>
-                    <FontAwesomeIcon icon={faExclamationTriangle} />
-                    &nbsp; {t('nominate.controllerAccountsDeprecated')}
-                  </h3>
-                  <h4>
-                    {t('nominate.proxyprompt')} {stringUpperFirst(network)}.
-                  </h4>
-                </CardHeaderWrapper>
-                <div>
-                  <ButtonPrimary
-                    text={t('nominate.updateToStash')}
-                    iconLeft={faCircleArrowRight}
-                    onClick={() => openModal({ key: 'UpdateController' })}
-                  />
-                </div>
-              </CardWrapper>
-            </PageRow>
-          )
-        : null}
-    </>
-  );
+  return showPrompt
+    ? !isSyncing && !isReadOnlyAccount(activeAccount) && (
+        <PageRow>
+          <CardWrapper className="warning">
+            <CardHeaderWrapper>
+              <h3 style={{ marginBottom: '0.75rem' }}>
+                <FontAwesomeIcon icon={faExclamationTriangle} />
+                &nbsp; {t('nominate.controllerAccountsDeprecated')}
+              </h3>
+              <h4>
+                {t('nominate.proxyprompt')} {stringUpperFirst(network)}.
+              </h4>
+            </CardHeaderWrapper>
+            <div>
+              <ButtonPrimary
+                text={t('nominate.updateToStash')}
+                iconLeft={faCircleArrowRight}
+                onClick={() => openModal({ key: 'UpdateController' })}
+              />
+            </div>
+          </CardWrapper>
+        </PageRow>
+      )
+    : null;
 };

--- a/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -35,66 +35,63 @@ export const UnstakePrompts = () => {
     isNotZero(totalUnlocked);
 
   return (
-    <>
-      {(isUnstaking || isFastUnstaking) && !isNetworkSyncing && (
-        <PageRow>
-          <CardWrapper
-            style={{ border: `1px solid ${annuncementBorderColor}` }}
-          >
-            <div className="content">
-              <h3>
-                {t('nominate.unstakePromptInProgress', {
-                  context: isFastUnstaking ? 'fast' : 'regular',
-                })}
-              </h3>
-              <h4>
-                {isFastUnstaking
-                  ? t('nominate.unstakePromptInQueue')
-                  : !canWithdrawUnlocks
-                    ? t('nominate.unstakePromptWaitingForUnlocks')
-                    : `${t('nominate.unstakePromptReadyToWithdraw')} ${t(
-                        'nominate.unstakePromptRevert',
-                        { unit }
-                      )}`}
-              </h4>
-              <ButtonRow yMargin>
-                {isFastUnstaking ? (
-                  <ButtonPrimary
-                    marginRight
-                    iconLeft={faBolt}
-                    text={getFastUnstakeText()}
-                    onClick={() =>
-                      openModal({ key: 'ManageFastUnstake', size: 'sm' })
-                    }
-                  />
-                ) : (
-                  <ButtonPrimary
-                    iconLeft={faLockOpen}
-                    text={
-                      canWithdrawUnlocks
-                        ? t('nominate.unlocked')
-                        : String(totalUnlockChunks ?? 0)
-                    }
-                    disabled={false}
-                    onClick={() =>
-                      openModal({
-                        key: 'UnlockChunks',
-                        options: {
-                          bondFor: 'nominator',
-                          poolClosure: true,
-                          disableWindowResize: true,
-                          disableScroll: true,
-                        },
-                        size: 'sm',
-                      })
-                    }
-                  />
-                )}
-              </ButtonRow>
-            </div>
-          </CardWrapper>
-        </PageRow>
-      )}
-    </>
+    (isUnstaking || isFastUnstaking) &&
+    !isNetworkSyncing && (
+      <PageRow>
+        <CardWrapper style={{ border: `1px solid ${annuncementBorderColor}` }}>
+          <div className="content">
+            <h3>
+              {t('nominate.unstakePromptInProgress', {
+                context: isFastUnstaking ? 'fast' : 'regular',
+              })}
+            </h3>
+            <h4>
+              {isFastUnstaking
+                ? t('nominate.unstakePromptInQueue')
+                : !canWithdrawUnlocks
+                  ? t('nominate.unstakePromptWaitingForUnlocks')
+                  : `${t('nominate.unstakePromptReadyToWithdraw')} ${t(
+                      'nominate.unstakePromptRevert',
+                      { unit }
+                    )}`}
+            </h4>
+            <ButtonRow yMargin>
+              {isFastUnstaking ? (
+                <ButtonPrimary
+                  marginRight
+                  iconLeft={faBolt}
+                  text={getFastUnstakeText()}
+                  onClick={() =>
+                    openModal({ key: 'ManageFastUnstake', size: 'sm' })
+                  }
+                />
+              ) : (
+                <ButtonPrimary
+                  iconLeft={faLockOpen}
+                  text={
+                    canWithdrawUnlocks
+                      ? t('nominate.unlocked')
+                      : String(totalUnlockChunks ?? 0)
+                  }
+                  disabled={false}
+                  onClick={() =>
+                    openModal({
+                      key: 'UnlockChunks',
+                      options: {
+                        bondFor: 'nominator',
+                        poolClosure: true,
+                        disableWindowResize: true,
+                        disableScroll: true,
+                      },
+                      size: 'sm',
+                    })
+                  }
+                />
+              )}
+            </ButtonRow>
+          </div>
+        </CardWrapper>
+      </PageRow>
+    )
   );
 };

--- a/src/pages/Overview/ActiveAccounts/Item.tsx
+++ b/src/pages/Overview/ActiveAccounts/Item.tsx
@@ -54,12 +54,10 @@ export const Item = ({ address, delegate = null }: ActiveAccountProps) => {
                 <Polkicon address={primaryAddress} size={remToUnit('1.7rem')} />
               </div>
               {delegatorAddress && (
-                <>
-                  <span>
-                    {proxyDelegate?.proxyType} {t('overview.proxy')}
-                    <FontAwesomeIcon icon={faArrowLeft} transform="shrink-2" />
-                  </span>
-                </>
+                <span>
+                  {proxyDelegate?.proxyType} {t('overview.proxy')}
+                  <FontAwesomeIcon icon={faArrowLeft} transform="shrink-2" />
+                </span>
               )}
               {ellipsisFn(primaryAddress)}
               <button

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -109,7 +109,7 @@ export const PayoutListInner = ({
   }
 
   if (!payouts.length) {
-    return <></>;
+    return null;
   }
 
   return (
@@ -206,26 +206,20 @@ export const PayoutListInner = ({
                     <div className="row">
                       <div>
                         <div>
-                          {label === t('payouts.payout') && (
-                            <>
-                              {batchIndex > 0 ? (
-                                <Identity address={p.validator_stash} />
-                              ) : (
-                                <div>{ellipsisFn(p.validator_stash)}</div>
-                              )}
-                            </>
-                          )}
-                          {label === t('payouts.poolClaim') && (
-                            <>
-                              {pool ? (
-                                <PoolIdentity pool={pool} />
-                              ) : (
-                                <h4>
-                                  {t('payouts.fromPool')} {p.pool_id}
-                                </h4>
-                              )}
-                            </>
-                          )}
+                          {label === t('payouts.payout') &&
+                            (batchIndex > 0 ? (
+                              <Identity address={p.validator_stash} />
+                            ) : (
+                              <div>{ellipsisFn(p.validator_stash)}</div>
+                            ))}
+                          {label === t('payouts.poolClaim') &&
+                            (pool ? (
+                              <PoolIdentity pool={pool} />
+                            ) : (
+                              <h4>
+                                {t('payouts.fromPool')} {p.pool_id}
+                              </h4>
+                            ))}
                           {label === t('payouts.slashed') && (
                             <h4>{t('payouts.deductedFromBond')}</h4>
                           )}

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -106,9 +106,7 @@ export const Payouts = ({ page }: PageProps) => {
           </div>
         </CardWrapper>
       </PageRow>
-      {!payoutsList?.length ? (
-        <></>
-      ) : (
+      {!!payoutsList?.length && (
         <PageRow>
           <CardWrapper>
             <PayoutList

--- a/src/pages/Pools/Home/ClosurePrompts.tsx
+++ b/src/pages/Pools/Home/ClosurePrompts.tsx
@@ -46,66 +46,62 @@ export const ClosurePrompts = () => {
     active.toNumber() === 0 && totalUnlockChunks === 0 && !targets.length;
 
   return (
-    <>
-      {depositorCanClose && (
-        <PageRow>
-          <CardWrapper
-            style={{ border: `1px solid ${annuncementBorderColor}` }}
-          >
-            <div className="content">
-              <h3>{t('pools.destroyPool')}</h3>
-              <h4>
-                {t('pools.leftThePool')}.{' '}
-                {targets.length > 0
-                  ? t('pools.stopNominating')
-                  : depositorCanWithdraw
-                    ? t('pools.closePool')
-                    : depositorCanUnbond
-                      ? t('pools.unbondYourFunds')
-                      : t('pools.withdrawUnlock')}
-              </h4>
-              <ButtonRow yMargin>
-                <ButtonPrimary
-                  marginRight
-                  text={t('pools.unbond')}
-                  disabled={
-                    isPoolSyncing ||
-                    (!depositorCanWithdraw && !depositorCanUnbond)
-                  }
-                  onClick={() =>
-                    openModal({
-                      key: 'UnbondPoolMember',
-                      options: { who: activeAccount, member: membership },
-                      size: 'sm',
-                    })
-                  }
-                />
-                <ButtonPrimary
-                  iconLeft={faLockOpen}
-                  text={
-                    depositorCanWithdraw
-                      ? t('pools.unlocked')
-                      : String(totalUnlockChunks ?? 0)
-                  }
-                  disabled={isPoolSyncing || !isBonding()}
-                  onClick={() =>
-                    openModal({
-                      key: 'UnlockChunks',
-                      options: {
-                        bondFor: 'pool',
-                        poolClosure: true,
-                        disableWindowResize: true,
-                        disableScroll: true,
-                      },
-                      size: 'sm',
-                    })
-                  }
-                />
-              </ButtonRow>
-            </div>
-          </CardWrapper>
-        </PageRow>
-      )}
-    </>
+    depositorCanClose && (
+      <PageRow>
+        <CardWrapper style={{ border: `1px solid ${annuncementBorderColor}` }}>
+          <div className="content">
+            <h3>{t('pools.destroyPool')}</h3>
+            <h4>
+              {t('pools.leftThePool')}.{' '}
+              {targets.length > 0
+                ? t('pools.stopNominating')
+                : depositorCanWithdraw
+                  ? t('pools.closePool')
+                  : depositorCanUnbond
+                    ? t('pools.unbondYourFunds')
+                    : t('pools.withdrawUnlock')}
+            </h4>
+            <ButtonRow yMargin>
+              <ButtonPrimary
+                marginRight
+                text={t('pools.unbond')}
+                disabled={
+                  isPoolSyncing ||
+                  (!depositorCanWithdraw && !depositorCanUnbond)
+                }
+                onClick={() =>
+                  openModal({
+                    key: 'UnbondPoolMember',
+                    options: { who: activeAccount, member: membership },
+                    size: 'sm',
+                  })
+                }
+              />
+              <ButtonPrimary
+                iconLeft={faLockOpen}
+                text={
+                  depositorCanWithdraw
+                    ? t('pools.unlocked')
+                    : String(totalUnlockChunks ?? 0)
+                }
+                disabled={isPoolSyncing || !isBonding()}
+                onClick={() =>
+                  openModal({
+                    key: 'UnlockChunks',
+                    options: {
+                      bondFor: 'pool',
+                      poolClosure: true,
+                      disableWindowResize: true,
+                      disableScroll: true,
+                    },
+                    size: 'sm',
+                  })
+                }
+              />
+            </ButtonRow>
+          </div>
+        </CardWrapper>
+      </PageRow>
+    )
   );
 };

--- a/src/pages/Pools/Home/Favorites/index.tsx
+++ b/src/pages/Pools/Home/Favorites/index.tsx
@@ -38,25 +38,23 @@ export const PoolFavorites = () => {
   }, [favorites]);
 
   return (
-    <>
-      <PageRow>
-        <CardWrapper>
-          {favoritesList === null || isPoolSyncing ? (
-            <ListStatusHeader>
-              {t('pools.fetchingFavoritePools')}...
-            </ListStatusHeader>
+    <PageRow>
+      <CardWrapper>
+        {favoritesList === null || isPoolSyncing ? (
+          <ListStatusHeader>
+            {t('pools.fetchingFavoritePools')}...
+          </ListStatusHeader>
+        ) : (
+          isReady &&
+          (favoritesList.length > 0 ? (
+            <PoolListProvider>
+              <PoolList pools={favoritesList} allowMoreCols pagination />
+            </PoolListProvider>
           ) : (
-            isReady &&
-            (favoritesList.length > 0 ? (
-              <PoolListProvider>
-                <PoolList pools={favoritesList} allowMoreCols pagination />
-              </PoolListProvider>
-            ) : (
-              <ListStatusHeader>{t('pools.noFavorites')}</ListStatusHeader>
-            ))
-          )}
-        </CardWrapper>
-      </PageRow>
-    </>
+            <ListStatusHeader>{t('pools.noFavorites')}</ListStatusHeader>
+          ))
+        )}
+      </CardWrapper>
+    </PageRow>
   );
 };

--- a/src/pages/Pools/Home/MembersList/Default.tsx
+++ b/src/pages/Pools/Home/MembersList/Default.tsx
@@ -117,71 +117,61 @@ export const MembersListInner = ({
     }
   }, [renderIterationRef.current]);
 
-  return (
-    <>
-      {!members.length ? (
-        <></>
-      ) : (
-        <ListWrapper>
-          <Header>
-            <div />
-            <div>
-              <button type="button" onClick={() => setListFormat('row')}>
-                <FontAwesomeIcon
-                  icon={faBars}
-                  color={
-                    listFormat === 'row' ? colors.primary[mode] : 'inherit'
-                  }
+  return !members.length ? null : (
+    <ListWrapper>
+      <Header>
+        <div />
+        <div>
+          <button type="button" onClick={() => setListFormat('row')}>
+            <FontAwesomeIcon
+              icon={faBars}
+              color={listFormat === 'row' ? colors.primary[mode] : 'inherit'}
+            />
+          </button>
+          <button type="button" onClick={() => setListFormat('col')}>
+            <FontAwesomeIcon
+              icon={faGripVertical}
+              color={listFormat === 'col' ? colors.primary[mode] : 'inherit'}
+            />
+          </button>
+        </div>
+      </Header>
+      <List $flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
+        {listMembers.length > 0 && pagination && (
+          <Pagination page={page} total={totalPages} setter={setPage} />
+        )}
+        {fetched !== 'synced' ? (
+          <ListStatusHeader style={{ marginTop: '0.5rem' }}>
+            {t('pools.fetchingMemberList')}...
+          </ListStatusHeader>
+        ) : (
+          <MotionContainer>
+            {listMembers.map((member: PoolMember, index: number) => (
+              <motion.div
+                className={`item ${listFormat === 'row' ? 'row' : 'col'}`}
+                key={`nomination_${index}`}
+                variants={{
+                  hidden: {
+                    y: 15,
+                    opacity: 0,
+                  },
+                  show: {
+                    y: 0,
+                    opacity: 1,
+                  },
+                }}
+              >
+                <Member
+                  who={member.who}
+                  batchKey={batchKey}
+                  batchIndex={membersDefault.indexOf(member)}
                 />
-              </button>
-              <button type="button" onClick={() => setListFormat('col')}>
-                <FontAwesomeIcon
-                  icon={faGripVertical}
-                  color={
-                    listFormat === 'col' ? colors.primary[mode] : 'inherit'
-                  }
-                />
-              </button>
-            </div>
-          </Header>
-          <List $flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
-            {listMembers.length > 0 && pagination && (
-              <Pagination page={page} total={totalPages} setter={setPage} />
-            )}
-            {fetched !== 'synced' ? (
-              <ListStatusHeader style={{ marginTop: '0.5rem' }}>
-                {t('pools.fetchingMemberList')}...
-              </ListStatusHeader>
-            ) : (
-              <MotionContainer>
-                {listMembers.map((member: PoolMember, index: number) => (
-                  <motion.div
-                    className={`item ${listFormat === 'row' ? 'row' : 'col'}`}
-                    key={`nomination_${index}`}
-                    variants={{
-                      hidden: {
-                        y: 15,
-                        opacity: 0,
-                      },
-                      show: {
-                        y: 0,
-                        opacity: 1,
-                      },
-                    }}
-                  >
-                    <Member
-                      who={member.who}
-                      batchKey={batchKey}
-                      batchIndex={membersDefault.indexOf(member)}
-                    />
-                  </motion.div>
-                ))}
-              </MotionContainer>
-            )}
-          </List>
-        </ListWrapper>
-      )}
-    </>
+              </motion.div>
+            ))}
+          </MotionContainer>
+        )}
+      </List>
+    </ListWrapper>
   );
 };
 

--- a/src/pages/Pools/Home/Status/MembershipStatus.tsx
+++ b/src/pages/Pools/Home/Status/MembershipStatus.tsx
@@ -75,18 +75,16 @@ export const MembershipStatus = ({
   return (
     <>
       {selectedActivePool ? (
-        <>
-          <Stat
-            label={label}
-            helpKey="Pool Membership"
-            type="address"
-            stat={{
-              address: selectedActivePool?.addresses?.stash ?? '',
-              display: membershipDisplay,
-            }}
-            buttons={showButtons ? membershipButtons : []}
-          />
-        </>
+        <Stat
+          label={label}
+          helpKey="Pool Membership"
+          type="address"
+          stat={{
+            address: selectedActivePool?.addresses?.stash ?? '',
+            display: membershipDisplay,
+          }}
+          buttons={showButtons ? membershipButtons : []}
+        />
       ) : (
         <Stat
           label={t('pools.poolMembership')}

--- a/src/pages/Pools/Home/Status/MembershipStatus.tsx
+++ b/src/pages/Pools/Home/Status/MembershipStatus.tsx
@@ -72,28 +72,24 @@ export const MembershipStatus = ({
     }
   }
 
-  return (
-    <>
-      {selectedActivePool ? (
-        <Stat
-          label={label}
-          helpKey="Pool Membership"
-          type="address"
-          stat={{
-            address: selectedActivePool?.addresses?.stash ?? '',
-            display: membershipDisplay,
-          }}
-          buttons={showButtons ? membershipButtons : []}
-        />
-      ) : (
-        <Stat
-          label={t('pools.poolMembership')}
-          helpKey="Pool Membership"
-          stat={t('pools.notInPool')}
-          buttons={!showButtons || isPoolSyncing ? [] : buttons}
-          buttonType={buttonType}
-        />
-      )}
-    </>
+  return selectedActivePool ? (
+    <Stat
+      label={label}
+      helpKey="Pool Membership"
+      type="address"
+      stat={{
+        address: selectedActivePool?.addresses?.stash ?? '',
+        display: membershipDisplay,
+      }}
+      buttons={showButtons ? membershipButtons : []}
+    />
+  ) : (
+    <Stat
+      label={t('pools.poolMembership')}
+      helpKey="Pool Membership"
+      stat={t('pools.notInPool')}
+      buttons={!showButtons || isPoolSyncing ? [] : buttons}
+      buttonType={buttonType}
+    />
   );
 };

--- a/src/pages/Pools/Home/context.tsx
+++ b/src/pages/Pools/Home/context.tsx
@@ -7,7 +7,7 @@ import type { PoolsTabsContextInterface } from '../types';
 
 export const PoolsTabsContext: React.Context<PoolsTabsContextInterface> =
   React.createContext({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
     setActiveTab: (t: number) => {},
     activeTab: 0,
   });

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -141,30 +141,24 @@ export const HomeInner = () => {
       )}
       {activeTab === 1 && <Members />}
       {activeTab === 2 && (
-        <>
-          <PageRow>
-            <CardWrapper>
-              <PoolListProvider>
-                <PoolList
-                  pools={bondedPools}
-                  defaultFilters={{
-                    includes: ['active'],
-                    excludes: ['locked', 'destroying'],
-                  }}
-                  allowMoreCols
-                  allowSearch
-                  pagination
-                />
-              </PoolListProvider>
-            </CardWrapper>
-          </PageRow>
-        </>
+        <PageRow>
+          <CardWrapper>
+            <PoolListProvider>
+              <PoolList
+                pools={bondedPools}
+                defaultFilters={{
+                  includes: ['active'],
+                  excludes: ['locked', 'destroying'],
+                }}
+                allowMoreCols
+                allowSearch
+                pagination
+              />
+            </PoolListProvider>
+          </CardWrapper>
+        </PageRow>
       )}
-      {activeTab === 3 && (
-        <>
-          <PoolFavorites />
-        </>
-      )}
+      {activeTab === 3 && <PoolFavorites />}
     </>
   );
 };

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -161,9 +161,7 @@ export const Roles = ({
           </h3>
         )}
 
-        {!(isOwner() === true || setters.length) ? (
-          <></>
-        ) : (
+        {!(isOwner() === true || setters.length) ? null : (
           <>
             {isEditing && (
               <div>

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -7,5 +7,5 @@ import { Home } from './Home';
 
 export const Pools = () => {
   const { onPoolSetup } = useSetup();
-  return <>{onPoolSetup ? <Create /> : <Home />}</>;
+  return onPoolSetup ? <Create /> : <Home />;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,15 +2847,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "aria-query@npm:5.3.0"
-  dependencies:
-    dequal: "npm:^2.0.3"
-  checksum: 2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
-  languageName: node
-  linkType: hard
-
 "array-buffer-byte-length@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-buffer-byte-length@npm:1.0.0"
@@ -2974,13 +2965,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types-flow@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "ast-types-flow@npm:0.0.8"
-  checksum: f2a0ba8055353b743c41431974521e5e852a9824870cd6fce2db0e538ac7bf4da406bbd018d109af29ff3f8f0993f6a730c9eddbd0abd031fbcb29ca75c1014e
-  languageName: node
-  linkType: hard
-
 "async@npm:^3.2.4":
   version: 3.2.5
   resolution: "async@npm:3.2.5"
@@ -3004,28 +2988,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:=4.7.0":
-  version: 4.7.0
-  resolution: "axe-core@npm:4.7.0"
-  checksum: 89ac5712b5932ac7d23398b4cb5ba081c394a086e343acc68ba49c83472706e18e0799804e8388c779dcdacc465377deb29f2714241d3fbb389cf3a6b275c9ba
-  languageName: node
-  linkType: hard
-
 "axios@npm:^0.21.4":
   version: 0.21.4
   resolution: "axios@npm:0.21.4"
   dependencies:
     follow-redirects: "npm:^1.14.0"
   checksum: fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
-  languageName: node
-  linkType: hard
-
-"axobject-query@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "axobject-query@npm:3.2.1"
-  dependencies:
-    dequal: "npm:^2.0.3"
-  checksum: f7debc2012e456139b57d888c223f6d3cb4b61eb104164a85e3d346273dd6ef0bc9a04b6660ca9407704a14a8e05fa6b6eb9d55f44f348c7210de7ffb350c3a7
   languageName: node
   linkType: hard
 
@@ -3640,13 +3608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"damerau-levenshtein@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "damerau-levenshtein@npm:1.0.8"
-  checksum: 4c2647e0f42acaee7d068756c1d396e296c3556f9c8314bac1ac63ffb236217ef0e7e58602b18bb2173deec7ec8e0cac8e27cccf8f5526666b4ff11a13ad54a3
-  languageName: node
-  linkType: hard
-
 "data-uri-to-buffer@npm:^4.0.0":
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
@@ -3778,13 +3739,6 @@ __metadata:
     has-property-descriptors: "npm:^1.0.0"
     object-keys: "npm:^1.1.1"
   checksum: 88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
-  languageName: node
-  linkType: hard
-
-"dequal@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "dequal@npm:2.0.3"
-  checksum: f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
   languageName: node
   linkType: hard
 
@@ -4003,7 +3957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-iterator-helpers@npm:^1.0.12, es-iterator-helpers@npm:^1.0.15":
+"es-iterator-helpers@npm:^1.0.12":
   version: 1.0.15
   resolution: "es-iterator-helpers@npm:1.0.15"
   dependencies:
@@ -4230,32 +4184,6 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
   checksum: 5f35dfbf4e8e67f741f396987de9504ad125c49f4144508a93282b4ea0127e052bde65ab6def1f31b6ace6d5d430be698333f75bdd7dca3bc14226c92a083196
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-jsx-a11y@npm:^6.8.0":
-  version: 6.8.0
-  resolution: "eslint-plugin-jsx-a11y@npm:6.8.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.2"
-    aria-query: "npm:^5.3.0"
-    array-includes: "npm:^3.1.7"
-    array.prototype.flatmap: "npm:^1.3.2"
-    ast-types-flow: "npm:^0.0.8"
-    axe-core: "npm:=4.7.0"
-    axobject-query: "npm:^3.2.1"
-    damerau-levenshtein: "npm:^1.0.8"
-    emoji-regex: "npm:^9.2.2"
-    es-iterator-helpers: "npm:^1.0.15"
-    hasown: "npm:^2.0.0"
-    jsx-ast-utils: "npm:^3.3.5"
-    language-tags: "npm:^1.0.9"
-    minimatch: "npm:^3.1.2"
-    object.entries: "npm:^1.1.7"
-    object.fromentries: "npm:^2.0.7"
-  peerDependencies:
-    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 199b883e526e6f9d7c54cb3f094abc54f11a1ec816db5fb6cae3b938eb0e503acc10ccba91ca7451633a9d0b9abc0ea03601844a8aba5fe88c5e8897c9ac8f49
   languageName: node
   linkType: hard
 
@@ -5856,7 +5784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.5":
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0":
   version: 3.3.5
   resolution: "jsx-ast-utils@npm:3.3.5"
   dependencies:
@@ -5874,22 +5802,6 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
-  languageName: node
-  linkType: hard
-
-"language-subtag-registry@npm:^0.3.20":
-  version: 0.3.22
-  resolution: "language-subtag-registry@npm:0.3.22"
-  checksum: d1e09971260a7cd3b9fdeb190d33af0b6e99c8697013537d9aaa15f7856d9d83aee128ba8078e219df0a7cf4b8dd18d1a0c188f6543b500d92a2689d2d114b70
-  languageName: node
-  linkType: hard
-
-"language-tags@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "language-tags@npm:1.0.9"
-  dependencies:
-    language-subtag-registry: "npm:^0.3.20"
-  checksum: 9ab911213c4bd8bd583c850201c17794e52cb0660d1ab6e32558aadc8324abebf6844e46f92b80a5d600d0fbba7eface2c207bfaf270a1c7fd539e4c3a880bff
   languageName: node
   linkType: hard
 
@@ -6506,7 +6418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.6, object.entries@npm:^1.1.7":
+"object.entries@npm:^1.1.6":
   version: 1.1.7
   resolution: "object.entries@npm:1.1.7"
   dependencies:
@@ -6888,7 +6800,6 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-import-resolver-typescript: "npm:^3.6.1"
     eslint-plugin-import: "npm:^2.29.1"
-    eslint-plugin-jsx-a11y: "npm:^6.8.0"
     eslint-plugin-prefer-arrow: "npm:^1.2.3"
     eslint-plugin-prefer-arrow-functions: "npm:^3.2.4"
     eslint-plugin-prettier: "npm:^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3567,13 +3567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"confusing-browser-globals@npm:^1.0.10":
-  version: 1.0.11
-  resolution: "confusing-browser-globals@npm:1.0.11"
-  checksum: 475d0a284fa964a5182b519af5738b5b64bf7e413cfd703c1b3496bf6f4df9f827893a9b221c0ea5873c1476835beb1e0df569ba643eff0734010c1eb780589e
-  languageName: node
-  linkType: hard
-
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
@@ -4158,52 +4151,6 @@ __metadata:
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
   checksum: 9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
-  languageName: node
-  linkType: hard
-
-"eslint-config-airbnb-base@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "eslint-config-airbnb-base@npm:15.0.0"
-  dependencies:
-    confusing-browser-globals: "npm:^1.0.10"
-    object.assign: "npm:^4.1.2"
-    object.entries: "npm:^1.1.5"
-    semver: "npm:^6.3.0"
-  peerDependencies:
-    eslint: ^7.32.0 || ^8.2.0
-    eslint-plugin-import: ^2.25.2
-  checksum: 93639d991654414756f82ad7860aac30b0dc6797277b7904ddb53ed88a32c470598696bbc6c503e066414024d305221974d3769e6642de65043bedf29cbbd30f
-  languageName: node
-  linkType: hard
-
-"eslint-config-airbnb-typescript@npm:^17.1.0":
-  version: 17.1.0
-  resolution: "eslint-config-airbnb-typescript@npm:17.1.0"
-  dependencies:
-    eslint-config-airbnb-base: "npm:^15.0.0"
-  peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^5.13.0 || ^6.0.0
-    "@typescript-eslint/parser": ^5.0.0 || ^6.0.0
-    eslint: ^7.32.0 || ^8.2.0
-    eslint-plugin-import: ^2.25.3
-  checksum: 46d1753d660fe4225ccd89e91dd9f812db490326dfb835cfb786ab0b9a4ca25a39171a838661233b8f6f9a19294aaedaa962e19df915066beb80e7422749f7f1
-  languageName: node
-  linkType: hard
-
-"eslint-config-airbnb@npm:^19.0.4":
-  version: 19.0.4
-  resolution: "eslint-config-airbnb@npm:19.0.4"
-  dependencies:
-    eslint-config-airbnb-base: "npm:^15.0.0"
-    object.assign: "npm:^4.1.2"
-    object.entries: "npm:^1.1.5"
-  peerDependencies:
-    eslint: ^7.32.0 || ^8.2.0
-    eslint-plugin-import: ^2.25.3
-    eslint-plugin-jsx-a11y: ^6.5.1
-    eslint-plugin-react: ^7.28.0
-    eslint-plugin-react-hooks: ^4.3.0
-  checksum: 867feeda45c4b480b1b8eff8fabc1bb107e837da8b48e5039e0c175ae6ad34af383b1924fc163bbfcef24a324e6651b1515e5bd12cbcbb19535a8838e2544a02
   languageName: node
   linkType: hard
 
@@ -6547,7 +6494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.2, object.assign@npm:^4.1.4":
+"object.assign@npm:^4.1.4":
   version: 4.1.5
   resolution: "object.assign@npm:4.1.5"
   dependencies:
@@ -6559,7 +6506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.5, object.entries@npm:^1.1.6, object.entries@npm:^1.1.7":
+"object.entries@npm:^1.1.6, object.entries@npm:^1.1.7":
   version: 1.1.7
   resolution: "object.entries@npm:1.1.7"
   dependencies:
@@ -6938,8 +6885,6 @@ __metadata:
     chroma-js: "npm:^2.4.2"
     date-fns: "npm:^2.29.3"
     eslint: "npm:^8.55.0"
-    eslint-config-airbnb: "npm:^19.0.4"
-    eslint-config-airbnb-typescript: "npm:^17.1.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-import-resolver-typescript: "npm:^3.6.1"
     eslint-plugin-import: "npm:^2.29.1"
@@ -7740,7 +7685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:^6.0.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:


### PR DESCRIPTION
- Turns on `react/jsx-no-useless-fragment` and fixes codebase.
- Removes `airbnb` eslint plugins.
- Fixes missing `displayName`s for forwradRefs.
- Remove unused `eslint-plugin-jsx-a11y` plugin.
- Removes unneeded off rules.