### PR TITLE
fix: balances no accounts sync

### DIFF
--- a/src/contexts/Balances/defaults.ts
+++ b/src/contexts/Balances/defaults.ts
@@ -15,5 +15,5 @@ export const defaultBalancesContext: BalancesContextInterface = {
   getLocks: (address) => ({ locks: [], maxLock: new BigNumber(0) }),
   getBalance: (address) => defaultBalance,
   getLedger: (source) => defaultLedger,
-  balancesSynced: false,
+  balancesInitialSynced: false,
 };

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ReactNode } from 'react';
-import { createContext, useContext, useRef, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import type { MaybeAddress } from 'types';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
 import * as defaults from './defaults';
@@ -33,8 +33,9 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
     }
   );
 
-  // Store whether balances for all imported accounts have been synced.
-  const [balancesSynced, setBalancesSynced] = useState<boolean>(false);
+  // Store whether balances for all imported accounts have been synced on initial page load.
+  const [balancesInitialSynced, setBalancesInitialSynced] =
+    useState<boolean>(false);
 
   // Check all accounts have been synced. App-wide syncing state for all accounts.
   const newAccountBalancesCallback = (e: Event) => {
@@ -50,7 +51,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
 
   // Check whether all accounts have been synced and update state accordingly.
   const checkBalancesSynced = () => {
-    setBalancesSynced(
+    setBalancesInitialSynced(
       Object.keys(BalancesController.balances).length === accounts.length
     );
   };
@@ -76,6 +77,13 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
     documentRef
   );
 
+  // If no accounts are imported, set balances synced to true.
+  useEffect(() => {
+    if (!accounts.length) {
+      setBalancesInitialSynced(true);
+    }
+  }, [accounts.length]);
+
   return (
     <BalancesContext.Provider
       value={{
@@ -84,7 +92,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
         getLocks,
         getBalance,
         getLedger,
-        balancesSynced,
+        balancesInitialSynced,
       }}
     >
       {children}

--- a/src/contexts/Balances/types.ts
+++ b/src/contexts/Balances/types.ts
@@ -10,7 +10,7 @@ export interface BalancesContextInterface {
   getLocks: (address: MaybeAddress) => BalanceLocks;
   getBalance: (address: MaybeAddress) => Balance;
   getLedger: (source: ActiveLedgerSource) => Ledger;
-  balancesSynced: boolean;
+  balancesInitialSynced: boolean;
 }
 
 export type ActiveBalancesState = Record<string, ActiveBalance>;

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -24,8 +24,8 @@ export const useUi = () => useContext(UIContext);
 
 export const UIProvider = ({ children }: { children: ReactNode }) => {
   const { isReady } = useApi();
-  const { balancesSynced } = useBalances();
   const { staking, eraStakers } = useStaking();
+  const { balancesInitialSynced } = useBalances();
   const { activeEra, metrics } = useNetworkMetrics();
   const { synced: activePoolsSynced } = useActivePools();
 
@@ -116,7 +116,7 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
       networkSyncing = true;
     }
 
-    if (!balancesSynced) {
+    if (!balancesInitialSynced) {
       syncing = true;
       networkSyncing = true;
     }


### PR DESCRIPTION
Fixes an issue where `balancesSynced` was not being updated to `true` when there were no accounts being imported.

Changes the nae of `balancesSynced` to `balancesInitialSynced`, as this syncing status is only used on the initial page load.