### PR TITLE
feat(refactor): Remove explicit `any` types project-wide

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,6 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     // The following rules need to be revised, or the codebase needs to be fixed to enable them.
-    "@typescript-eslint/no-explicit-any": "off",
     // "@typescript-eslint/no-unnecessary-condition": "error",
     // --------------------------------------------
     "react/jsx-no-useless-fragment": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     // The following rules need to be revised, or the codebase needs to be fixed to enable them.
+    "@typescript-eslint/no-explicit-any": "off",
     // "@typescript-eslint/no-unnecessary-condition": "error",
     // --------------------------------------------
     "react/jsx-no-useless-fragment": "error",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@ledgerhq/hw-transport-webhid": "^6.28.1",
-    "@polkadot-cloud/assets": "^0.2.0",
+    "@polkadot-cloud/assets": "^0.2.1",
     "@polkadot-cloud/core": "^1.1.0",
     "@polkadot-cloud/react": "^0.2.0",
     "@polkadot-cloud/utils": "^0.1.0",

--- a/src/config/tips.ts
+++ b/src/config/tips.ts
@@ -1,7 +1,13 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-export const TipsConfig = [
+interface TipConfig {
+  id: string;
+  s: number;
+  page?: string;
+}
+
+export const TipsConfig: TipConfig[] = [
   {
     id: 'connectExtensions',
     s: 1,

--- a/src/contexts/Migrate/index.tsx
+++ b/src/contexts/Migrate/index.tsx
@@ -28,21 +28,21 @@ export const MigrateProvider = ({
 
   // Removes the previous nominator setup objects from local storage.
   const removeDeprecatedNominatorSetups = () =>
-    Object.values(NetworkList).forEach((n: any) => {
+    Object.values(NetworkList).forEach((n) => {
       for (const a of accounts)
         localStorage.removeItem(`${n.name}_stake_setup_${a.address}`);
     });
 
   // Removes the previous pool setup objects from local storage.
   const removeDeprecatedPoolSetups = () =>
-    Object.values(NetworkList).forEach((n: any) => {
+    Object.values(NetworkList).forEach((n) => {
       for (const a of accounts)
         localStorage.removeItem(`${n.name}_pool_setup_${a.address}`);
     });
 
   // Removes the previous active proxies from local storage.
   const removeDeprecatedActiveProxies = () =>
-    Object.values(NetworkList).forEach((n: any) => {
+    Object.values(NetworkList).forEach((n) => {
       localStorage.removeItem(`${n.name}_active_proxy`);
     });
 

--- a/src/contexts/Pools/ActivePools/defaults.ts
+++ b/src/contexts/Pools/ActivePools/defaults.ts
@@ -3,7 +3,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import BigNumber from 'bignumber.js';
-import type { ActivePool, ActivePoolsContextState } from '../types';
+import type {
+  ActiveBondedPool,
+  ActivePool,
+  ActivePoolsContextState,
+  RewardPool,
+} from '../types';
 
 export const nominationStatus = {};
 
@@ -14,16 +19,23 @@ export const poolRoles = {
   bouncer: '',
 };
 
-export const bondedPool = {
+export const bondedPool: ActiveBondedPool = {
   points: '0',
   state: 'Blocked',
   memberCounter: '0',
-  roles: null,
+  roles: {
+    depositor: '',
+    nominator: '',
+    root: '',
+    bouncer: '',
+  },
 };
 
-export const rewardPool = {
+export const rewardPool: RewardPool = {
   lastRecordedRewardCounter: '0',
   lastRecordedTotalPayouts: '0',
+  totalCommissionClaimed: '0',
+  totalCommissionPending: '0',
   totalRewardsClaimed: '0',
 };
 
@@ -35,7 +47,7 @@ export const selectedActivePool: ActivePool = {
   },
   bondedPool,
   rewardPool,
-  rewardAccountBalance: {},
+  rewardAccountBalance: new BigNumber(0),
   pendingRewards: new BigNumber(0),
 };
 

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -8,6 +8,7 @@ import type {
   ActivePool,
   ActivePoolsContextState,
   PoolAddresses,
+  PoolTargets,
 } from 'contexts/Pools/types';
 import { useStaking } from 'contexts/Staking';
 import type { AnyApi, AnyJson, Sync } from 'types';
@@ -67,7 +68,7 @@ export const ActivePoolsProvider = ({
   const unsubNominations = useRef<AnyApi[]>([]);
 
   // Store account target validators.
-  const [targets, setTargetsState] = useState<Record<number, AnyJson>>({});
+  const [targets, setTargetsState] = useState<PoolTargets>({});
   const targetsRef = useRef(targets);
 
   // Store the member count of the selected pool.
@@ -165,9 +166,7 @@ export const ActivePoolsProvider = ({
           rewardPool = rewardPool?.unwrapOr(undefined)?.toHuman();
           if (rewardPool && bondedPool) {
             const rewardAccountBalance = balance?.free;
-
             const pendingRewards = await fetchPendingRewards();
-
             const pool = {
               id,
               addresses,

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -183,8 +183,8 @@ export const BondedPoolsProvider = ({
    * poolSearchFilter Iterates through the supplied list and refers to the meta batch of the list to
    * filter those list items that match the search term. Returns the updated filtered list.
    */
-  const poolSearchFilter = (list: any, searchTerm: string) => {
-    const filteredList: any = [];
+  const poolSearchFilter = (list: AnyJson, searchTerm: string) => {
+    const filteredList: AnyJson = [];
 
     for (const pool of list) {
       // If pool metadata has not yet been synced, include the pool in results.
@@ -288,7 +288,7 @@ export const BondedPoolsProvider = ({
     // first get the roles of the account
     const roles = getAccountRoles(who);
     // format new list has pool => roles
-    const pools: any = {};
+    const pools: Record<number, AnyJson> = {};
     Object.entries(roles).forEach(([key, poolIds]) => {
       // now looping through a role
       poolIds.forEach((poolId) => {
@@ -306,7 +306,7 @@ export const BondedPoolsProvider = ({
   };
 
   // determine roles to replace from roleEdits
-  const toReplace = (roleEdits: any) => {
+  const toReplace = (roleEdits: AnyJson) => {
     const root = roleEdits?.root?.newAddress ?? '';
     const nominator = roleEdits?.nominator?.newAddress ?? '';
     const bouncer = roleEdits?.bouncer?.newAddress ?? '';
@@ -319,7 +319,7 @@ export const BondedPoolsProvider = ({
   };
 
   // replaces the pool roles from roleEdits
-  const replacePoolRoles = (poolId: number, roleEdits: any) => {
+  const replacePoolRoles = (poolId: number, roleEdits: AnyJson) => {
     let pool = bondedPools.find((b) => b.id === poolId) || null;
 
     if (!pool) return;

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -110,6 +110,7 @@ export const PoolMembersProvider = ({
     if (!poolMember) {
       return null;
     }
+
     return {
       who,
       poolId: poolMember.poolId,
@@ -284,16 +285,16 @@ export const PoolMembersProvider = ({
   const removePoolMember = (who: MaybeAddress) => {
     if (!pluginEnabled('subscan')) return;
 
-    const newMembers = poolMembersNode.filter((p: any) => p.who !== who);
+    const newMembers = poolMembersNode.filter((p) => p.who !== who);
     setPoolMembersNode(newMembers ?? []);
   };
 
   // Adds a record to poolMembers.
   // Currently only used when an account joins or creates a pool.
-  const addToPoolMembers = (member: any) => {
+  const addToPoolMembers = (member: { who: string; poolId: number }) => {
     if (!member || pluginEnabled('subscan')) return;
 
-    const exists = poolMembersNode.find((m: any) => m.who === member.who);
+    const exists = poolMembersNode.find((m) => m.who === member.who);
     if (!exists) {
       setPoolMembersNode(poolMembersNode.concat(member));
     }

--- a/src/contexts/Pools/PoolMemberships/index.tsx
+++ b/src/contexts/Pools/PoolMemberships/index.tsx
@@ -89,6 +89,7 @@ export const PoolMembershipsProvider = ({
       if (membership) {
         // format pool's unlocking chunks
         const unbondingEras: AnyApi = membership.unbondingEras;
+
         const unlocking = [];
         for (const [e, v] of Object.entries(unbondingEras || {})) {
           unlocking.push({

--- a/src/contexts/Pools/types.ts
+++ b/src/contexts/Pools/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type BigNumber from 'bignumber.js';
+import type { AnyFilter } from 'library/Filter/types';
 import type { AnyApi, AnyJson, AnyMetaBatch, MaybeAddress, Sync } from 'types';
 
 // PoolsConfig types
@@ -52,25 +53,22 @@ export interface PoolMembership {
   lastRecordedRewardCounter: string;
   unbondingEras: Record<number, string>;
   claimPermission: ClaimPermission;
-  unlocking: {
-    era: number;
-    value: BigNumber;
-  }[];
+  unlocking: PoolUnlocking[];
 }
 
 // BondedPool types
 export interface BondedPoolsContextState {
-  queryBondedPool: (p: number) => any;
+  queryBondedPool: (p: number) => AnyApi;
   getBondedPool: (p: number) => BondedPool | null;
   updateBondedPools: (p: BondedPool[]) => void;
   addToBondedPools: (p: BondedPool) => void;
   removeFromBondedPools: (p: number) => void;
-  getPoolNominationStatus: (n: MaybeAddress, o: MaybeAddress) => any;
+  getPoolNominationStatus: (n: MaybeAddress, o: MaybeAddress) => AnyApi;
   getPoolNominationStatusCode: (t: NominationStatuses | null) => string;
-  getAccountRoles: (w: MaybeAddress) => any;
-  getAccountPools: (w: MaybeAddress) => any;
+  getAccountRoles: (w: MaybeAddress) => AnyApi;
+  getAccountPools: (w: MaybeAddress) => AnyApi;
   replacePoolRoles: (poolId: number, roleEdits: AnyJson) => void;
-  poolSearchFilter: (l: any, v: string) => void;
+  poolSearchFilter: (l: AnyFilter, v: string) => void;
   bondedPools: BondedPool[];
   poolsMetaData: Record<number, string>;
   poolsNominations: Record<number, PoolNominations>;
@@ -80,24 +78,15 @@ export interface BondedPoolsContextState {
 export interface ActivePool {
   id: number;
   addresses: PoolAddresses;
-  bondedPool: any;
-  rewardPool: any;
-  rewardAccountBalance: any;
-  pendingRewards: any;
+  bondedPool: ActiveBondedPool;
+  rewardPool: RewardPool;
+  rewardAccountBalance: BigNumber;
+  pendingRewards: BigNumber;
 }
 
-export interface BondedPool {
+export type BondedPool = ActiveBondedPool & {
   addresses: PoolAddresses;
   id: number;
-  memberCounter: string;
-  points: string;
-  roles: {
-    depositor: string;
-    nominator: string;
-    root: string;
-    bouncer: string;
-  };
-  state: PoolState;
   commission?: {
     current?: AnyJson | null;
     max?: AnyJson | null;
@@ -107,6 +96,21 @@ export interface BondedPool {
     } | null;
     throttleFrom?: AnyJson | null;
   };
+};
+
+export interface ActiveBondedPool {
+  points: string;
+  memberCounter: string;
+  roles: PoolRoles;
+  state: PoolState;
+}
+
+export interface RewardPool {
+  lastRecordedRewardCounter: string;
+  lastRecordedTotalPayouts: string;
+  totalCommissionClaimed: string;
+  totalCommissionPending: string;
+  totalRewardsClaimed: string;
 }
 
 export type PoolNominations = {
@@ -125,13 +129,13 @@ export interface ActivePoolsContextState {
   isDepositor: () => boolean;
   isBouncer: () => boolean;
   getPoolBondedAccount: () => MaybeAddress;
-  getPoolUnlocking: () => any;
+  getPoolUnlocking: () => PoolUnlocking[];
   getPoolRoles: () => PoolRoles;
-  setTargets: (t: any) => void;
+  setTargets: (t: PoolTargets) => void;
   getNominationsStatus: () => NominationStatuses;
   setSelectedPoolId: (p: string) => void;
   selectedActivePool: ActivePool | null;
-  targets: any;
+  targets: PoolTargets;
   poolNominations: any;
   synced: Sync;
   selectedPoolMemberCount: number;
@@ -155,16 +159,23 @@ export interface PoolMemberContext {
 
 // Misc types
 export interface PoolRoles {
-  depositor: string;
-  nominator: string;
-  root: string;
-  bouncer: string;
+  depositor?: string;
+  nominator?: string;
+  root?: string;
+  bouncer?: string;
 }
 
 export interface PoolAddresses {
   stash: string;
   reward: string;
 }
+
+export type PoolUnlocking = {
+  era: number;
+  value: BigNumber;
+};
+
+export type PoolTargets = Record<number, AnyJson>;
 
 export type MaybePool = number | null;
 

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -24,7 +24,7 @@ import type {
 } from 'contexts/Staking/types';
 import type { AnyApi, AnyJson, MaybeAddress } from 'types';
 import Worker from 'workers/stakers?worker';
-import type { ResponseInitialiseExposures } from 'workers/types';
+import type { ProcessExposuresResponse } from 'workers/types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
@@ -103,7 +103,7 @@ export const StakingProvider = ({
 
   worker.onmessage = (message: MessageEvent) => {
     if (message) {
-      const { data }: { data: ResponseInitialiseExposures } = message;
+      const { data }: { data: ProcessExposuresResponse } = message;
       const { task, networkName, era } = data;
 
       // ensure task matches, & era is still the same.
@@ -274,7 +274,7 @@ export const StakingProvider = ({
         continue;
       }
 
-      if (!(staker.others ?? []).find((o: any) => o.who === who)) {
+      if (!(staker.others ?? []).find((o) => o.who === who)) {
         statuses[target] = 'inactive';
         continue;
       }

--- a/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -32,6 +32,7 @@ import {
   defaultEraPointsBoundaries,
 } from './defaults';
 import { getLocalEraValidators, setLocalEraValidators } from '../Utils';
+import type { ValidatorEntry } from '@polkadot-cloud/assets/types';
 
 export const ValidatorsProvider = ({
   children,
@@ -84,7 +85,9 @@ export const ValidatorsProvider = ({
   const [poolNominated, setPoolNominated] = useState<Validator[] | null>(null);
 
   // Stores a randomised validator community dataset.
-  const [validatorCommunity] = useState([...shuffle(ValidatorCommunity)]);
+  const [validatorCommunity] = useState<ValidatorEntry[]>([
+    ...shuffle(ValidatorCommunity),
+  ]);
 
   // Track whether the validator list has been fetched.
   const [erasRewardPointsFetched, setErasRewawrdPointsFetched] =

--- a/src/library/Filter/LargeItem.tsx
+++ b/src/library/Filter/LargeItem.tsx
@@ -4,6 +4,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
 import { LargeItemWrapper } from './Wrappers';
+import type { LargerFilterItemProps } from './types';
 
 export const LargeItem = ({
   disabled = false,
@@ -13,7 +14,7 @@ export const LargeItem = ({
   subtitle,
   transform,
   onClick,
-}: any) => (
+}: LargerFilterItemProps) => (
   <motion.button
     disabled={disabled}
     whileHover={{ scale: 1.01 }}

--- a/src/library/Filter/Tabs.tsx
+++ b/src/library/Filter/Tabs.tsx
@@ -4,15 +4,16 @@
 import { useState } from 'react';
 import { useFilters } from 'contexts/Filters';
 import { TabsWrapper, TabWrapper } from './Wrappers';
+import type { FilterTabsProps } from './types';
 
-export const Tabs = ({ config, activeIndex }: any) => {
+export const Tabs = ({ config, activeIndex }: FilterTabsProps) => {
   const { resetFilters, setMultiFilters } = useFilters();
 
   const [active, setActive] = useState<number>(activeIndex);
 
   return (
     <TabsWrapper>
-      {config.map((c: any, i: number) => (
+      {config.map((c, i) => (
         <TabWrapper
           key={`pools_tab_filter_${i}`}
           $active={i === active}

--- a/src/library/Filter/types.ts
+++ b/src/library/Filter/types.ts
@@ -3,6 +3,30 @@
 
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type React from 'react';
+import type { AnyFunction } from 'types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyFilter = any;
+
+export interface LargerFilterItemProps {
+  disabled?: boolean;
+  active: boolean;
+  icon: IconProp;
+  title: string;
+  subtitle: string;
+  transform: string;
+  onClick: AnyFunction;
+}
+export interface FilterTabsProps {
+  config: FilterConfig[];
+  activeIndex: number;
+}
+
+export interface FilterConfig {
+  includes: string[];
+  excludes: string[];
+  label: string;
+}
 
 export interface ItemProps {
   icon?: IconProp;
@@ -14,18 +38,18 @@ export interface ItemProps {
 
 export interface CategoryProps {
   title: string;
-  buttons?: any[];
+  buttons?: AnyFilter[];
   children: React.ReactNode;
 }
 
 export interface ValidatorFilterContextInterface {
   orderValidators: (v: string) => void;
-  applyValidatorOrder: (l: any, o: string) => any;
-  applyValidatorFilters: (l: any, k: string, f?: string[]) => any;
+  applyValidatorOrder: (l: AnyFilter, o: string) => AnyFilter;
+  applyValidatorFilters: (l: AnyFilter, k: string, f?: string[]) => AnyFilter;
   toggleFilterValidators: (v: string) => void;
   toggleAllValidatorFilters: (t: number) => void;
   resetValidatorFilters: () => void;
-  validatorSearchFilter: (l: any, k: string, v: string) => void;
+  validatorSearchFilter: (l: AnyFilter, k: string, v: string) => void;
   validatorFilters: string[];
   validatorOrder: string;
 }

--- a/src/library/Form/types.ts
+++ b/src/library/Form/types.ts
@@ -7,7 +7,7 @@ import type {
   ExtensionAccount,
   ExternalAccount,
 } from '@polkadot-cloud/react/types';
-import type { BondFor, MaybeAddress } from 'types';
+import type { AnyFunction, AnyJson, BondFor, MaybeAddress } from 'types';
 
 export interface ExtensionAccountItem extends ExtensionAccount {
   active?: boolean;
@@ -35,7 +35,7 @@ export interface AccountDropdownProps {
 
 export interface BondFeedbackProps {
   syncing?: boolean;
-  setters: any;
+  setters: AnyFunction;
   bondFor: BondFor;
   defaultBond: number | null;
   inSetup?: boolean;
@@ -53,13 +53,13 @@ export interface BondInputProps {
   value: string;
   defaultValue: string;
   syncing?: boolean;
-  setters: any;
+  setters: AnyFunction;
   disabled: boolean;
   disableTxFeeUpdate?: boolean;
 }
 
 export interface UnbondFeedbackProps {
-  setters: any;
+  setters: AnyFunction;
   bondFor: BondFor;
   defaultBond?: number;
   inSetup?: boolean;
@@ -74,8 +74,8 @@ export interface UnbondInputProps {
   unbondToMin: BigNumber;
   defaultValue: number | string;
   disabled: boolean;
-  setters: any;
-  value: any;
+  setters: AnyFunction;
+  value: AnyJson;
 }
 
 export interface NominateStatusBarProps {
@@ -84,7 +84,7 @@ export interface NominateStatusBarProps {
 
 export interface DropdownProps {
   items: DropdownInput[];
-  onChange: (o: any) => void;
+  onChange: (o: AnyJson) => void;
   label?: string;
   placeholder: string;
   value: DropdownInput;

--- a/src/library/Graphs/EraPoints.tsx
+++ b/src/library/Graphs/EraPoints.tsx
@@ -17,6 +17,7 @@ import { useTheme } from 'contexts/Themes';
 import { graphColors } from 'styles/graphs';
 import { useNetwork } from 'contexts/Network';
 import type { EraPointsProps } from './types';
+import type { AnyJson } from 'types';
 
 ChartJS.register(
   CategoryScale,
@@ -88,7 +89,7 @@ export const EraPoints = ({ items = [], height }: EraPointsProps) => {
         },
         callbacks: {
           title: () => [],
-          label: (context: any) => `${context.parsed.y}`,
+          label: (context: AnyJson) => `${context.parsed.y}`,
         },
         intersect: false,
         interaction: {

--- a/src/library/Graphs/GeoDonut.tsx
+++ b/src/library/Graphs/GeoDonut.tsx
@@ -9,6 +9,7 @@ import chroma from 'chroma-js';
 import { ellipsisFn } from '@polkadot-cloud/utils';
 import { useNetwork } from 'contexts/Network';
 import type { GeoDonutProps } from './types';
+import type { AnyJson } from 'types';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -48,7 +49,7 @@ export const GeoDonut = ({
         maxHeight: 25,
         labels: {
           boxWidth: 10,
-          generateLabels: (chart: any) => {
+          generateLabels: (chart: AnyJson) => {
             const ls =
               ChartJS.overrides.doughnut.plugins.legend.labels.generateLabels(
                 chart
@@ -63,7 +64,7 @@ export const GeoDonut = ({
       tooltip: {
         enabled: true,
         callbacks: {
-          label: (context: any) => ` ${title}: ${context.raw.toFixed(1)} %`,
+          label: (context: AnyJson) => ` ${title}: ${context.raw.toFixed(1)} %`,
         },
       },
     },

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -24,7 +24,7 @@ import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
 import { locales } from 'locale';
 import { graphColors } from 'styles/graphs';
-import type { AnySubscan } from 'types';
+import type { AnyJson, AnySubscan } from 'types';
 import { useNetwork } from 'contexts/Network';
 import type { PayoutBarProps } from './types';
 import { formatRewardsForGraphs } from './Utils';
@@ -173,7 +173,7 @@ export const PayoutBar = ({ days, height }: PayoutBarProps) => {
         },
         callbacks: {
           title: () => [],
-          label: (context: any) =>
+          label: (context: AnyJson) =>
             `${
               context.dataset.order === 3 ? `${t('pending')}: ` : ''
             }${new BigNumber(context.parsed.y)

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -20,7 +20,7 @@ import { useSubscan } from 'contexts/Plugins/Subscan';
 import { useTheme } from 'contexts/Themes';
 import { useUi } from 'contexts/UI';
 import { graphColors } from 'styles/graphs';
-import type { AnySubscan } from 'types';
+import type { AnyJson, AnySubscan } from 'types';
 import { useNetwork } from 'contexts/Network';
 import type { PayoutLineProps } from './types';
 import {
@@ -136,7 +136,7 @@ export const PayoutLine = ({
         },
         callbacks: {
           title: () => [],
-          label: (context: any) =>
+          label: (context: AnyJson) =>
             ` ${new BigNumber(context.parsed.y)
               .decimalPlaces(units)
               .toFormat()} ${unit}`,

--- a/src/library/Hooks/index.tsx
+++ b/src/library/Hooks/index.tsx
@@ -1,22 +1,22 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { FC } from 'react';
+import type { FC, RefObject } from 'react';
 import { useEffect } from 'react';
-import type { AnyJson } from 'types';
+import type { AnyFunction, AnyJson } from 'types';
 
 /*
  * A hook that alerts clicks outside of the passed ref.
  */
 export const useOutsideAlerter = (
-  ref: any,
-  callback: any,
-  ignore: any = []
+  ref: RefObject<HTMLElement>,
+  callback: AnyFunction,
+  ignore: string[] = []
 ) => {
   useEffect(() => {
-    const handleClickOutside = (event: any) => {
+    const handleClickOutside = (event: AnyJson) => {
       if (ref.current && !ref.current.contains(event.target)) {
-        const invalid = ignore.find((i: any) =>
+        const invalid = ignore.find((i: string) =>
           event.target.classList.contains(i)
         );
         if (invalid === undefined) {

--- a/src/library/Hooks/usePoolFilters/index.tsx
+++ b/src/library/Hooks/usePoolFilters/index.tsx
@@ -5,6 +5,7 @@ import { useBondedPools } from 'contexts/Pools/BondedPools';
 import type { BondedPool } from 'contexts/Pools/types';
 import { useStaking } from 'contexts/Staking';
 import type { AnyFunction, AnyJson } from 'types';
+import type { AnyFilter } from 'library/Filter/types';
 
 export const usePoolFilters = () => {
   const { t } = useTranslation('library');
@@ -16,7 +17,7 @@ export const usePoolFilters = () => {
    * Include active pools.
    * Returns the updated filtered list.
    */
-  const includeActive = (list: any) => {
+  const includeActive = (list: AnyFilter) => {
     if (!Object.keys(poolsNominations).length) return list;
 
     const filteredList = list.filter((p: BondedPool) => {
@@ -34,7 +35,7 @@ export const usePoolFilters = () => {
    * Dont include active pools.
    * Returns the updated filtered list.
    */
-  const excludeActive = (list: any) => {
+  const excludeActive = (list: AnyFilter) => {
     if (!Object.keys(poolsNominations).length) return list;
 
     const filteredList = list.filter((p: BondedPool) => {
@@ -53,7 +54,7 @@ export const usePoolFilters = () => {
    * Iterates through the supplied list and checks whether state is locked.
    * Returns the updated filtered list.
    */
-  const includeLocked = (list: any) =>
+  const includeLocked = (list: AnyFilter) =>
     list.filter((p: BondedPool) => p.state.toLowerCase() === 'Blocked');
 
   /*
@@ -61,7 +62,7 @@ export const usePoolFilters = () => {
    * Iterates through the supplied list and checks whether state is destroying.
    * Returns the updated filtered list.
    */
-  const includeDestroying = (list: any) =>
+  const includeDestroying = (list: AnyFilter) =>
     list.filter((p: BondedPool) => p.state === 'Destroying');
 
   /*
@@ -69,7 +70,7 @@ export const usePoolFilters = () => {
    * Iterates through the supplied list and checks whether state is locked.
    * Returns the updated filtered list.
    */
-  const excludeLocked = (list: any) =>
+  const excludeLocked = (list: AnyFilter) =>
     list.filter((p: BondedPool) => p.state !== 'Blocked');
 
   /*
@@ -77,7 +78,7 @@ export const usePoolFilters = () => {
    * Iterates through the supplied list and checks whether state is destroying.
    * Returns the updated filtered list.
    */
-  const excludeDestroying = (list: any) =>
+  const excludeDestroying = (list: AnyFilter) =>
     list.filter((p: BondedPool) => p.state !== 'Destroying');
 
   // includes to be listed in filter overlay.

--- a/src/library/Hooks/useValidatorFilters/index.tsx
+++ b/src/library/Hooks/useValidatorFilters/index.tsx
@@ -7,6 +7,7 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { AnyFunction, AnyJson } from 'types';
 import { useStaking } from 'contexts/Staking';
 import { MaxEraRewardPointsEras } from 'consts';
+import type { AnyFilter } from 'library/Filter/types';
 
 export const useValidatorFilters = () => {
   const { t } = useTranslation('library');
@@ -23,7 +24,7 @@ export const useValidatorFilters = () => {
    * filterMissingIdentity: Iterates through the supplied list and filters those with missing
    * identities. Returns the updated filtered list.
    */
-  const filterMissingIdentity = (list: any) => {
+  const filterMissingIdentity = (list: AnyFilter) => {
     // Return lsit early if identity sync has not completed.
     if (
       !Object.values(validatorIdentities).length ||
@@ -31,7 +32,7 @@ export const useValidatorFilters = () => {
     ) {
       return list;
     }
-    const filteredList: any = [];
+    const filteredList: AnyFilter = [];
     for (const validator of list) {
       const identityExists = validatorIdentities[validator.address] ?? false;
       const superExists = validatorSupers[validator.address] ?? false;
@@ -49,13 +50,13 @@ export const useValidatorFilters = () => {
    * filterOverSubscribed: Iterates through the supplied list and filters those who are over
    * subscribed. Returns the updated filtered list.
    */
-  const filterOverSubscribed = (list: any) => {
+  const filterOverSubscribed = (list: AnyFilter) => {
     // Return list early if eraStakers is still syncing.
     if (erasStakersSyncing) {
       return list;
     }
 
-    const filteredList: any = [];
+    const filteredList: AnyFilter = [];
     for (const validator of list) {
       const { oversubscribed } = getLowestRewardFromStaker(validator.address);
 
@@ -71,24 +72,24 @@ export const useValidatorFilters = () => {
    * filterAllCommission: Filters the supplied list and removes items with 100% commission. Returns
    * the updated filtered list.
    */
-  const filterAllCommission = (list: any) =>
-    list.filter((validator: any) => validator?.prefs?.commission !== 100);
+  const filterAllCommission = (list: AnyFilter) =>
+    list.filter((validator: AnyFilter) => validator?.prefs?.commission !== 100);
 
   /*
    * filterBlockedNominations: Filters the supplied list and removes items that have blocked
    * nominations. Returns the updated filtered list.
    */
-  const filterBlockedNominations = (list: any) =>
-    list.filter((validator: any) => validator?.prefs?.blocked !== true);
+  const filterBlockedNominations = (list: AnyFilter) =>
+    list.filter((validator: AnyFilter) => validator?.prefs?.blocked !== true);
 
   /*
    * filterActive: Filters the supplied list and removes items that are inactive. Returns the
    * updated filtered list.
    */
-  const filterActive = (list: any) => {
+  const filterActive = (list: AnyFilter) => {
     // if list has not yet been populated, return original list
     if (sessionValidators.length === 0) return list;
-    return list.filter((validator: any) =>
+    return list.filter((validator: AnyFilter) =>
       sessionValidators.includes(validator.address)
     );
   };
@@ -97,10 +98,10 @@ export const useValidatorFilters = () => {
    * filterNonParachainValidator: Filters the supplied list and removes items that are inactive.
    * Returns the updated filtered list.
    */
-  const filterNonParachainValidator = (list: any) => {
+  const filterNonParachainValidator = (list: AnyFilter) => {
     // if list has not yet been populated, return original list
     if ((sessionParaValidators?.length ?? 0) === 0) return list;
-    return list.filter((validator: any) =>
+    return list.filter((validator: AnyFilter) =>
       sessionParaValidators.includes(validator.address)
     );
   };
@@ -109,11 +110,11 @@ export const useValidatorFilters = () => {
    * filterInSession: Filters the supplied list and removes items that are in the current session.
    * Returns the updated filtered list.
    */
-  const filterInSession = (list: any) => {
+  const filterInSession = (list: AnyFilter) => {
     // if list has not yet been populated, return original list
     if (sessionValidators.length === 0) return list;
     return list.filter(
-      (validator: any) => !sessionValidators.includes(validator.address)
+      (validator: AnyFilter) => !sessionValidators.includes(validator.address)
     );
   };
 
@@ -173,20 +174,20 @@ export const useValidatorFilters = () => {
    * orderLowestCommission: Orders a list by commission, lowest first. Returns the updated ordered
    * list.
    */
-  const orderLowestCommission = (list: any) =>
+  const orderLowestCommission = (list: AnyFilter) =>
     [...list].sort((a, b) => a.prefs.commission - b.prefs.commission);
 
   /*
    * orderHighestCommission: Orders a list by commission, highest first. Returns the updated ordered
    * list.
    */
-  const orderHighestCommission = (list: any) =>
+  const orderHighestCommission = (list: AnyFilter) =>
     [...list].sort((a, b) => b.prefs.commission - a.prefs.commission);
 
   /*
    * orderByRank: Orders a list by validator rank.
    */
-  const orderByRank = (list: any) =>
+  const orderByRank = (list: AnyFilter) =>
     [...list].sort((a, b) => {
       const aRank = validatorEraPointsHistory[a.address]?.rank || 9999;
       const bRank = validatorEraPointsHistory[b.address]?.rank || 9999;
@@ -218,7 +219,7 @@ export const useValidatorFilters = () => {
    * applySearch Iterates through the supplied list and filters those that match the search term.
    * Returns the updated filtered list.
    */
-  const applySearch = (list: any, searchTerm: string) => {
+  const applySearch = (list: AnyFilter, searchTerm: string) => {
     // If we cannot derive data, fallback to include validator in filtered list.
     if (
       !searchTerm ||
@@ -228,7 +229,7 @@ export const useValidatorFilters = () => {
       return list;
     }
 
-    const filteredList: any = [];
+    const filteredList: AnyFilter = [];
     for (const validator of list) {
       const identity = validatorIdentities[validator.address] ?? '';
       const identityRaw = identity?.info?.display?.Raw ?? '';

--- a/src/library/List/context.tsx
+++ b/src/library/List/context.tsx
@@ -3,10 +3,11 @@
 
 import React, { useState } from 'react';
 import * as defaults from './defaults';
+import type { AnyJson } from 'types';
+import type { ListContextInterface, ListProviderProps } from './types';
 
-export const ListContext: React.Context<any> = React.createContext(
-  defaults.defaultContext
-);
+export const ListContext: React.Context<ListContextInterface> =
+  React.createContext(defaults.defaultContext);
 
 export const useList = () => React.useContext(ListContext);
 
@@ -14,23 +15,23 @@ export const ListProvider = ({
   selectToggleable = true,
   selectActive: initialSelctActive = false,
   children,
-}: any) => {
-  // store the currently selected validators from the list
-  const [selected, setSelected] = useState<any[]>([]);
+}: ListProviderProps) => {
+  // Store the currently selected validators from the list.
+  const [selected, setSelected] = useState<AnyJson[]>([]);
 
-  // store whether validator selection is active
-  const [selectActive, setSelectActiveState] = useState(
+  // Store whether validator selection is active.
+  const [selectActive, setSelectActiveState] = useState<boolean>(
     initialSelctActive ?? false
   );
 
-  // store the list format of the list
-  const [listFormat, _setListFormat] = useState('col');
+  // Store the list format of the list.
+  const [listFormat, _setListFormat] = useState<'col' | 'row'>('col');
 
-  const addToSelected = (_item: any) => {
+  const addToSelected = (_item: AnyJson) => {
     setSelected([...selected].concat(_item));
   };
 
-  const removeFromSelected = (items: any[]) => {
+  const removeFromSelected = (items: AnyJson[]) => {
     setSelected([...selected].filter((item) => !items.includes(item)));
   };
 
@@ -45,7 +46,7 @@ export const ListProvider = ({
     }
   };
 
-  const setListFormat = (v: string) => {
+  const setListFormat = (v: 'col' | 'row') => {
     _setListFormat(v);
   };
 

--- a/src/library/List/defaults.ts
+++ b/src/library/List/defaults.ts
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-export const defaultContext = {
-  setSelectable: (_selectable: boolean) => {},
-  addToSelected: (item: any) => {},
-  removeFromSelected: (items: any[]) => {},
+import type { ListContextInterface } from './types';
+
+export const defaultContext: ListContextInterface = {
+  setSelectActive: (selectedActive) => {},
+  addToSelected: (item) => {},
+  removeFromSelected: (items) => {},
   resetSelected: () => {},
   setListFormat: (v: string) => {},
+  selectActive: false,
   selected: [],
-  selectable: false,
   listFormat: 'col',
   selectToggleable: true,
 };

--- a/src/library/List/types.ts
+++ b/src/library/List/types.ts
@@ -3,6 +3,7 @@
 
 import type { AnyJson } from '@polkadot-cloud/react/types';
 import type React from 'react';
+import type { ReactNode } from 'react';
 import type { DisplayFor } from 'types';
 
 export interface PaginationWrapperProps {
@@ -30,4 +31,22 @@ export interface SelectableProps {
   actionsSelected: AnyJson[];
   canSelect: boolean;
   displayFor: DisplayFor;
+}
+
+export interface ListContextInterface {
+  setSelectActive: (selectedActive: boolean) => void;
+  addToSelected: (item: AnyJson) => void;
+  removeFromSelected: (items: AnyJson[]) => void;
+  resetSelected: () => void;
+  setListFormat: (v: 'col' | 'row') => void;
+  selected: AnyJson[];
+  selectActive: boolean;
+  listFormat: 'col' | 'row';
+  selectToggleable: boolean;
+}
+
+export interface ListProviderProps {
+  selectToggleable?: boolean;
+  selectActive?: boolean;
+  children: ReactNode;
 }

--- a/src/library/SetupSteps/Nominate.tsx
+++ b/src/library/SetupSteps/Nominate.tsx
@@ -11,6 +11,7 @@ import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { Subheading } from 'pages/Nominate/Wrappers';
 import { GenerateNominations } from '../GenerateNominations';
 import type { NominationsProps } from './types';
+import type { AnyJson } from 'types';
 
 export const Nominate = ({ bondFor, section }: NominationsProps) => {
   const { t } = useTranslation('library');
@@ -22,7 +23,7 @@ export const Nominate = ({ bondFor, section }: NominationsProps) => {
   const { maxNominations } = consts;
 
   // Handler for updating setup.
-  const handleSetupUpdate = (value: any) =>
+  const handleSetupUpdate = (value: AnyJson) =>
     setActiveAccountSetup(bondFor, value);
 
   return (

--- a/src/modals/Bond/index.tsx
+++ b/src/modals/Bond/index.tsx
@@ -149,7 +149,7 @@ export const Bond = () => {
       <Close />
       <ModalPadding>
         <h2 className="title unbounded">{t('addToBond')}</h2>
-        {pendingRewards > 0 && bondFor === 'pool' ? (
+        {pendingRewards.isGreaterThan(0) && bondFor === 'pool' ? (
           <ModalWarnings withMargin>
             <Warning
               text={`${t('bondingWithdraw')} ${pendingRewards} ${unit}.`}

--- a/src/modals/ChangePoolRoles/RoleChange.tsx
+++ b/src/modals/ChangePoolRoles/RoleChange.tsx
@@ -6,8 +6,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ellipsisFn, remToUnit } from '@polkadot-cloud/utils';
 import { Polkicon } from '@polkadot-cloud/react';
 import { RoleChangeWrapper } from './Wrapper';
+import type { RoleChangeProps } from './types';
 
-export const RoleChange = ({ roleName, oldAddress, newAddress }: any) => {
+export const RoleChange = ({
+  roleName,
+  oldAddress,
+  newAddress,
+}: RoleChangeProps) => {
   return (
     <RoleChangeWrapper>
       <div className="label">{roleName}</div>

--- a/src/modals/ChangePoolRoles/types.ts
+++ b/src/modals/ChangePoolRoles/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export interface RoleChangeProps {
+  roleName: string;
+  oldAddress: string;
+  newAddress: string;
+}

--- a/src/modals/ManagePool/Forms/LeavePool/index.tsx
+++ b/src/modals/ManagePool/Forms/LeavePool/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { getUnixTime } from 'date-fns';
+import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
@@ -31,7 +32,11 @@ import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 
-export const LeavePool = ({ setSection }: any) => {
+export const LeavePool = ({
+  setSection,
+}: {
+  setSection: Dispatch<SetStateAction<number>>;
+}) => {
   const { t } = useTranslation('modals');
   const { api, consts } = useApi();
   const {

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -150,7 +150,7 @@ export const Unbond = () => {
     submitExtrinsic.proxySupported
   );
 
-  if (pendingRewards > 0 && bondFor === 'pool') {
+  if (pendingRewards.isGreaterThan(0) && bondFor === 'pool') {
     warnings.push(`${t('unbondingWithdraw')} ${pendingRewards} ${unit}.`);
   }
   if (nominatorActiveBelowMin) {

--- a/src/modals/WithdrawPoolMember/index.tsx
+++ b/src/modals/WithdrawPoolMember/index.tsx
@@ -43,11 +43,11 @@ export const WithdrawPoolMember = () => {
   // calculate total for withdraw
   let totalWithdrawUnit = new BigNumber(0);
 
-  Object.entries(unbondingEras).forEach((entry: any) => {
+  Object.entries(unbondingEras).forEach((entry) => {
     const [era, amount] = entry;
-    if (activeEra.index > era) {
+    if (activeEra.index.isGreaterThan(era)) {
       totalWithdrawUnit = totalWithdrawUnit.plus(
-        new BigNumber(rmCommas(amount))
+        new BigNumber(rmCommas(amount as string))
       );
     }
   });

--- a/src/pages/Community/List.tsx
+++ b/src/pages/Community/List.tsx
@@ -42,7 +42,7 @@ export const List = () => {
   return (
     <PageRow yMargin>
       <ItemsWrapper variants={container} initial="hidden" animate="show">
-        {entityItems.map((item: any, index: number) => (
+        {entityItems.map((item, index: number) => (
           <Item key={`community_item_${index}`} item={item} actionable />
         ))}
       </ItemsWrapper>

--- a/src/pages/Community/context.tsx
+++ b/src/pages/Community/context.tsx
@@ -4,10 +4,10 @@
 import React, { useEffect, useState } from 'react';
 import { useNetwork } from 'contexts/Network';
 import * as defaults from './defaults';
+import type { CommunitySectionsContextInterface } from './types';
 
-export const CommunitySectionsContext: React.Context<any> = React.createContext(
-  defaults.defaultContext
-);
+export const CommunitySectionsContext: React.Context<CommunitySectionsContextInterface> =
+  React.createContext(defaults.defaultContext);
 
 export const useCommunitySections = () =>
   React.useContext(CommunitySectionsContext);
@@ -23,7 +23,7 @@ export const CommunitySectionsProvider = ({
   const [activeSection, setActiveSectionState] = useState<number>(0);
 
   // store the active entity item of the community page
-  const [activeItem, setActiveItem] = useState(defaults.item);
+  const [activeItem, setActiveItem] = useState(defaults.communityItem);
 
   // store the Y scroll position when the last entity was visited
   // used to automatically scroll back down upon returning to the entity lsit.
@@ -32,10 +32,10 @@ export const CommunitySectionsProvider = ({
   // go back to first section and reset item when network switches
   useEffect(() => {
     setActiveSectionState(0);
-    setActiveItem(defaults.item);
+    setActiveItem(defaults.communityItem);
   }, [network]);
 
-  const setActiveSection = (t: any) => {
+  const setActiveSection = (t: number) => {
     setActiveSectionState(t);
   };
 

--- a/src/pages/Community/defaults.ts
+++ b/src/pages/Community/defaults.ts
@@ -2,13 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-export const item = {
+import type { CommunitySectionsContextInterface, Item } from './types';
+
+export const communityItem: Item = {
   name: '',
-  thumbnail: null,
-  validators: [],
+  thumbnail: '',
+  validators: {},
 };
 
-export const defaultContext = {
-  setActiveSection: (t: number) => {},
+export const defaultContext: CommunitySectionsContextInterface = {
+  setActiveSection: (t) => {},
   activeSection: 0,
+  activeItem: communityItem,
+  setActiveItem: (item) => {},
+  scrollPos: 0,
+  setScrollPos: (scrollPos) => {},
 };

--- a/src/pages/Community/types.ts
+++ b/src/pages/Community/types.ts
@@ -1,16 +1,27 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 
+import type { Dispatch, SetStateAction } from 'react';
+
 export interface ItemProps {
   item: Item;
   actionable: boolean;
 }
 
 export interface Item {
-  bio: string;
+  bio?: string;
   name: string;
-  email: string;
-  twitter: string;
-  website: string;
+  email?: string;
+  twitter?: string;
+  website?: string;
   thumbnail: string;
   validators: Record<string, string>;
+}
+
+export interface CommunitySectionsContextInterface {
+  setActiveSection: (t: number) => void;
+  activeSection: number;
+  activeItem: Item;
+  setActiveItem: Dispatch<SetStateAction<Item>>;
+  scrollPos: number;
+  setScrollPos: Dispatch<SetStateAction<number>>;
 }

--- a/src/pages/Nominate/Setup/Bond/index.tsx
+++ b/src/pages/Nominate/Setup/Bond/index.tsx
@@ -13,6 +13,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
+import type { NominatorProgress } from 'contexts/Setup/types';
 
 export const Bond = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
@@ -31,10 +32,10 @@ export const Bond = ({ section }: SetupStepProps) => {
   });
 
   // bond valid
-  const [bondValid, setBondValid]: any = useState(false);
+  const [bondValid, setBondValid] = useState<boolean>(false);
 
   // handler for updating bond
-  const handleSetupUpdate = (value: any) => {
+  const handleSetupUpdate = (value: NominatorProgress) => {
     setActiveAccountSetup('nominator', value);
   };
 

--- a/src/pages/Nominate/Setup/Summary/index.tsx
+++ b/src/pages/Nominate/Setup/Summary/index.tsx
@@ -42,9 +42,11 @@ export const Summary = ({ section }: SetupStepProps) => {
       return null;
     }
 
-    const targetsToSubmit = nominations.map((item: any) => ({
-      Id: item.address,
-    }));
+    const targetsToSubmit = nominations.map(
+      ({ address }: { address: string }) => ({
+        Id: address,
+      })
+    );
 
     const payeeToSubmit =
       payee.destination === 'Account'

--- a/src/pages/Overview/StakeStatus/Tips/Items.tsx
+++ b/src/pages/Overview/StakeStatus/Tips/Items.tsx
@@ -4,12 +4,13 @@
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAnimationControls } from 'framer-motion';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePrompt } from 'contexts/Prompt';
 import { Tip } from 'library/Tips/Tip';
 import { ItemInnerWrapper, ItemWrapper, ItemsWrapper } from './Wrappers';
+import type { TipDisplayWithControls, TipItemsProps } from './types';
 
-export const ItemsInner = ({ items, page }: any) => {
+export const Items = ({ items, page }: TipItemsProps) => {
   const controls = useAnimationControls();
 
   // stores whether this is the initial display of tips
@@ -40,7 +41,7 @@ export const ItemsInner = ({ items, page }: any) => {
         },
       }}
     >
-      {items.map((item: any, index: number) => (
+      {items.map((item, index: number) => (
         <Item
           key={`tip_${index}_${page}`}
           index={index}
@@ -61,7 +62,7 @@ const Item = ({
   controls,
   initial,
   page,
-}: any) => {
+}: TipDisplayWithControls) => {
   const { openPromptWith } = usePrompt();
   const [isStopped, setIsStopped] = useState(true);
 
@@ -123,13 +124,3 @@ const Item = ({
     </ItemWrapper>
   );
 };
-
-export class Items extends React.Component<any, any> {
-  shouldComponentUpdate(nextProps: any) {
-    return JSON.stringify(this.props.items) !== JSON.stringify(nextProps.items);
-  }
-
-  render() {
-    return <ItemsInner {...this.props} />;
-  }
-}

--- a/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -20,6 +20,7 @@ import { Items } from './Items';
 import { PageToggle } from './PageToggle';
 import { Syncing } from './Syncing';
 import { TipsWrapper } from './Wrappers';
+import type { TipDisplay } from './types';
 
 export const Tips = () => {
   const { i18n, t } = useTranslation();
@@ -134,14 +135,14 @@ export const Tips = () => {
   }
 
   // filter tips relevant to connected account.
-  let items = TipsConfig.filter((i: AnyJson) => segments.includes(i.s));
+  let items = TipsConfig.filter((i) => segments.includes(i.s));
 
-  items = items.map((i: any) => {
-    const { id } = i;
+  items = items.map((item) => {
+    const { id } = item;
 
     return fillVariables(
       {
-        ...i,
+        ...item,
         title: t(`${id}.0`, { ns: 'tips' }),
         subtitle: t(`${id}.1`, { ns: 'tips' }),
         description: i18n.getResource(
@@ -162,7 +163,7 @@ export const Tips = () => {
     ? 1
     : pageRef.current * itemsPerPageRef.current - (itemsPerPageRef.current - 1);
 
-  const itemsDisplay = items.slice(start - 1, end);
+  const itemsDisplay = items.slice(start - 1, end) as TipDisplay[];
 
   const setPageHandler = (newPage: number) => {
     setStateWithRef(newPage, setPage, pageRef);

--- a/src/pages/Overview/StakeStatus/Tips/types.ts
+++ b/src/pages/Overview/StakeStatus/Tips/types.ts
@@ -1,6 +1,8 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { AnimationControls } from 'framer-motion';
+
 export interface PageToggleProps {
   start: number;
   end: number;
@@ -9,3 +11,24 @@ export interface PageToggleProps {
   totalItems: number;
   setPageHandler: (p: number) => void;
 }
+
+export interface TipItemsProps {
+  items: TipDisplay[];
+  page: number;
+  showTitle: boolean;
+}
+
+export interface TipDisplay {
+  description: string[];
+  id: string;
+  page: string;
+  s: number;
+  title: string;
+  subtitle: string;
+}
+
+export type TipDisplayWithControls = TipDisplay & {
+  controls: AnimationControls;
+  index: number;
+  initial: boolean;
+};

--- a/src/pages/Pools/Create/Bond/index.tsx
+++ b/src/pages/Pools/Create/Bond/index.tsx
@@ -13,6 +13,7 @@ import { Header } from 'library/SetupSteps/Header';
 import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
+import type { PoolProgress } from 'contexts/Setup/types';
 
 export const Bond = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
@@ -34,7 +35,7 @@ export const Bond = ({ section }: SetupStepProps) => {
   const [bondValid, setBondValid] = useState<boolean>(false);
 
   // handler for updating bond
-  const handleSetupUpdate = (value: any) => {
+  const handleSetupUpdate = (value: PoolProgress) => {
     setActiveAccountSetup('pool', value);
   };
 

--- a/src/pages/Pools/Create/PoolName/index.tsx
+++ b/src/pages/Pools/Create/PoolName/index.tsx
@@ -10,6 +10,7 @@ import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { Input } from './Input';
+import type { PoolProgress } from 'contexts/Setup/types';
 
 export const PoolName = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
@@ -29,7 +30,7 @@ export const PoolName = ({ section }: SetupStepProps) => {
   const [valid, setValid] = useState<boolean>(initialValue !== '');
 
   // handler for updating bond
-  const handleSetupUpdate = (value: any) => {
+  const handleSetupUpdate = (value: PoolProgress) => {
     setActiveAccountSetup('pool', value);
   };
 

--- a/src/pages/Pools/Create/PoolRoles/index.tsx
+++ b/src/pages/Pools/Create/PoolRoles/index.tsx
@@ -10,6 +10,7 @@ import { MotionContainer } from 'library/SetupSteps/MotionContainer';
 import type { SetupStepProps } from 'library/SetupSteps/types';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { Roles } from '../../Roles';
+import type { PoolProgress } from 'contexts/Setup/types';
 
 export const PoolRoles = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
@@ -36,7 +37,7 @@ export const PoolRoles = ({ section }: SetupStepProps) => {
   const [rolesValid, setRolesValid] = useState<boolean>(true);
 
   // handler for updating pool roles
-  const handleSetupUpdate = (value: any) => {
+  const handleSetupUpdate = (value: PoolProgress) => {
     setActiveAccountSetup('pool', value);
   };
 

--- a/src/pages/Pools/Create/Summary/index.tsx
+++ b/src/pages/Pools/Create/Summary/index.tsx
@@ -50,7 +50,9 @@ export const Summary = ({ section }: SetupStepProps) => {
       return null;
     }
 
-    const targetsToSubmit = nominations.map((item: any) => item.address);
+    const targetsToSubmit = nominations.map(
+      ({ address }: { address: string }) => address
+    );
 
     const bondToSubmit = unitToPlanck(bond, units);
     const bondAsString = bondToSubmit.isNaN() ? '0' : bondToSubmit.toString();

--- a/src/pages/Pools/Home/Favorites/index.tsx
+++ b/src/pages/Pools/Home/Favorites/index.tsx
@@ -12,6 +12,7 @@ import { CardWrapper } from 'library/Card/Wrappers';
 import { PoolList } from 'library/PoolList/Default';
 import { ListStatusHeader } from 'library/List';
 import { PoolListProvider } from 'library/PoolList/context';
+import type { BondedPool } from 'contexts/Pools/types';
 
 export const PoolFavorites = () => {
   const { t } = useTranslation('pages');
@@ -21,19 +22,19 @@ export const PoolFavorites = () => {
   const { favorites, removeFavorite } = usePoolsConfig();
 
   // Store local favorite list and update when favorites list is mutated.
-  const [favoritesList, setFavoritesList] = useState<any[]>([]);
+  const [favoritesList, setFavoritesList] = useState<BondedPool[]>([]);
 
   useEffect(() => {
     // map favorites to bonded pools
-    let newFavoritesList = favorites.map((f) => {
-      const pool = bondedPools.find((b) => b.addresses.stash === f);
-      if (!pool) removeFavorite(f);
-      return pool;
-    });
+    const newFavoritesList = favorites
+      .map((f) => {
+        const pool = bondedPools.find((b) => b.addresses.stash === f);
+        if (!pool) removeFavorite(f);
+        return pool;
+      })
+      .filter((f): f is BondedPool => f !== undefined);
 
     // filter not found bonded pools
-    newFavoritesList = newFavoritesList.filter((f: any) => f !== undefined);
-
     setFavoritesList(newFavoritesList);
   }, [favorites]);
 

--- a/src/pages/Pools/Home/MembersList/Member.tsx
+++ b/src/pages/Pools/Home/MembersList/Member.tsx
@@ -24,15 +24,24 @@ import {
   Wrapper,
 } from 'library/ListItem/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
+import type { AnyJson } from 'types';
 
-export const Member = ({ who, batchKey, batchIndex }: any) => {
+export const Member = ({
+  who,
+  batchKey,
+  batchIndex,
+}: {
+  who: string;
+  batchKey: string;
+  batchIndex: number;
+}) => {
   const { t } = useTranslation('pages');
   const { meta } = usePoolMembers();
   const { openModal } = useOverlay().modal;
   const { selectActive } = useList();
   const { activeEra } = useNetworkMetrics();
   const { selectedActivePool, isOwner, isBouncer } = useActivePools();
-  const { setMenuPosition, setMenuItems, open }: any = useMenu();
+  const { setMenuPosition, setMenuItems, open } = useMenu();
   const { state, roles } = selectedActivePool?.bondedPool || {};
   const { bouncer, root, depositor } = roles || {};
 
@@ -46,7 +55,7 @@ export const Member = ({ who, batchKey, batchIndex }: any) => {
   const poolMembers = meta[batchKey]?.poolMembers ?? [];
   const member = poolMembers[batchIndex] ?? null;
 
-  const menuItems: any[] = [];
+  const menuItems: AnyJson[] = [];
 
   if (member && (canUnbondBlocked || canUnbondDestroying)) {
     const { points, unbondingEras } = member;
@@ -108,7 +117,7 @@ export const Member = ({ who, batchKey, batchIndex }: any) => {
       <div className="inner">
         <MenuPosition ref={posRef} />
         <div className="row top">
-          {selectActive && <Select item={who} />}
+          {selectActive && <Select item={{ address: who }} />}
           <Identity address={who} />
           <div>
             <Labels>

--- a/src/pages/Pools/Home/MembersList/types.ts
+++ b/src/pages/Pools/Home/MembersList/types.ts
@@ -1,6 +1,8 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { AnyJson } from 'types';
+
 export interface MembersListProps {
   allowMoreCols: boolean;
   pagination: boolean;
@@ -10,7 +12,7 @@ export interface MembersListProps {
 }
 
 export type DefaultMembersListProps = MembersListProps & {
-  members: any;
+  members: AnyJson;
 };
 
 export type FetchpageMembersListProps = MembersListProps & {

--- a/src/pages/Pools/Home/PoolStats/Announcements.tsx
+++ b/src/pages/Pools/Home/PoolStats/Announcements.tsx
@@ -27,7 +27,7 @@ export const Announcements = () => {
   // calculate the latest reward account balance
   const rewardPoolBalance = BigNumber.max(
     0,
-    new BigNumber(rewardAccountBalance).minus(existentialDeposit)
+    new BigNumber(rewardAccountBalance || 0).minus(existentialDeposit)
   );
   const rewardBalance = planckToUnit(rewardPoolBalance, units);
 

--- a/src/pages/Pools/Roles/RoleEditInput/index.tsx
+++ b/src/pages/Pools/Roles/RoleEditInput/index.tsx
@@ -7,8 +7,13 @@ import { useTranslation } from 'react-i18next';
 import { useNetwork } from 'contexts/Network';
 import { formatAccountSs58 } from 'contexts/Connect/Utils';
 import { Wrapper } from './Wrapper';
+import type { RoleEditInputProps } from '../types';
 
-export const RoleEditInput = ({ setRoleEdit, roleKey, roleEdit }: any) => {
+export const RoleEditInput = ({
+  setRoleEdit,
+  roleKey,
+  roleEdit,
+}: RoleEditInputProps) => {
   const { t } = useTranslation('pages');
   const {
     networkData: { ss58 },

--- a/src/pages/Pools/Roles/index.tsx
+++ b/src/pages/Pools/Roles/index.tsx
@@ -108,7 +108,7 @@ export const Roles = ({
       if (listenIsValid) {
         listenIsValid(isRoleEditsValid());
       }
-      const rolesUpdated: any = {};
+      const rolesUpdated: Record<string, string> = {};
       for (const [k, v] of Object.entries(roleEdits)) {
         rolesUpdated[k] = v.newAddress;
       }

--- a/src/pages/Pools/Roles/types.ts
+++ b/src/pages/Pools/Roles/types.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { PoolRoles } from 'contexts/Pools/types';
+import type { AnyFunction } from 'types';
 
 export interface RolesProps {
   batchKey: string;
   defaultRoles: PoolRoles;
-  listenIsValid?: any;
-  setters?: any;
+  listenIsValid?: AnyFunction;
+  setters?: AnyFunction;
   inline?: boolean;
 }
 
@@ -17,3 +18,9 @@ export type RoleEditEntry = {
   valid: boolean;
   reformatted: boolean;
 };
+
+export interface RoleEditInputProps {
+  roleKey: string;
+  roleEdit: RoleEditEntry;
+  setRoleEdit: (role: string, edit: RoleEditEntry) => void;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 declare namespace JSX {
   interface IntrinsicElements {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     'dotlottie-player': any;
   }
 }

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -6,7 +6,7 @@ import type { Exposure } from 'contexts/Staking/types';
 import type { ErasRewardPoints } from 'contexts/Validators/types';
 import type { AnyApi, AnyJson } from 'types';
 
-// eslint-disable-next-line no-restricted-globals
+// eslint-disable-next-line no-restricted-globals, @typescript-eslint/no-explicit-any
 export const ctx: Worker = self as any;
 
 // handle incoming message and route to correct handler.

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -8,7 +8,7 @@ import type {
 } from 'contexts/Staking/types';
 import type { MaybeAddress, NetworkName } from 'types';
 
-export interface DataInitialiseExposures {
+export interface ProcessExposuresArgs {
   task: string;
   networkName: NetworkName;
   era: string;
@@ -18,7 +18,7 @@ export interface DataInitialiseExposures {
   maxExposurePageSize: number;
 }
 
-export interface ResponseInitialiseExposures {
+export interface ProcessExposuresResponse {
   task: string;
   networkName: NetworkName;
   era: string;
@@ -26,5 +26,15 @@ export interface ResponseInitialiseExposures {
   totalActiveNominators: number;
   activeAccountOwnStake: ActiveAccountStaker[];
   activeValidators: number;
+  who: MaybeAddress;
+}
+
+export interface ProcessEraForExposureArgs {
+  era: string;
+  maxExposurePageSize: string;
+  exposures: Exposure[];
+  exitOnExposed: boolean;
+  task: string;
+  networkName: NetworkName;
   who: MaybeAddress;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-cloud/assets@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@polkadot-cloud/assets@npm:0.2.0"
-  checksum: 16e5c8c17b32bc30ba8d2e5f4015e7a40762b45e93e6682477bc194ca7b18ca5b7a859c399f6082c61b33977c99456a50c72a12d174d1a99e7dd5cdd4f2e9b90
+"@polkadot-cloud/assets@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@polkadot-cloud/assets@npm:0.2.1"
+  checksum: a6d89dbacfa903fead98f937995113b596bde91c1532fc75bbf87d3986283114c27bbb63e74280f5078ae24d7748a72321c2c9f7622de4fb6ecc5863cf0527d7
   languageName: node
   linkType: hard
 
@@ -6768,7 +6768,7 @@ __metadata:
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
     "@ledgerhq/hw-transport-webhid": "npm:^6.28.1"
     "@ledgerhq/logs": "npm:^6.12.0"
-    "@polkadot-cloud/assets": "npm:^0.2.0"
+    "@polkadot-cloud/assets": "npm:^0.2.1"
     "@polkadot-cloud/core": "npm:^1.1.0"
     "@polkadot-cloud/react": "npm:^0.2.0"
     "@polkadot-cloud/utils": "npm:^0.1.0"


### PR DESCRIPTION
This PR replaces a large chunk of the remaining explicit `any` types either with concrete types or aliased any types.

Staking dashboard generally needs better typing and this is a work in progress, but this PR takes a big step in this direction.