### PR TITLE
feat(refactor): use `html5-qrcode`, remove `react-qr-reader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chroma-js": "^2.4.2",
     "date-fns": "^3.0.6",
     "framer-motion": "^10.16.16",
+    "html5-qrcode": "^2.3.8",
     "i18next": "^23.7.11",
     "i18next-browser-languagedetector": "^7.2.0",
     "lodash.throttle": "^4.1.1",
@@ -54,7 +55,6 @@
     "react-error-boundary": "^4.0.12",
     "react-helmet": "^6.1.0",
     "react-i18next": "^14.0.0",
-    "react-qr-reader": "^2.2.1",
     "react-router-dom": "^6.21.1",
     "react-scroll": "^1.9.0",
     "styled-components": "^6.1.3"
@@ -66,7 +66,6 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.17",
     "@types/react-helmet": "^6.1.11",
-    "@types/react-qr-reader": "^2.1.7",
     "@types/react-scroll": "^1.8.10",
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/eslint-plugin": "^6.16.0",

--- a/src/contexts/Prompt/defaults.tsx
+++ b/src/contexts/Prompt/defaults.tsx
@@ -12,4 +12,5 @@ export const defaultPromptContext: PromptContextInterface = {
   size: 'small',
   status: 0,
   Prompt: null,
+  setOnClosePrompt: (value) => {},
 };

--- a/src/contexts/Prompt/index.tsx
+++ b/src/contexts/Prompt/index.tsx
@@ -10,6 +10,7 @@ export const PromptProvider = ({ children }: { children: React.ReactNode }) => {
     size: 'large',
     status: 0,
     Prompt: null,
+    onClosePrompt: null,
   });
 
   const setPrompt = (Prompt: Prompt) => {
@@ -36,6 +37,10 @@ export const PromptProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   const closePrompt = () => {
+    if (state.onClosePrompt) {
+      state.onClosePrompt();
+    }
+
     setState({
       ...state,
       status: 0,
@@ -43,9 +48,17 @@ export const PromptProvider = ({ children }: { children: React.ReactNode }) => {
     });
   };
 
+  const setOnClosePrompt = (onClosePrompt: (() => void) | null) => {
+    setState({
+      ...state,
+      onClosePrompt,
+    });
+  };
+
   return (
     <PromptContext.Provider
       value={{
+        setOnClosePrompt,
         openPromptWith,
         closePrompt,
         setStatus,

--- a/src/contexts/Prompt/types.ts
+++ b/src/contexts/Prompt/types.ts
@@ -13,12 +13,14 @@ export interface PromptContextInterface {
   size: string;
   status: number;
   Prompt: Prompt;
+  setOnClosePrompt: (onClosePrompt: (() => void) | null) => void;
 }
 
 export interface PromptState {
   size: string;
   status: number;
   Prompt: Prompt;
+  onClosePrompt: (() => void) | null;
 }
 
 export type Prompt = ReactNode | null;

--- a/src/library/Import/Wrappers.ts
+++ b/src/library/Import/Wrappers.ts
@@ -135,7 +135,7 @@ export const QRViewerWrapper = styled.div`
   }
 
   .viewer {
-    border-radius: 1.25rem;
+    border-radius: 0.75rem;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/library/QRCode/Scan.tsx
+++ b/src/library/QRCode/Scan.tsx
@@ -1,30 +1,27 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import React, { useCallback, useMemo } from 'react';
-import Reader from 'react-qr-reader';
+import type { ReactElement } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScanWrapper } from './Wrappers.js';
 import type { ScanProps } from './types.js';
 import { createImgSize } from './util.js';
+import { Html5Qrcode } from 'html5-qrcode';
 
-const DEFAULT_DELAY = 150;
-
-const DEFAULT_ERROR = (error: Error): void => {
-  throw new Error(error.message);
+const DEFAULT_ERROR = (error: string): void => {
+  throw new Error(error);
 };
 
-const Scan = ({
+const QrScanInner = ({
   className = '',
-  delay = DEFAULT_DELAY,
   onError = DEFAULT_ERROR,
   onScan,
   size,
-  style = {},
-}: ScanProps): React.ReactElement<ScanProps> => {
+}: ScanProps): ReactElement<ScanProps> => {
   const containerStyle = useMemo(() => createImgSize(size), [size]);
 
   const onErrorCallback = useCallback(
-    (error: Error) => onError(error),
+    (error: string) => onError(error),
     [onError]
   );
 
@@ -35,15 +32,96 @@ const Scan = ({
 
   return (
     <ScanWrapper className={className} style={containerStyle}>
-      <Reader
-        className="ui--qr-Scan"
-        delay={delay}
-        onError={onErrorCallback}
-        onScan={onScanCallback}
-        style={style}
+      <Html5QrCodePlugin
+        fps={10}
+        qrCodeSuccessCallback={onScanCallback}
+        qrCodeErrorCallback={onErrorCallback}
       />
     </ScanWrapper>
   );
 };
 
-export const QrScan = React.memo(Scan);
+export const QrScan = memo(QrScanInner);
+
+interface Html5QrScannerProps {
+  fps: number;
+  qrCodeSuccessCallback: (data: string | null) => void;
+  qrCodeErrorCallback: (error: string) => void;
+}
+
+export const Html5QrCodePlugin = ({
+  fps,
+  qrCodeSuccessCallback,
+  qrCodeErrorCallback,
+}: Html5QrScannerProps) => {
+  // Store the HTML QR Code instance.
+  const [html5QrCode, setHtml5QrCode] = useState<Html5Qrcode | null>(null);
+
+  // Reference of the HTML element used to scan the QR code.
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleHtmlQrCode = (): void => {
+    if (!ref.current) {
+      return;
+    }
+
+    Html5Qrcode.getCameras()
+      .then((devices) => {
+        if (devices && devices.length) {
+          const cameraId = devices[0].id;
+
+          html5QrCode
+            ?.start(
+              cameraId,
+              {
+                fps,
+              },
+              (decodedText) => {
+                // do something when code is read
+                qrCodeSuccessCallback(decodedText);
+              },
+              (errorMessage) => {
+                // parse error
+                qrCodeErrorCallback(errorMessage);
+              }
+            )
+            .catch((err) => {
+              console.error(err);
+            });
+        } else {
+          // TODO: display error if no camera devices are available.
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      // Instantiate Html5Qrcode once DOM element exists.
+      setHtml5QrCode(new Html5Qrcode(ref.current.id));
+
+      // Cleanup function when component will unmount.
+      return () => {
+        if (html5QrCode) {
+          html5QrCode
+            .stop()
+            .then(() => {
+              // QR code scanning is stopped
+            })
+            .catch((err) => {
+              console.error(err);
+            });
+        }
+      };
+    }
+  }, []);
+
+  // Start QR scanner when API object is instantiated.
+  useEffect(() => {
+    handleHtmlQrCode();
+  }, [html5QrCode]);
+
+  return <div ref={ref} id="html5qr-code-full-region" />;
+};

--- a/src/library/QRCode/Scan.tsx
+++ b/src/library/QRCode/Scan.tsx
@@ -7,6 +7,7 @@ import { ScanWrapper } from './Wrappers.js';
 import type { ScanProps } from './types.js';
 import { createImgSize } from './util.js';
 import { Html5Qrcode } from 'html5-qrcode';
+import { usePrompt } from 'contexts/Prompt';
 
 const DEFAULT_ERROR = (error: string): void => {
   throw new Error(error);
@@ -55,6 +56,8 @@ export const Html5QrCodePlugin = ({
   qrCodeErrorCallback,
 }: Html5QrScannerProps) => {
   // Store the HTML QR Code instance.
+  const { setOnClosePrompt } = usePrompt();
+
   const [html5QrCode, setHtml5QrCode] = useState<Html5Qrcode | null>(null);
 
   // Reference of the HTML element used to scan the QR code.
@@ -92,27 +95,18 @@ export const Html5QrCodePlugin = ({
     }
   };
 
-  const stopHtmlQrCode = async () => {
-    try {
-      if (!html5QrCode) {
-        return;
-      }
-      await html5QrCode.stop();
-      html5QrCode?.clear();
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
   useEffect(() => {
     if (ref.current) {
       // Instantiate Html5Qrcode once DOM element exists.
-      setHtml5QrCode(new Html5Qrcode(ref.current.id));
+      const hewHtml5QrCode = new Html5Qrcode(ref.current.id);
+      setHtml5QrCode(hewHtml5QrCode);
+
+      // Stop HTML5 Qr Code when prompt closes.
+      setOnClosePrompt(() => {
+        hewHtml5QrCode?.stop();
+      });
       // Cleanup function when component will unmount.
     }
-    return () => {
-      stopHtmlQrCode();
-    };
   }, []);
 
   // Start QR scanner when API object is instantiated.

--- a/src/library/QRCode/types.ts
+++ b/src/library/QRCode/types.ts
@@ -43,7 +43,7 @@ export interface DisplayPayloadProps {
 export interface ScanProps {
   className?: string | undefined;
   delay?: number;
-  onError?: undefined | ((error: Error) => void);
+  onError?: undefined | ((error: string) => void);
   onScan: (data: string) => void;
   size?: string | number | undefined;
   style?: React.CSSProperties | undefined;
@@ -51,7 +51,7 @@ export interface ScanProps {
 
 export interface ScanSignatureProps {
   className?: string;
-  onError?: (error: Error) => void;
+  onError?: (error: string) => void;
   onScan: (scanned: ScanType) => void;
   size?: string | number;
   style?: React.CSSProperties;

--- a/src/library/QRCode/util.ts
+++ b/src/library/QRCode/util.ts
@@ -68,10 +68,10 @@ export const createImgSize = (
     };
   }
 
-  const height = isString(size) ? size : `${size}px`;
+  const width = isString(size) ? size : `${size}px`;
 
   return {
-    height,
-    width: height,
+    width,
+    height: 'auto',
   };
 };

--- a/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
+++ b/src/library/SubmitTx/ManualSign/Vault/SignPrompt.tsx
@@ -22,7 +22,7 @@ export const SignPrompt = ({ submitAddress }: SignerPromptProps) => {
   const { getTxPayload, setTxSignature } = useTxMeta();
   const payload = getTxPayload();
   const payloadU8a = payload?.toU8a();
-  const { setStatus: setPromptStatus } = usePrompt();
+  const { closePrompt } = usePrompt();
 
   // Whether user is on sign or submit stage.
   const [stage, setStage] = useState(1);
@@ -57,7 +57,7 @@ export const SignPrompt = ({ submitAddress }: SignerPromptProps) => {
           <QrScanSignature
             size={279}
             onScan={({ signature }: AnyJson) => {
-              setPromptStatus(0);
+              closePrompt();
               setTxSignature(signature);
             }}
           />
@@ -89,7 +89,7 @@ export const SignPrompt = ({ submitAddress }: SignerPromptProps) => {
             text={t('cancel')}
             lg
             marginLeft
-            onClick={() => setPromptStatus(0)}
+            onClick={() => closePrompt()}
           />
         </div>
       </div>

--- a/src/modals/ImportVault/Reader.tsx
+++ b/src/modals/ImportVault/Reader.tsx
@@ -20,7 +20,7 @@ export const Reader = () => {
     networkData: { ss58 },
   } = useNetwork();
   const { addOtherAccounts } = useOtherAccounts();
-  const { setStatus: setPromptStatus } = usePrompt();
+  const { closePrompt } = usePrompt();
   const { addVaultAccount, vaultAccountExists, vaultAccounts } =
     useVaultAccounts();
 
@@ -51,7 +51,7 @@ export const Reader = () => {
       if (account) {
         addOtherAccounts([account]);
       }
-      setPromptStatus(0);
+      closePrompt();
     }
 
     // Display feedback.
@@ -85,7 +85,7 @@ export const Reader = () => {
           <ButtonSecondary
             lg
             text={t('cancel')}
-            onClick={() => setPromptStatus(0)}
+            onClick={() => closePrompt()}
           />
         </div>
       </div>

--- a/src/modals/ImportVault/Reader.tsx
+++ b/src/modals/ImportVault/Reader.tsx
@@ -73,7 +73,7 @@ export const Reader = () => {
       <h3 className="title">{t('scanFromPolkadotVault')}</h3>
       <div className="viewer">
         <QrScanSignature
-          size={279}
+          size={250}
           onScan={({ signature }) => {
             handleQrData(signature);
           }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,15 +2455,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-qr-reader@npm:^2.1.7":
-  version: 2.1.7
-  resolution: "@types/react-qr-reader@npm:2.1.7"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 4170574591c5e04afa216cdd6b240bbbf31cb770d72156be50343e778a39518aebff0800e87681c318e6507f9334040939057b45e7bdfde89822f72d328c3500
-  languageName: node
-  linkType: hard
-
 "@types/react-scroll@npm:^1.8.10":
   version: 1.8.10
   resolution: "@types/react-scroll@npm:1.8.10"
@@ -5169,6 +5160,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html5-qrcode@npm:^2.3.8":
+  version: 2.3.8
+  resolution: "html5-qrcode@npm:2.3.8"
+  checksum: 3d7d0b3687e41a6fc0a06345f67e89ad3c7c00a3d0d8846d6fd31985e1ed2ac1c310e625f0b650dbc689f6b83469e3378417e7431ae5a9194178f1172bf6a93a
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -5818,13 +5816,6 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
-  languageName: node
-  linkType: hard
-
-"jsqr@npm:^1.2.0":
-  version: 1.4.0
-  resolution: "jsqr@npm:1.4.0"
-  checksum: 69fbfe4c866a04c97b377901a166544a583bfc76b838c275efa9af058d64e5612267079b1e96ea7b6434385803571b1c6a97a43c85f4373e8afa4f4034fc916c
   languageName: node
   linkType: hard
 
@@ -6828,7 +6819,6 @@ __metadata:
     "@types/react": "npm:^18.2.45"
     "@types/react-dom": "npm:^18.2.17"
     "@types/react-helmet": "npm:^6.1.11"
-    "@types/react-qr-reader": "npm:^2.1.7"
     "@types/react-scroll": "npm:^1.8.10"
     "@types/styled-components": "npm:^5.1.34"
     "@typescript-eslint/eslint-plugin": "npm:^6.16.0"
@@ -6853,6 +6843,7 @@ __metadata:
     eslint-plugin-unused-imports: "npm:^3.0.0"
     framer-motion: "npm:^10.16.16"
     gh-pages: "npm:^6.1.1"
+    html5-qrcode: "npm:^2.3.8"
     i18next: "npm:^23.7.11"
     i18next-browser-languagedetector: "npm:^7.2.0"
     lodash.throttle: "npm:^4.1.1"
@@ -6866,7 +6857,6 @@ __metadata:
     react-error-boundary: "npm:^4.0.12"
     react-helmet: "npm:^6.1.0"
     react-i18next: "npm:^14.0.0"
-    react-qr-reader: "npm:^2.2.1"
     react-router-dom: "npm:^6.21.1"
     react-scroll: "npm:^1.9.0"
     sass: "npm:^1.69.5"
@@ -7228,20 +7218,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-qr-reader@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "react-qr-reader@npm:2.2.1"
-  dependencies:
-    jsqr: "npm:^1.2.0"
-    prop-types: "npm:^15.7.2"
-    webrtc-adapter: "npm:^7.2.1"
-  peerDependencies:
-    react: ~16
-    react-dom: ~16
-  checksum: f36eed877c554f13c2e962aa88054a779bf12d11100cbc801d747b5843fbe88610d095a0f2e43c4a6ce72377234583f94d22c31781e27a01fae71a7662e8b0e7
-  languageName: node
-  linkType: hard
-
 "react-router-dom@npm:^6.21.1":
   version: 6.21.1
   resolution: "react-router-dom@npm:6.21.1"
@@ -7543,15 +7519,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rtcpeerconnection-shim@npm:^1.2.15":
-  version: 1.2.15
-  resolution: "rtcpeerconnection-shim@npm:1.2.15"
-  dependencies:
-    sdp: "npm:^2.6.0"
-  checksum: efa4d9ba66146e2e03b6fb34bd1ceb77bf14f2fb2ee8c75c2c8f6a2494ffacc37c214caf5d4a3dcc761ba0b5bfd20fa61fa0820447f64e24b1e959f725ff7410
-  languageName: node
-  linkType: hard
-
 "run-applescript@npm:^5.0.0":
   version: 5.0.0
   resolution: "run-applescript@npm:5.0.0"
@@ -7642,13 +7609,6 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: b777f7ca0115e6d93e126ac490dbd82642d14983b3079f58f35519d992fa46260be7d6e6cede433a92db70306310c6f5f06e144f0e40c484199e09c1f7be53dd
-  languageName: node
-  linkType: hard
-
-"sdp@npm:^2.12.0, sdp@npm:^2.6.0":
-  version: 2.12.0
-  resolution: "sdp@npm:2.12.0"
-  checksum: 1a2ffdc20d79711175f89e87a6ce8db9b4757e694bed9760e5f919eed5925c9fb43ea63c5fd38f428a3edd45baae826318153fdc1db590a504eed7a809a23e32
   languageName: node
   linkType: hard
 
@@ -8995,16 +8955,6 @@ __metadata:
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: 70ed6b5708e14afa2ab699221ea197d7c68ec0c8274bbe0181aecc5ba636ca27cbd383d2049f0eb9d529e738f5c088825502b317f3df24d18a278e4cc9a10e8b
-  languageName: node
-  linkType: hard
-
-"webrtc-adapter@npm:^7.2.1":
-  version: 7.7.1
-  resolution: "webrtc-adapter@npm:7.7.1"
-  dependencies:
-    rtcpeerconnection-shim: "npm:^1.2.15"
-    sdp: "npm:^2.12.0"
-  checksum: f3432a5d6247896dd61458f7c4b2c15177aaab7aa42c4d32855735bcd948fc646c0471afe95d542edf45e170b2e6405353e8020752e8db4a74c36be524303767
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces `react-qr-reader` (which takes React 16 as a dependency) with `html5-qrcode`.