### PR TITLE
feat(refactor): Move staking metrics `payee` to active balances

### DIFF
--- a/src/contexts/Balances/defaults.ts
+++ b/src/contexts/Balances/defaults.ts
@@ -5,6 +5,7 @@
 import {
   defaultBalance,
   defaultLedger,
+  defaultPayee,
 } from 'static/BalancesController/defaults';
 import type { BalancesContextInterface } from './types';
 import BigNumber from 'bignumber.js';
@@ -15,5 +16,6 @@ export const defaultBalancesContext: BalancesContextInterface = {
   getLocks: (address) => ({ locks: [], maxLock: new BigNumber(0) }),
   getBalance: (address) => defaultBalance,
   getLedger: (source) => defaultLedger,
+  getPayee: (address) => defaultPayee,
   balancesInitialSynced: false,
 };

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -27,11 +27,10 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
   const controller = getBondedAccount(activeAccount);
 
   // Listen to balance updates for the active account, active proxy and controller..
-  const { activeBalances, getLocks, getBalance, getLedger } = useActiveBalances(
-    {
+  const { activeBalances, getLocks, getBalance, getLedger, getPayee } =
+    useActiveBalances({
       accounts: [activeAccount, activeProxy, controller],
-    }
-  );
+    });
 
   // Store whether balances for all imported accounts have been synced on initial page load.
   const [balancesInitialSynced, setBalancesInitialSynced] =
@@ -92,6 +91,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
         getLocks,
         getBalance,
         getLedger,
+        getPayee,
         balancesInitialSynced,
       }}
     >

--- a/src/contexts/Balances/types.ts
+++ b/src/contexts/Balances/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type BigNumber from 'bignumber.js';
+import type { PayeeConfig } from 'contexts/Setup/types';
 import type { MaybeAddress } from 'types';
 
 export interface BalancesContextInterface {
@@ -10,6 +11,7 @@ export interface BalancesContextInterface {
   getLocks: (address: MaybeAddress) => BalanceLocks;
   getBalance: (address: MaybeAddress) => Balance;
   getLedger: (source: ActiveLedgerSource) => Ledger;
+  getPayee: (address: MaybeAddress) => PayeeConfig;
   balancesInitialSynced: boolean;
 }
 
@@ -18,6 +20,7 @@ export type ActiveBalancesState = Record<string, ActiveBalance>;
 export interface ActiveBalance {
   ledger: Ledger;
   balances: Balances;
+  payee: PayeeConfig;
 }
 
 export interface Balances {

--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -19,10 +19,6 @@ export const defaultStakingMetrics: StakingMetrics = {
   validatorCount: new BigNumber(0),
   maxValidatorsCount: new BigNumber(0),
   minNominatorBond: new BigNumber(0),
-  payee: {
-    destination: null,
-    account: null,
-  },
   totalStaked: new BigNumber(0),
 };
 

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -14,7 +14,6 @@ import type { ReactNode } from 'react';
 import { createContext, useContext, useRef, useState } from 'react';
 import { useBalances } from 'contexts/Balances';
 import type { ExternalAccount } from '@polkadot-cloud/react/types';
-import type { PayeeConfig, PayeeOptions } from 'contexts/Setup/types';
 import type {
   EraStakers,
   Exposure,
@@ -153,7 +152,6 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
           [api.query.staking.erasValidatorReward, previousEra.toString()],
           [api.query.staking.erasTotalStake, previousEra.toString()],
           api.query.staking.minNominatorBond,
-          [api.query.staking.payee, activeAccount],
           [api.query.staking.erasTotalStake, activeEra.index.toString()],
         ],
         (q) => {
@@ -165,38 +163,13 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
             lastReward: new BigNumber(q[4].toString()),
             lastTotalStake: new BigNumber(q[5].toString()),
             minNominatorBond: new BigNumber(q[6].toString()),
-            payee: processPayee(q[7]),
-            totalStaked: new BigNumber(q[8].toString()),
+            totalStaked: new BigNumber(q[7].toString()),
           });
         }
       );
 
       unsub.current = u;
     }
-  };
-
-  // Process raw payee object from API. payee with `Account` type is returned as an key value pair,
-  // with all others strings. This function handles both cases and formats into a unified structure.
-  const processPayee = (rawPayee: AnyApi) => {
-    const payeeHuman = rawPayee.toHuman();
-
-    let payeeFinal: PayeeConfig;
-    if (typeof payeeHuman === 'string') {
-      const destination = payeeHuman as PayeeOptions;
-      payeeFinal = {
-        destination,
-        account: null,
-      };
-    } else {
-      const payeeEntry = Object.entries(payeeHuman);
-      const destination = `${payeeEntry[0][0]}` as PayeeOptions;
-      const account = `${payeeEntry[0][1]}` as MaybeAddress;
-      payeeFinal = {
-        destination,
-        account,
-      };
-    }
-    return payeeFinal;
   };
 
   // Fetches erasStakers exposures for an era, and saves to `localStorage`.

--- a/src/contexts/Staking/types.ts
+++ b/src/contexts/Staking/types.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type BigNumber from 'bignumber.js';
-import type { PayeeConfig } from 'contexts/Setup/types';
 import type { NominationStatus } from 'library/ValidatorList/ValidatorItem/types';
 import type { MaybeAddress } from 'types';
 
@@ -14,7 +13,6 @@ export interface StakingMetrics {
   validatorCount: BigNumber;
   maxValidatorsCount: BigNumber;
   minNominatorBond: BigNumber;
-  payee: PayeeConfig;
   totalStaked: BigNumber;
 }
 

--- a/src/library/Hooks/useActiveBalances/index.tsx
+++ b/src/library/Hooks/useActiveBalances/index.tsx
@@ -20,7 +20,9 @@ import BigNumber from 'bignumber.js';
 import {
   defaultBalance,
   defaultLedger,
+  defaultPayee,
 } from 'static/BalancesController/defaults';
+import type { PayeeConfig } from 'contexts/Setup/types';
 
 export const useActiveBalances = ({
   accounts,
@@ -87,6 +89,17 @@ export const useActiveBalances = ({
       }
     }
     return defaultLedger;
+  };
+
+  // Gets an active balance's payee.
+  const getPayee = (address: MaybeAddress): PayeeConfig => {
+    if (address) {
+      const maybePayee = activeBalances[address]?.payee;
+      if (maybePayee) {
+        return maybePayee;
+      }
+    }
+    return defaultPayee;
   };
 
   // Gets the amount of balance reserved for existential deposit.
@@ -163,6 +176,7 @@ export const useActiveBalances = ({
     getLocks,
     getBalance,
     getLedger,
+    getPayee,
     getEdReserved,
   };
 };

--- a/src/modals/UpdatePayee/index.tsx
+++ b/src/modals/UpdatePayee/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import type { PayeeConfig, PayeeOptions } from 'contexts/Setup/types';
-import { useStaking } from 'contexts/Staking';
 import { Warning } from 'library/Form/Warning';
 import { usePayeeConfig } from 'library/Hooks/usePayeeConfig';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
@@ -22,20 +21,21 @@ import type { MaybeAddress } from 'types';
 import { useTxMeta } from 'contexts/TxMeta';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
+import { useBalances } from 'contexts/Balances';
 
 export const UpdatePayee = () => {
   const { t } = useTranslation('modals');
   const { api } = useApi();
-  const { staking } = useStaking();
-  const { activeAccount } = useActiveAccounts();
+  const { getPayee } = useBalances();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
   const { getPayeeItems } = usePayeeConfig();
+  const { activeAccount } = useActiveAccounts();
   const { getSignerWarnings } = useSignerWarnings();
   const { setModalStatus, setModalResize } = useOverlay().modal;
 
   const controller = getBondedAccount(activeAccount);
-  const { payee } = staking;
+  const payee = getPayee(activeAccount);
 
   const DefaultSelected: PayeeConfig = {
     destination: null,

--- a/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
+++ b/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
@@ -11,17 +11,20 @@ import { Stat } from 'library/Stat';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
+import { useBalances } from 'contexts/Balances';
 
 export const PayoutDestinationStatus = () => {
   const { t } = useTranslation('pages');
   const { isSyncing } = useUi();
+  const { getPayee } = useBalances();
+  const { inSetup } = useStaking();
   const { openModal } = useOverlay().modal;
-  const { staking, inSetup } = useStaking();
   const { isFastUnstaking } = useUnstaking();
   const { getPayeeItems } = usePayeeConfig();
   const { activeAccount } = useActiveAccounts();
   const { isReadOnlyAccount } = useImportedAccounts();
-  const { payee } = staking;
+
+  const payee = getPayee(activeAccount);
 
   // Get payee status text to display.
   const getPayeeStatus = () => {

--- a/src/pages/Nominate/Setup/Payee/index.tsx
+++ b/src/pages/Nominate/Setup/Payee/index.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSetup } from 'contexts/Setup';
-import type { PayeeConfig, PayeeOptions } from 'contexts/Setup/types';
+import type { PayeeOptions } from 'contexts/Setup/types';
 import { Spacer } from 'library/Form/Wrappers';
 import { usePayeeConfig } from 'library/Hooks/usePayeeConfig';
 import { PayeeInput } from 'library/PayeeInput';
@@ -17,6 +17,7 @@ import type { SetupStepProps } from 'library/SetupSteps/types';
 import type { MaybeAddress } from 'types';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { Subheading } from 'pages/Nominate/Wrappers';
+import { defaultPayee } from 'static/BalancesController/defaults';
 
 export const Payee = ({ section }: SetupStepProps) => {
   const { t } = useTranslation('pages');
@@ -30,11 +31,6 @@ export const Payee = ({ section }: SetupStepProps) => {
 
   // Store the current user-inputted custom payout account.
   const [account, setAccount] = useState<MaybeAddress>(payee.account);
-
-  const DefaultPayeeConfig: PayeeConfig = {
-    destination: 'Staked',
-    account: null,
-  };
 
   // determine whether this section is completed.
   const isComplete = () =>
@@ -64,7 +60,7 @@ export const Payee = ({ section }: SetupStepProps) => {
     if (!payee || (!payee.destination && !payee.account)) {
       setActiveAccountSetup('nominator', {
         ...progress,
-        payee: DefaultPayeeConfig,
+        payee: defaultPayee,
       });
     }
   }, [activeAccount]);

--- a/src/static/BalancesController/defaults.ts
+++ b/src/static/BalancesController/defaults.ts
@@ -4,6 +4,7 @@
 
 import BigNumber from 'bignumber.js';
 import type { Balance, Ledger } from 'contexts/Balances/types';
+import type { PayeeConfig } from 'contexts/Setup/types';
 
 export const defaultBalance: Balance = {
   free: new BigNumber(0),
@@ -16,4 +17,9 @@ export const defaultLedger: Ledger = {
   active: new BigNumber(0),
   total: new BigNumber(0),
   unlocking: [],
+};
+
+export const defaultPayee: PayeeConfig = {
+  destination: 'Staked',
+  account: null,
 };

--- a/src/static/BalancesController/index.ts
+++ b/src/static/BalancesController/index.ts
@@ -159,7 +159,8 @@ export class BalancesController {
     };
   };
 
-  // Handle payee callback.
+  // Handle payee callback. payee with `Account` type is returned as an key value pair, with all
+  // others strings. This function handles both cases and formats into a unified structure.
   static handlePayeeCallback = (address: string, result: AnyApi): void => {
     const payeeHuman = result.toHuman();
 


### PR DESCRIPTION
In preparation to move all of staking metrics to `APIController`, `payee` has been moved to active account subscriptions. Only the payee for the active accounts are now subscribed to, rather than all the imported accounts.