### PR TITLE
feat(refactor): API to static class

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -81,12 +81,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     setRpcEndpointState(key);
   };
 
-  // Resets app state when switching networks.
-  const onChangeNetwork = () => {
-    setConsts(defaultConsts);
-    setchainState(defaultChainState);
-  };
-
   // Fetch chain state. Called once `provider` has been initialised.
   const onApiReady = async () => {
     const { api } = APIController;
@@ -227,10 +221,12 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     }
   };
 
-  // Handle an initial RPC connection.
+  // Handle an initial api connection.
   useEffect(() => {
-    if (!APIController.provider && !isLightClient) {
-      APIController.initialize(network, 'ws', { rpcEndpoint });
+    if (!APIController.provider) {
+      APIController.initialize(network, isLightClient ? 'sc' : 'ws', {
+        rpcEndpoint,
+      });
     }
   });
 
@@ -244,9 +240,9 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
   // Trigger API connection handler on network or light client change.
   useEffectIgnoreInitial(() => {
     setRpcEndpoint(initialRpcEndpoint());
-
     if (network !== APIController.network) {
-      onChangeNetwork();
+      setConsts(defaultConsts);
+      setchainState(defaultChainState);
     }
 
     APIController.reconnect(network, isLightClient ? 'sc' : 'ws', rpcEndpoint);

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -18,7 +18,6 @@ import type {
   APIConstants,
   APIContextInterface,
   APIProviderProps,
-  ApiStatus,
 } from 'contexts/Api/types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import {
@@ -28,6 +27,7 @@ import {
 } from './defaults';
 import { APIController } from 'static/APController';
 import { isCustomEvent } from 'static/utils';
+import type { ApiStatus } from 'static/APController/types';
 
 export const APIContext = createContext<APIContextInterface>(defaultApiContext);
 

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -29,6 +29,8 @@ import {
   defaultChainState,
   defaultConsts,
 } from './defaults';
+import { APIController } from 'static/APController';
+import { isCustomEvent } from 'static/utils';
 
 export const APIContext = createContext<APIContextInterface>(defaultApiContext);
 
@@ -269,6 +271,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
   // Handle an initial RPC connection.
   useEffect(() => {
     if (!provider && !isLightClient) {
+      APIController.initailize(network, 'ws', { rpcEndpoint });
       connectProvider();
     }
   });
@@ -301,6 +304,22 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
       getChainState();
     }
   }, [provider]);
+
+  const eventCallback = (e: Event) => {
+    if (isCustomEvent(e)) {
+      const { event } = e.detail;
+      console.log('RECEIVED EVENT: ', event);
+      console.log(APIController.api);
+    }
+  };
+
+  // Add event listener for notifications.
+  useEffect(() => {
+    document.addEventListener('polkadot-api', eventCallback);
+    return () => {
+      document.removeEventListener('polkadot-api', eventCallback);
+    };
+  }, []);
 
   return (
     <APIContext.Provider

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -55,9 +55,15 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     useState<string>(initialRpcEndpoint());
 
   // Store whether in light client mode.
-  const [isLightClient, setIsLightClient] = useState<boolean>(
+  const [isLightClient, setIsLightClientState] = useState<boolean>(
     !!localStorage.getItem('light_client')
   );
+
+  // Setter for light client. Updates state and local storage.
+  const setIsLightClient = (value: boolean) => {
+    setIsLightClientState(value);
+    localStorage.setItem('light_client', value ? 'true' : 'false');
+  };
 
   // Store network constants.
   const [consts, setConsts] = useState<APIConstants>(defaultConsts);
@@ -103,10 +109,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
 
       setchainState({ chain, version, ss58Prefix });
     }
-
-    // store active network in localStorage.
-    // NOTE: this should ideally refer to above `chain` value.
-    localStorage.setItem('network', String(network));
 
     // Assume chain state is correct and bootstrap network consts.
     connectedCallback();

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -200,34 +200,6 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     });
   };
 
-  // Handle an initial RPC connection.
-  useEffect(() => {
-    if (!APIController.provider && !isLightClient) {
-      APIController.initialize(network, 'ws', { rpcEndpoint });
-    }
-  });
-
-  // If RPC endpoint changes, and not on light client, re-connect.
-  useEffectIgnoreInitial(() => {
-    if (!isLightClient) {
-      APIController.reconnect(network, 'ws', rpcEndpoint);
-    }
-  }, [rpcEndpoint]);
-
-  // Trigger API connection handler on network or light client change.
-  useEffectIgnoreInitial(() => {
-    setRpcEndpoint(initialRpcEndpoint());
-    if (network !== APIController.network) {
-      onChangeNetwork();
-    }
-
-    APIController.reconnect(network, isLightClient ? 'sc' : 'ws', rpcEndpoint);
-
-    return () => {
-      APIController.cancelFn?.();
-    };
-  }, [isLightClient, network]);
-
   // Handle `polkadot-api` events.
   const eventCallback = (e: Event) => {
     if (isCustomEvent(e)) {
@@ -252,6 +224,35 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
       }
     }
   };
+
+  // Handle an initial RPC connection.
+  useEffect(() => {
+    if (!APIController.provider && !isLightClient) {
+      APIController.initialize(network, 'ws', { rpcEndpoint });
+    }
+  });
+
+  // If RPC endpoint changes, and not on light client, re-connect.
+  useEffectIgnoreInitial(() => {
+    if (!isLightClient) {
+      APIController.reconnect(network, 'ws', rpcEndpoint);
+    }
+  }, [rpcEndpoint]);
+
+  // Trigger API connection handler on network or light client change.
+  useEffectIgnoreInitial(() => {
+    setRpcEndpoint(initialRpcEndpoint());
+
+    if (network !== APIController.network) {
+      onChangeNetwork();
+    }
+
+    APIController.reconnect(network, isLightClient ? 'sc' : 'ws', rpcEndpoint);
+
+    return () => {
+      APIController.cancelFn?.();
+    };
+  }, [isLightClient, network]);
 
   // Add event listener for `polkadot-api` notifications.
   useEffect(() => {

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -79,7 +79,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
   };
 
   // Store chain state.
-  const [chainState, setchainState] =
+  const [chainState, setChainState] =
     useState<APIChainState>(defaultChainState);
 
   // Store network constants.
@@ -105,7 +105,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
       const version = newChainState[1]?.toJSON();
       const ss58Prefix = Number(newChainState[2]?.toString());
 
-      setchainState({ chain, version, ss58Prefix });
+      setChainState({ chain, version, ss58Prefix });
     }
 
     // Assume chain state is correct and bootstrap network consts.
@@ -247,7 +247,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     // If network changes, reset consts and chain state.
     if (network !== APIController.network) {
       setConsts(defaultConsts);
-      setchainState(defaultChainState);
+      setChainState(defaultChainState);
     }
     // Reconnect API instance.
     APIController.reconnect(network, isLightClient ? 'sc' : 'ws', rpcEndpoint);

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -34,9 +34,23 @@ export const APIContext = createContext<APIContextInterface>(defaultApiContext);
 export const useApi = () => useContext(APIContext);
 
 export const APIProvider = ({ children, network }: APIProviderProps) => {
-  // Store chain state.
-  const [chainState, setchainState] =
-    useState<APIChainState>(defaultChainState);
+  // Store API connection status.
+  const [apiStatus, setApiStatus] = useState<ApiStatus>('disconnected');
+
+  // Store whether light client is active.
+  const [isLightClient, setIsLightClientState] = useState<boolean>(
+    !!localStorage.getItem('light_client')
+  );
+
+  // Setter for whether light client is active. Updates state and local storage.
+  const setIsLightClient = (value: boolean) => {
+    setIsLightClientState(value);
+    if (!value) {
+      localStorage.removeItem('light_client');
+      return;
+    }
+    localStorage.setItem('light_client', 'true');
+  };
 
   // Store the active RPC provider.
   const initialRpcEndpoint = () => {
@@ -51,29 +65,9 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
 
     return NetworkList[network].endpoints.defaultRpcEndpoint;
   };
+
   const [rpcEndpoint, setRpcEndpointState] =
     useState<string>(initialRpcEndpoint());
-
-  // Store whether in light client mode.
-  const [isLightClient, setIsLightClientState] = useState<boolean>(
-    !!localStorage.getItem('light_client')
-  );
-
-  // Setter for light client. Updates state and local storage.
-  const setIsLightClient = (value: boolean) => {
-    setIsLightClientState(value);
-    if (!value) {
-      localStorage.removeItem('light_client');
-      return;
-    }
-    localStorage.setItem('light_client', 'true');
-  };
-
-  // Store network constants.
-  const [consts, setConsts] = useState<APIConstants>(defaultConsts);
-
-  // Store API connection status.
-  const [apiStatus, setApiStatus] = useState<ApiStatus>('disconnected');
 
   // Set RPC provider with local storage and validity checks.
   const setRpcEndpoint = (key: string) => {
@@ -81,9 +75,15 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
       return;
     }
     localStorage.setItem(`${network}_rpc_endpoint`, key);
-
     setRpcEndpointState(key);
   };
+
+  // Store chain state.
+  const [chainState, setchainState] =
+    useState<APIChainState>(defaultChainState);
+
+  // Store network constants.
+  const [consts, setConsts] = useState<APIConstants>(defaultConsts);
 
   // Fetch chain state. Called once `provider` has been initialised.
   const onApiReady = async () => {

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -6,8 +6,7 @@ import type { U8aLike } from '@polkadot/util/types';
 import type BigNumber from 'bignumber.js';
 import type { ReactNode } from 'react';
 import type { AnyJson, Network, NetworkName } from '../../types';
-
-export type ApiStatus = 'connecting' | 'connected' | 'disconnected' | 'ready';
+import type { ApiStatus } from 'static/APController/types';
 
 export interface APIProviderProps {
   children: ReactNode;

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -7,7 +7,7 @@ import type BigNumber from 'bignumber.js';
 import type { ReactNode } from 'react';
 import type { AnyJson, Network, NetworkName } from '../../types';
 
-export type ApiStatus = 'connecting' | 'connected' | 'disconnected';
+export type ApiStatus = 'connecting' | 'connected' | 'disconnected' | 'ready';
 
 export interface APIProviderProps {
   children: ReactNode;

--- a/src/contexts/Pools/PoolMembers/index.tsx
+++ b/src/contexts/Pools/PoolMembers/index.tsx
@@ -52,6 +52,7 @@ export const PoolMembersProvider = ({
   // Clear existing state for network refresh
   useEffectIgnoreInitial(() => {
     setPoolMembersNode([]);
+    setPoolMembersApi([]);
     unsubscribeAndResetMeta();
   }, [network]);
 
@@ -69,6 +70,7 @@ export const PoolMembersProvider = ({
       }
     } else {
       setPoolMembersNode([]);
+      setPoolMembersApi([]);
     }
     return () => {
       unsubscribe();
@@ -78,6 +80,7 @@ export const PoolMembersProvider = ({
   const unsubscribe = () => {
     unsubscribeAndResetMeta();
     setPoolMembersNode([]);
+    setPoolMembersApi([]);
   };
 
   const unsubscribeAndResetMeta = () => {

--- a/src/contexts/Pools/PoolsConfig/defaults.ts
+++ b/src/contexts/Pools/PoolsConfig/defaults.ts
@@ -6,7 +6,7 @@ import BigNumber from 'bignumber.js';
 import type { PoolsConfigContextState, PoolStats } from './types';
 import type { PoolAddresses } from '../BondedPools/types';
 
-export const stats: PoolStats = {
+export const defaultStats: PoolStats = {
   counterForPoolMembers: new BigNumber(0),
   counterForBondedPools: new BigNumber(0),
   counterForRewardPools: new BigNumber(0),
@@ -24,7 +24,7 @@ export const defaultPoolsConfigContext: PoolsConfigContextState = {
   removeFavorite: () => {},
   createAccounts: () => poolAddresses,
   favorites: [],
-  stats,
+  stats: defaultStats,
 };
 
 export const poolAddresses: PoolAddresses = {

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -5,27 +5,24 @@ import { bnToU8a, u8aConcat } from '@polkadot/util';
 import { rmCommas, setStateWithRef } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import BN from 'bn.js';
-import React, { useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { EmptyH256, ModPrefix, U32Opts } from 'consts';
 import type { PoolConfigState, PoolsConfigContextState } from './types';
 import type { AnyApi } from 'types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import { useApi } from '../../Api';
-import * as defaults from './defaults';
+import { defaultStats, defaultPoolsConfigContext } from './defaults';
 
-export const PoolsConfigProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
+export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork();
   const { api, isReady, consts } = useApi();
   const { poolsPalletId } = consts;
 
   // store pool metadata
   const [poolsConfig, setPoolsConfig] = useState<PoolConfigState>({
-    stats: defaults.stats,
+    stats: defaultStats,
     unsub: null,
   });
   const poolsConfigRef = useRef(poolsConfig);
@@ -38,15 +35,6 @@ export const PoolsConfigProvider = ({
 
   // stores the user's favorite pools
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites());
-
-  useEffectIgnoreInitial(() => {
-    if (isReady) {
-      subscribeToPoolConfig();
-    }
-    return () => {
-      unsubscribe();
-    };
-  }, [network, isReady]);
 
   const unsubscribe = () => {
     if (poolsConfigRef.current.unsub !== null) {
@@ -199,6 +187,25 @@ export const PoolsConfigProvider = ({
       .toString();
   };
 
+  // Handle ready state.
+  useEffectIgnoreInitial(() => {
+    if (isReady) {
+      subscribeToPoolConfig();
+    }
+  }, [network, isReady]);
+
+  // Handle network change.
+  useEffect(() => {
+    unsubscribe();
+    setPoolsConfig({
+      stats: defaultStats,
+      unsub: null,
+    });
+  }, [network]);
+
+  // Unsubscribe on component unmount.
+  useEffect(() => () => unsubscribe());
+
   return (
     <PoolsConfigContext.Provider
       value={{
@@ -206,7 +213,7 @@ export const PoolsConfigProvider = ({
         removeFavorite,
         createAccounts,
         favorites,
-        stats: poolsConfigRef.current.stats,
+        stats: poolsConfig.stats,
       }}
     >
       {children}
@@ -215,7 +222,7 @@ export const PoolsConfigProvider = ({
 };
 
 export const PoolsConfigContext = React.createContext<PoolsConfigContextState>(
-  defaults.defaultPoolsConfigContext
+  defaultPoolsConfigContext
 );
 
 export const usePoolsConfig = () => React.useContext(PoolsConfigContext);

--- a/src/library/NetworkBar/Status.tsx
+++ b/src/library/NetworkBar/Status.tsx
@@ -21,7 +21,7 @@ export const Status = () => {
           {t('connecting')}...
         </motion.p>
       )}
-      {apiStatus === 'connected' && (
+      {['connected', 'ready'].includes(apiStatus) && (
         <motion.p animate={{ opacity: [0, 1] }} transition={{ duration: 0.3 }}>
           {t('connectedToNetwork')}
         </motion.p>

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -65,11 +65,12 @@ export const SideMenu = () => {
     setSideMenu(false);
   });
 
-  const apiStatusClass = ['connecting', 'connected'].includes(apiStatus)
-    ? 'warning'
-    : apiStatus === 'ready'
-      ? 'success'
-      : 'danger';
+  const apiStatusClass =
+    apiStatus === 'connecting'
+      ? 'warning'
+      : ['connected', 'ready'].includes(apiStatus)
+        ? 'success'
+        : 'danger';
 
   return (
     <Wrapper ref={ref} $minimised={sideMenuMinimised}>

--- a/src/library/SideMenu/index.tsx
+++ b/src/library/SideMenu/index.tsx
@@ -65,12 +65,11 @@ export const SideMenu = () => {
     setSideMenu(false);
   });
 
-  const apiStatusClass =
-    apiStatus === 'connecting'
-      ? 'warning'
-      : apiStatus === 'connected'
-        ? 'success'
-        : 'danger';
+  const apiStatusClass = ['connecting', 'connected'].includes(apiStatus)
+    ? 'warning'
+    : apiStatus === 'ready'
+      ? 'success'
+      : 'danger';
 
   return (
     <Wrapper ref={ref} $minimised={sideMenuMinimised}>

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -5,7 +5,6 @@ import BigNumber from 'bignumber.js';
 import { fromUnixTime } from 'date-fns';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from 'contexts/Api';
 import { useNetworkMetrics } from 'contexts/NetworkMetrics';
 import { useEraTimeLeft } from 'library/Hooks/useEraTimeLeft';
 import { useTimeLeft } from 'library/Hooks/useTimeLeft';
@@ -14,7 +13,6 @@ import { Timeleft } from 'library/StatBoxList/Timeleft';
 
 export const ActiveEraStat = () => {
   const { t } = useTranslation('pages');
-  const { apiStatus } = useApi();
   const { activeEra } = useNetworkMetrics();
   const { get: getEraTimeleft } = useEraTimeLeft();
   const { timeleft, setFromNow } = useTimeLeft();
@@ -25,7 +23,7 @@ export const ActiveEraStat = () => {
   // re-set timer on era change (also covers network change).
   useEffect(() => {
     setFromNow(dateFrom, dateTo);
-  }, [apiStatus, activeEra]);
+  }, [activeEra]);
 
   // NOTE: this maybe should be called in an interval. Needs more testing.
   const { percentSurpassed, percentRemaining } = getEraTimeleft();

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -1,0 +1,96 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { makeCancelable } from '@polkadot-cloud/utils';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { ScProvider } from '@polkadot/rpc-provider/substrate-connect';
+import { NetworkList } from 'config/networks';
+import type { NetworkName } from 'types';
+import type { SubstrateConnect } from './types';
+
+export class APIController {
+  // ---------------------
+  // Class members.
+  // ---------------------
+
+  // API provider.
+  static provider: WsProvider | ScProvider;
+
+  // API instance.
+  static _api: ApiPromise;
+
+  static get api(): ApiPromise {
+    return this._api;
+  }
+
+  // Cancel function of substrate connect.
+  static cancelFn: () => void;
+
+  // ---------------------
+  // Class methods.
+  // ---------------------
+
+  // Class initialisation. Sets the `provider` and `api` class members.
+  static async initailize(
+    network: NetworkName,
+    type: 'ws' | 'sc',
+    config: {
+      rpcEndpoint: string;
+    }
+  ) {
+    if (type === 'ws') {
+      this.initWsProvider(network, config.rpcEndpoint);
+    } else {
+      await this.initScProvider(network);
+    }
+
+    this.initEvents();
+
+    this._api = await ApiPromise.create({ provider: this.provider });
+
+    document.dispatchEvent(
+      new CustomEvent('polkadot-api', { detail: { event: 'ready' } })
+    );
+  }
+
+  // Set up API events. Relays information to `docunent` for the UI to handle.
+  static initEvents() {
+    this.provider.on('connected', () => {
+      document.dispatchEvent(
+        new CustomEvent('polkadot-api', { detail: { event: 'connected' } })
+      );
+    });
+    this.provider.on('disconnected', () => {
+      document.dispatchEvent(
+        new CustomEvent('polkadot-api', { detail: { event: 'disconnected' } })
+      );
+    });
+    this.provider.on('error', (err) => {
+      document.dispatchEvent(
+        new CustomEvent('polkadot-api', { detail: { event: 'error', err } })
+      );
+    });
+  }
+
+  // Initiate Websocket Provider
+  static initWsProvider(network: NetworkName, rpcEndpoint: string) {
+    this.provider = new WsProvider(
+      NetworkList[network].endpoints.rpcEndpoints[rpcEndpoint]
+    );
+  }
+
+  // Dynamically load substrate connect.
+  static async initScProvider(network: NetworkName) {
+    // Dynamically load substrate connect.
+    const ScPromise = makeCancelable(import('@substrate/connect'));
+    this.cancelFn = ScPromise.cancel;
+
+    const Sc = (await ScPromise.promise) as SubstrateConnect;
+
+    this.provider = new ScProvider(
+      // @ts-expect-error mismatch between `@polkadot/rpc-provider/substrate-connect` and  `@substrate/connect` types: Chain[]' is not assignable to type 'string'.
+      Sc,
+      NetworkList[network].endpoints.lightClient
+    );
+  }
+}

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -63,22 +63,25 @@ export class APIController {
     type: ConnectionType,
     rpcEndpoint: string
   ) {
-    // Tell UI api is disconnected while we awit disconnect.
-    document.dispatchEvent(
-      new CustomEvent('polkadot-api', { detail: { event: 'disconnected' } })
-    );
     await this.api.disconnect();
-
     this.network = network;
 
     document.dispatchEvent(
       new CustomEvent('polkadot-api', { detail: { event: 'connecting' } })
     );
+
     if (type === 'ws') {
       this.initWsProvider(network, rpcEndpoint);
     } else {
       await this.initScProvider(network);
     }
+
+    this.initEvents();
+    this._api = await ApiPromise.create({ provider: this.provider });
+
+    document.dispatchEvent(
+      new CustomEvent('polkadot-api', { detail: { event: 'ready' } })
+    );
   }
 
   // Set up API events. Relays information to `document` for the UI to handle.

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -134,13 +134,13 @@ export class APIController {
   // Remove API event listeners.
   static resetEvents() {
     this.provider.on('connected', () => {
-      /* noop */
+      /* No nothing */
     });
     this.provider.on('disconnected', () => {
-      /* noop */
+      /* No nothing */
     });
     this.provider.on('error', () => {
-      /* noop */
+      /* No nothing */
     });
   }
 }

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -166,13 +166,14 @@ export class APIController {
 
   // Ensures the provided status is a valid `EventStatus` being passed, or falls back to `error`.
   static ensureEventStatus = (status: string | EventStatus): EventStatus => {
-    if (
-      status === 'connecting' ||
-      status === 'connected' ||
-      status === 'disconnected' ||
-      status === 'ready' ||
-      status === 'error'
-    ) {
+    const eventStatus: string[] = [
+      'connecting',
+      'connected',
+      'disconnected',
+      'ready',
+      'error',
+    ];
+    if (eventStatus.includes(status)) {
       return status as EventStatus;
     }
     return 'error' as EventStatus;

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -45,7 +45,9 @@ export class APIController {
       new CustomEvent('polkadot-api', { detail: { event: 'connecting' } })
     );
 
+    // Set the new network to the class member and local storage.
     this.network = network;
+    localStorage.setItem('network', network);
 
     if (type === 'ws') {
       this.initWsProvider(network, config.rpcEndpoint);
@@ -70,7 +72,9 @@ export class APIController {
     await this.api.disconnect();
     this.resetEvents();
 
+    // Set the new network to the class member and local storage.
     this.network = network;
+    localStorage.setItem('network', network);
 
     document.dispatchEvent(
       new CustomEvent('polkadot-api', { detail: { event: 'connecting' } })

--- a/src/static/APController/types.ts
+++ b/src/static/APController/types.ts
@@ -6,3 +6,12 @@ export interface SubstrateConnect {
 }
 
 export type ConnectionType = 'ws' | 'sc';
+
+export type ApiStatus = 'connecting' | 'connected' | 'disconnected' | 'ready';
+
+export type EventStatus = keyof ApiStatus | 'error';
+
+export interface EventDetail {
+  event: EventStatus;
+  err?: string;
+}

--- a/src/static/APController/types.ts
+++ b/src/static/APController/types.ts
@@ -4,3 +4,5 @@ export interface SubstrateConnect {
   WellKnownChain: (typeof ScType)['WellKnownChain'];
   createScClient: (typeof ScType)['createScClient'];
 }
+
+export type ConnectionType = 'ws' | 'sc';

--- a/src/static/APController/types.ts
+++ b/src/static/APController/types.ts
@@ -9,7 +9,7 @@ export type ConnectionType = 'ws' | 'sc';
 
 export type ApiStatus = 'connecting' | 'connected' | 'disconnected' | 'ready';
 
-export type EventStatus = keyof ApiStatus | 'error';
+export type EventStatus = ApiStatus | 'error';
 
 export interface EventDetail {
   event: EventStatus;

--- a/src/static/APController/types.ts
+++ b/src/static/APController/types.ts
@@ -1,0 +1,6 @@
+import type * as ScType from '@substrate/connect';
+
+export interface SubstrateConnect {
+  WellKnownChain: (typeof ScType)['WellKnownChain'];
+  createScClient: (typeof ScType)['createScClient'];
+}


### PR DESCRIPTION
This PR separates the Polkadot JS API `api` and `provider` objects from React completely, cutting down on re-renders and having a better separation of concerns. This PR will pave the way for more API related tasks to be separated from the React component hierarchy.

- [x] `api` and `provider` state objects have been removed, and React only re-renders on `apiStatus` changes.
- [x] Events are dispatched from a static `APIController` class to manage API status.
- [x] Adds a new `ready` API status that signals to React that the API is ready to use. Note that this is different from `connected`; even though the API is connected it still might not be ready to use. 
- [x] Improves types, `@ts-expect-error` is used where a Substrate Connect type mismatch exists.

#### Misc:

- [x] Fixes an issue in `PoolMembers` context where `poolMembersApi` was not being reset alongside `poolMembersRpc`.
- [x] Misc syntax tidy up.