### PR TITLE
feat: use `navigator.onLine` to handle api connection

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -211,7 +211,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     if (err === 'offline-event') {
       NotificationsController.emit({
         title: t('disconnected'),
-        subtitle: t('lostConnectionToNode'),
+        subtitle: t('connectionLost'),
       });
     }
   };

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -106,11 +106,6 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
     let networkSyncing = false;
     let poolSyncing = false;
 
-    if (!isReady) {
-      syncing = true;
-      networkSyncing = true;
-      poolSyncing = true;
-    }
     // staking metrics have synced
     if (staking.lastReward === new BigNumber(0)) {
       syncing = true;

--- a/src/locale/cn/library.json
+++ b/src/locale/cn/library.json
@@ -41,6 +41,7 @@
     "connectedTo": "连接到",
     "connectedToNetwork": "已连接网络",
     "connecting": "连接中",
+    "connectionLost": "连接已丢失",
     "continue": "继续",
     "copyAddress": "复制地址",
     "copyPoolAddress": "复制池地址",

--- a/src/locale/en/library.json
+++ b/src/locale/en/library.json
@@ -41,6 +41,7 @@
     "connectedTo": "Connected To",
     "connectedToNetwork": "Connected to Network",
     "connecting": "Connecting",
+    "connectionLost": "Connection has been lost",
     "continue": "Continue",
     "copyAddress": "Copy Address",
     "copyPoolAddress": "Copy Pool Address",

--- a/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
 import { useStaking } from 'contexts/Staking';
-import { useUi } from 'contexts/UI';
 import { Announcement as AnnouncementLoader } from 'library/Loader/Announcement';
 import { useNetwork } from 'contexts/Network';
 import { Item } from './Wrappers';
@@ -23,7 +22,6 @@ import type { BondedPool } from 'contexts/Pools/BondedPools/types';
 
 export const Announcements = () => {
   const { t } = useTranslation('pages');
-  const { isSyncing } = useUi();
   const { staking } = useStaking();
   const { stats } = usePoolsConfig();
   const {
@@ -65,7 +63,7 @@ export const Announcements = () => {
   const networkUnit = unit;
 
   // total staked on the network
-  if (!isSyncing) {
+  if (!totalStaked.isZero()) {
     announcements.push({
       class: 'neutral',
       title: t('overview.networkCurrentlyStaked', {

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -163,8 +163,11 @@ export class APIController {
     window.addEventListener('offline', async () => {
       // Disconnect from api instance.
       await this.api?.disconnect();
-      // Tell UI api has been disconnected.
-      this.dispatchEvent(this.ensureEventStatus('disconnected'));
+      // Tell UI api has been disconnected from an offline event.
+      this.dispatchEvent(
+        this.ensureEventStatus('disconnected'),
+        'offline-event'
+      );
     });
 
     window.addEventListener('online', () => {

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -161,16 +161,14 @@ export class APIController {
 
   // Set up online / offline event listeners. Relays information to `document` for the UI to handle.
   static initOnlineEvents() {
-    window.addEventListener('offline', () => {
-      console.log('app is offline');
+    window.addEventListener('offline', async () => {
       // Disconnect from api instance.
-      this.api?.disconnect();
-      // Tell UI API has been disconnected.
+      await this.api?.disconnect();
+      // Tell UI api has been disconnected.
       this.dispatchEvent(this.ensureEventStatus('disconnected'));
     });
 
     window.addEventListener('online', () => {
-      console.log('app is online');
       // Reconnect to the current API configuration.
       this.reconnect(this.network, this._connectionType, this._rpcEndpoint);
     });

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -56,8 +56,8 @@ export class APIController {
     this.initOnlineEvents();
 
     // Set class members and local storage.
-    this.network = network;
     localStorage.setItem('network', network);
+    this.network = network;
     this._connectionType = type;
     this._rpcEndpoint = config.rpcEndpoint;
 
@@ -74,9 +74,9 @@ export class APIController {
     await this.api?.disconnect();
     this.resetEvents();
 
-    // Set the new network to the class member and local storage.
-    this.network = network;
+    // Set class members and local storage.
     localStorage.setItem('network', network);
+    this.network = network;
     this._connectionType = type;
     this._rpcEndpoint = rpcEndpoint;
 


### PR DESCRIPTION
Although not a perfect solution as `navigator.onLine` can return false positives (VPN / virtualisation), this PR automatically disconnects the Polkadot JS API when the app goes offline, and reconnects when the app goes online again.

This could be coupled with a polling solution in another PR for further reacting to going offline, and to ping to confirm we are in-fact online when an `online` event is fired.