### PR TITLE
feat(ux): block number in network bar

### DIFF
--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -275,6 +275,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
     return () => {
       document.removeEventListener('polkadot-api', eventCallback);
       APIController.cancelFn?.();
+      APIController.unsubscribe();
     };
   }, []);
 

--- a/src/library/NetworkBar/Wrappers.ts
+++ b/src/library/NetworkBar/Wrappers.ts
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { SideMenuStickyThreshold } from 'consts';
 
 export const Wrapper = styled.div`
+  --network-bar-font-size: 0.9rem;
+
   background: var(--background-app-footer);
   color: var(--text-color-secondary);
   display: flex;
@@ -17,7 +19,7 @@ export const Wrapper = styled.div`
   backdrop-filter: blur(4px);
   position: relative;
   padding-top: 0.15rem;
-  font-size: 0.85rem;
+  font-size: var(--network-bar-font-size);
   width: 100%;
 
   @media (min-width: ${SideMenuStickyThreshold + 1}px) {
@@ -25,7 +27,7 @@ export const Wrapper = styled.div`
   }
 
   .network_icon {
-    margin: 0 0 0 1rem;
+    margin: 0 0 0 1.25rem;
     width: 1.5rem;
     height: 1.5rem;
   }
@@ -51,15 +53,15 @@ export const Summary = styled.div`
   a,
   button {
     color: var(--text-color-secondary);
-    font-size: 0.85rem;
+    font-size: var(--network-bar-font-size);
     opacity: 0.75;
   }
   p {
+    font-size: var(--network-bar-font-size);
     border-left: 1px solid var(--accent-color-transparent);
     margin: 0.25rem 0.5rem 0.25rem 0.15rem;
-    font-size: 0.85rem;
     padding-left: 0.5rem;
-    line-height: 1.2rem;
+    line-height: 1.3rem;
   }
   .stat {
     margin: 0 0.25rem;
@@ -90,13 +92,13 @@ export const Summary = styled.div`
       display: flex;
       align-items: center;
       flex-flow: row-reverse wrap;
-      padding-right: 0.5rem;
+      padding-right: 0.75rem;
 
       button {
+        font-size: var(--network-bar-font-size);
         color: var(--text-color-secondary);
         border-radius: 0.4rem;
         padding: 0.25rem 0.5rem;
-        font-size: 0.85rem;
       }
       span {
         &.pos {

--- a/src/library/NetworkBar/Wrappers.ts
+++ b/src/library/NetworkBar/Wrappers.ts
@@ -9,6 +9,7 @@ export const Wrapper = styled.div`
 
   background: var(--background-app-footer);
   color: var(--text-color-secondary);
+  font-size: var(--network-bar-font-size);
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
@@ -19,7 +20,6 @@ export const Wrapper = styled.div`
   backdrop-filter: blur(4px);
   position: relative;
   padding-top: 0.15rem;
-  font-size: var(--network-bar-font-size);
   width: 100%;
 
   @media (min-width: ${SideMenuStickyThreshold + 1}px) {

--- a/src/library/NetworkBar/Wrappers.ts
+++ b/src/library/NetworkBar/Wrappers.ts
@@ -65,6 +65,10 @@ export const Summary = styled.div`
     margin: 0 0.25rem;
     display: flex;
     align-items: center;
+
+    &.last {
+      margin-left: 1rem;
+    }
   }
 
   /* left and right sections for each row*/

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -106,7 +106,7 @@ export const NetworkBar = () => {
               <Odometer
                 wholeColor="var(--text-color-secondary)"
                 value={new BigNumber(blockNumber || '0').toFormat()}
-                spaceBefore={'0.25rem'}
+                spaceBefore={'0.35rem'}
               />
             </div>
           </div>

--- a/src/library/NetworkBar/index.tsx
+++ b/src/library/NetworkBar/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { capitalizeFirstLetter } from '@polkadot-cloud/utils';
-import { useEffect, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { usePlugins } from 'contexts/Plugins';
@@ -10,6 +10,12 @@ import { usePrices } from 'library/Hooks/usePrices';
 import { useNetwork } from 'contexts/Network';
 import { Status } from './Status';
 import { Summary, Wrapper } from './Wrappers';
+import { isCustomEvent } from 'static/utils';
+import { useEventListener } from 'usehooks-ts';
+import { Odometer } from '@polkadot-cloud/react';
+import BigNumber from 'bignumber.js';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHive } from '@fortawesome/free-brands-svg-icons';
 
 export const NetworkBar = () => {
   const { t } = useTranslation('library');
@@ -23,22 +29,30 @@ export const NetworkBar = () => {
   const ORGANISATION = import.meta.env.VITE_ORGANISATION;
   const LEGAL_DISCLOSURES_URL = import.meta.env.VITE_LEGAL_DISCLOSURES_URL;
 
-  const [networkName, setNetworkName] = useState<string>(
-    capitalizeFirstLetter(network)
-  );
+  // Store incoming block number.
+  const [blockNumber, setBlockNumber] = useState<string>();
 
-  useEffect(() => {
-    setNetworkName(
-      `${capitalizeFirstLetter(network)}${isLightClient ? ` Light` : ``}`
-    );
-  }, [network, isLightClient]);
+  const newBlockCallback = (e: Event) => {
+    if (isCustomEvent(e)) {
+      setBlockNumber(e.detail.blockNumber);
+    }
+  };
+
+  const ref = useRef<Document>(document);
+  useEventListener('new-block-number', newBlockCallback, ref);
 
   return (
     <Wrapper>
       <networkData.brand.icon className="network_icon" />
       <Summary>
         <section>
-          <p>{ORGANISATION === undefined ? networkName : ORGANISATION}</p>
+          <p>
+            {ORGANISATION === undefined
+              ? `${capitalizeFirstLetter(network)}${
+                  isLightClient ? ` Light` : ``
+                }`
+              : ORGANISATION}
+          </p>
           {PRIVACY_URL !== undefined ? (
             <p>
               <a href={PRIVACY_URL} target="_blank" rel="noreferrer">
@@ -86,6 +100,15 @@ export const NetworkBar = () => {
                 </div>
               </>
             )}
+
+            <div className="stat last">
+              <FontAwesomeIcon icon={faHive} />
+              <Odometer
+                wholeColor="var(--text-color-secondary)"
+                value={new BigNumber(blockNumber || '0').toFormat()}
+                spaceBefore={'0.25rem'}
+              />
+            </div>
           </div>
         </section>
       </Summary>

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -165,7 +165,7 @@ export class APIController {
       this.dispatchEvent(this.ensureEventStatus('disconnected'));
     });
     this.provider.on('error', (err: string) => {
-      this.dispatchEvent(this.ensureEventStatus('error'), err);
+      this.dispatchEvent(this.ensureEventStatus('error'), { err });
     });
   }
 
@@ -175,10 +175,9 @@ export class APIController {
       await this.disconnect();
 
       // Tell UI api has been disconnected from an offline event.
-      this.dispatchEvent(
-        this.ensureEventStatus('disconnected'),
-        'offline-event'
-      );
+      this.dispatchEvent(this.ensureEventStatus('disconnected'), {
+        err: 'offline-event',
+      });
     });
 
     window.addEventListener('online', () => {
@@ -188,10 +187,15 @@ export class APIController {
   }
 
   // Handler for dispatching events.
-  static dispatchEvent(event: EventStatus, err?: string) {
+  static dispatchEvent(
+    event: EventStatus,
+    options?: {
+      err?: string;
+    }
+  ) {
     const detail: EventDetail = { event };
-    if (err) {
-      detail['err'] = err;
+    if (options?.err) {
+      detail['err'] = options.err;
     }
     document.dispatchEvent(new CustomEvent('polkadot-api', { detail }));
   }

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -208,8 +208,12 @@ export class APIController {
   static subscribeBlockNumber = async () => {
     if (this._unsubs['blockNumber'] === undefined) {
       const unsub = await this.api.query.system.number((num: BlockNumber) => {
-        // TODO: dispatch event to document for UI to handle.
-        console.log(num.toNumber());
+        // Send block number to UI as event.
+        document.dispatchEvent(
+          new CustomEvent(`new-block-number`, {
+            detail: { blockNumber: num.toString() },
+          })
+        );
       });
       this._unsubs['blockNumber'] = unsub as unknown as VoidFn;
     }

--- a/src/static/APController/index.ts
+++ b/src/static/APController/index.ts
@@ -42,12 +42,16 @@ export class APIController {
   // Cancel function of dynamic substrate connect import.
   static cancelFn: () => void;
 
-  static get api() {
-    return this._api;
-  }
+  // ------------------------------------------------------
+  // Getters.
+  // ------------------------------------------------------
 
   static get provider() {
     return this._provider;
+  }
+
+  static get api() {
+    return this._api;
   }
 
   // ------------------------------------------------------

--- a/src/static/APController/types.ts
+++ b/src/static/APController/types.ts
@@ -1,4 +1,5 @@
 import type * as ScType from '@substrate/connect';
+import type { NetworkName } from 'types';
 
 export interface SubstrateConnect {
   WellKnownChain: (typeof ScType)['WellKnownChain'];
@@ -14,4 +15,10 @@ export type EventStatus = ApiStatus | 'error';
 export interface EventDetail {
   event: EventStatus;
   err?: string;
+}
+
+export interface APIConfig {
+  type: ConnectionType;
+  network: NetworkName;
+  rpcEndpoint: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ declare global {
   }
   interface DocumentEventMap {
     notification: CustomEvent<NotificationItem>;
+    'new-block-number': CustomEvent<{ blockNumber: string }>;
   }
 }
 


### PR DESCRIPTION
This PR sets up a subscription from `APIController`, which reports block numbers to `document` via a custom event. `NetworkBar` then listens for updates and updates its state accordingly.

Block number subscription can be used in a future PR to determine whether the app is offline.