### PR TITLE
fix: roll back Substrate Connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@polkawatch/ddp-client": "^2.0.10",
-    "@substrate/connect": "^0.8.5",
+    "@substrate/connect": "0.7.35",
     "@zondax/ledger-substrate": "^0.41.3",
     "bignumber.js": "^9.1.2",
     "bn.js": "^5.2.1",

--- a/src/static/APIController/index.ts
+++ b/src/static/APIController/index.ts
@@ -173,15 +173,15 @@ export class APIController {
 
   // Instantiates provider and connects to an api instance.
   static async connect({ type, network, rpcEndpoint }: APIConfig) {
-    // Tell UI api is connecting.
-    this.dispatchEvent(this.ensureEventStatus('connecting'));
-
     // Initiate provider.
     if (type === 'ws') {
       this.initWsProvider(network, rpcEndpoint);
     } else {
       await this.initScProvider(network);
     }
+
+    // Tell UI api is connecting.
+    this.dispatchEvent(this.ensureEventStatus('connecting'));
 
     // Initialise provider events.
     this.initProviderEvents();

--- a/src/static/APIController/index.ts
+++ b/src/static/APIController/index.ts
@@ -136,12 +136,17 @@ export class APIController {
     this._connectionType = type;
     this._rpcEndpoint = rpcEndpoint;
 
-    // Register connection attempt.
-    this._connectAttempts++;
-
-    // Start connection attempt.
-    this.onMonitorConnect(config);
-    await withTimeout(this.getTimeout(), this.connect(config));
+    // Handle reconnecting if not light client.
+    if (type !== 'sc') {
+      // Register connection attempt.
+      this._connectAttempts++;
+      // Start connection attempt.
+      this.onMonitorConnect(config);
+      await withTimeout(this.getTimeout(), this.connect(config));
+    } else {
+      // Light client: Connect without timeout logic.
+      await this.connect(config);
+    }
   }
 
   // Calculate connection timeout. First attempt = base, second = 3x, 6x thereafter.
@@ -155,7 +160,7 @@ export class APIController {
     }
   };
 
-  // Check if API is connected after a ser period, and try again if it has not.
+  // Check if API is connected after a time period, and try again if it has not.
   static onMonitorConnect = async (config: APIConfig) => {
     setTimeout(() => {
       // If blocks are not being subscribed to, assume connection failed.
@@ -216,7 +221,7 @@ export class APIController {
       .lightClient as WellKnownChain;
 
     this._provider = new ScProvider(
-      // @ts-expect-error mismatch between `@polkadot/rpc-provider/substrate-connect` and  `@substrate/connect` types: Chain[]' is not assignable to type 'string'.
+      // @<disable>-ts-expect-error mismatch between `@polkadot/rpc-provider/substrate-connect` and  `@substrate/connect` types: Chain[]' is not assignable to type 'string'.
       Sc,
       WellKnownChain[lightClientKey]
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,7 +1066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.3":
+"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.3":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 23c020b33da4172c988e44100e33cd9f8f6250b68b43c467d3551f82070ebd9716e0d9d2347427aa3774c85934a35fa9ee6f026fca2117e3fa12db7bedae7668
@@ -1133,70 +1133,6 @@ __metadata:
   version: 0.1.1
   resolution: "@pkgr/core@npm:0.1.1"
   checksum: 3f7536bc7f57320ab2cf96f8973664bef624710c403357429fbf680a5c3b4843c1dbd389bb43daa6b1f6f1f007bb082f5abcb76bb2b5dc9f421647743b71d3d8
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@polkadot-api/metadata-builders": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/substrate-bindings": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/substrate-client": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/utils": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  peerDependencies:
-    rxjs: ">=7.8.0"
-  checksum: 7ba588f34412b3f8f4fead3053602b501451f69bce99d1fc3e62c51d326ec8f1cf93a243d935ca36cc475242c6250e8c528ff0dd446f0a0133a8cf2fe3f65553
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 18214275725db7c0a1aea1d1cc704e72601e3cef89f2a9a2e497d53857382433a675ce066fcba377d39570820d4e9ec305c10fa93ce287618bf117f7579d83d8
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/json-rpc-provider@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/json-rpc-provider@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: c03d416e6b35c29b6fb4bfd3aa00b7ca7319d3053df74668a6d873ffb520985365f32907e01fcc0edb2c2083de1b64a164cc21346f3748798bac3a8d342c6414
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/metadata-builders@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/metadata-builders@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@polkadot-api/substrate-bindings": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/utils": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 3676319de74d93106a391c94d758678e034c5463e29a0b6c30f79fab5c085ddc7a86b4b142d98a16900bc3f6e02a7c326ced9179861d1c052feee67a4bd80da8
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/substrate-bindings@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/substrate-bindings@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@noble/hashes": "npm:^1.3.1"
-    "@polkadot-api/utils": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@scure/base": "npm:^1.1.1"
-    scale-ts: "npm:^1.4.3"
-  checksum: 266ce8f99e70f39a400d9b76e44879311eb73d251e68fd2dcfe31587951106b725343952282e0b85eedb8a6d3c4671aeccb59168538033e4930e76c06a850bca
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/substrate-client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/substrate-client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 3b154a9906ada19c756985673663b8426464fee378dfba17be3746a5d2ac65bf07aa34a3d28c58b05fff6ab0388f3be3ecc5653b060e8d456f277c16ae7f51d5
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/utils@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/utils@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 7b26956e2cd613e370531bd9a41c62bbf40d2d23e704257ca48bcf09d97bf328a8a23e55829ecc59ad8be88929360dc514bdae5e9c2192be7e79e4ecb376c4b7
   languageName: node
   linkType: hard
 
@@ -1907,20 +1843,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect-extension-protocol@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@substrate/connect-extension-protocol@npm:2.0.0"
-  checksum: 14a7c96b49e686dbc710214abe0fe312a366011a3521952f2317684e2463d75d54080fe358bdd8ff8d972c9de7f0e7f508dfc5210cf694574943dd8ecc490e89
-  languageName: node
-  linkType: hard
-
-"@substrate/connect-known-chains@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@substrate/connect-known-chains@npm:1.0.6"
-  checksum: 1414ec1ea4f0e1bcbb0a9b5c893cb5d2aa83242a7f48b2f38a77897256586295656b960dd936835f1375646452c3d377079375d3d66bfb4bcac3e9f6a17312c7
-  languageName: node
-  linkType: hard
-
 "@substrate/connect@npm:0.7.35":
   version: 0.7.35
   resolution: "@substrate/connect@npm:0.7.35"
@@ -1928,35 +1850,6 @@ __metadata:
     "@substrate/connect-extension-protocol": "npm:^1.0.1"
     smoldot: "npm:2.0.7"
   checksum: 61db11e4498fd2fdb0e6fe243ba4e9506a33960a991ad4cb1d221f2c2df371e28207fdf87a67262106de84c72e0c170ed43d48619f41ff35bcfbc3b75e2b64f6
-  languageName: node
-  linkType: hard
-
-"@substrate/connect@npm:^0.8.5":
-  version: 0.8.5
-  resolution: "@substrate/connect@npm:0.8.5"
-  dependencies:
-    "@substrate/connect-extension-protocol": "npm:^2.0.0"
-    "@substrate/connect-known-chains": "npm:^1.0.6"
-    "@substrate/light-client-extension-helpers": "npm:^0.0.2"
-    smoldot: "npm:2.0.17"
-  checksum: 1022013395c83af516342492e35ab4d1a83a04421a62842273e4b56cb6c89644e89ad490275a141772b4dbaa069905071e1079cdae136cd6ac7199e3235b989a
-  languageName: node
-  linkType: hard
-
-"@substrate/light-client-extension-helpers@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "@substrate/light-client-extension-helpers@npm:0.0.2"
-  dependencies:
-    "@polkadot-api/client": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/json-rpc-provider": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/json-rpc-provider-proxy": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@polkadot-api/substrate-client": "npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-    "@substrate/connect-extension-protocol": "npm:^2.0.0"
-    "@substrate/connect-known-chains": "npm:^1.0.6"
-    rxjs: "npm:^7.8.1"
-  peerDependencies:
-    smoldot: 2.x
-  checksum: 8838591b616a1a93e60c043d2cc9285fce313de781aa045acdd8ab0c27baa9259e227795f81389ee7db329045cbedfe7302053bb7536412280bde62f291a4d3d
   languageName: node
   linkType: hard
 
@@ -6404,7 +6297,7 @@ __metadata:
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkawatch/ddp-client": "npm:^2.0.10"
-    "@substrate/connect": "npm:^0.8.5"
+    "@substrate/connect": "npm:0.7.35"
     "@types/chroma-js": "npm:^2.4.3"
     "@types/lodash.throttle": "npm:^4.1.9"
     "@types/react": "npm:^18.2.48"
@@ -7127,13 +7020,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scale-ts@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "scale-ts@npm:1.4.3"
-  checksum: 521b52b9152e906611752b7eff5cb6b59d90ea42b2f8a87b0fcf63df4007059cda717fd6e7ca8926a8894dca5e152f159ae11e1dd128084d5cbe5cbe704ff84f
-  languageName: node
-  linkType: hard
-
 "scheduler@npm:^0.23.0":
   version: 0.23.0
   resolution: "scheduler@npm:0.23.0"
@@ -7345,15 +7231,6 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
-  languageName: node
-  linkType: hard
-
-"smoldot@npm:2.0.17":
-  version: 2.0.17
-  resolution: "smoldot@npm:2.0.17"
-  dependencies:
-    ws: "npm:^8.8.1"
-  checksum: edd936106fce7110ae0e87cd85ef05822bea001094fcbc44a329675a1f987c96aa891d5e7bb9c69eb56f5394c1c5af50baaa36b837099399fbdc67640fa9a5fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rolling back `@substrate/connect` to 0.7, and disabling connection re-attempts if light client is the connection method.