### PR TITLE
feat(refactor): Staking metrics to bootstrap and API

### DIFF
--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -12,6 +12,7 @@ import type {
   APINetworkMetrics,
   APIPoolsConfig,
 } from 'contexts/Api/types';
+import { defaultStakingMetrics } from 'contexts/Staking/defaults';
 
 export const defaultChainState: APIChainState = {
   chain: null,
@@ -74,5 +75,6 @@ export const defaultApiContext: APIContextInterface = {
   networkMetrics: defaultNetworkMetrics,
   activeEra: defaultActiveEra,
   poolsConfig: defaultPoolsConfig,
+  stakingMetrics: defaultStakingMetrics,
   isPagedRewardsActive: (e) => false,
 };

--- a/src/contexts/Api/defaults.ts
+++ b/src/contexts/Api/defaults.ts
@@ -11,8 +11,8 @@ import type {
   APIContextInterface,
   APINetworkMetrics,
   APIPoolsConfig,
+  APIStakingMetrics,
 } from 'contexts/Api/types';
-import { defaultStakingMetrics } from 'contexts/Staking/defaults';
 
 export const defaultChainState: APIChainState = {
   chain: null,
@@ -60,6 +60,17 @@ export const defaultPoolsConfig: APIPoolsConfig = {
   minCreateBond: new BigNumber(0),
   minJoinBond: new BigNumber(0),
   globalMaxCommission: 0,
+};
+
+export const defaultStakingMetrics: APIStakingMetrics = {
+  totalNominators: new BigNumber(0),
+  totalValidators: new BigNumber(0),
+  lastReward: new BigNumber(0),
+  lastTotalStake: new BigNumber(0),
+  validatorCount: new BigNumber(0),
+  maxValidatorsCount: new BigNumber(0),
+  minNominatorBond: new BigNumber(0),
+  totalStaked: new BigNumber(0),
 };
 
 export const defaultApiContext: APIContextInterface = {

--- a/src/contexts/Api/index.tsx
+++ b/src/contexts/Api/index.tsx
@@ -17,6 +17,7 @@ import type {
   APINetworkMetrics,
   APIPoolsConfig,
   APIProviderProps,
+  APIStakingMetrics,
 } from './types';
 import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import {
@@ -26,6 +27,7 @@ import {
   defaultChainState,
   defaultPoolsConfig,
   defaultNetworkMetrics,
+  defaultStakingMetrics,
 } from './defaults';
 import { APIController } from 'static/APIController';
 import { isCustomEvent } from 'static/utils';
@@ -34,8 +36,6 @@ import { NotificationsController } from 'static/NotificationsController';
 import { useTranslation } from 'react-i18next';
 import { useEventListener } from 'usehooks-ts';
 import BigNumber from 'bignumber.js';
-import type { StakingMetrics } from 'contexts/Staking/types';
-import { defaultStakingMetrics } from 'contexts/Staking/defaults';
 
 export const APIContext = createContext<APIContextInterface>(defaultApiContext);
 
@@ -111,7 +111,7 @@ export const APIProvider = ({ children, network }: APIProviderProps) => {
   const poolsConfigRef = useRef(poolsConfig);
 
   // Store staking metrics in state.
-  const [stakingMetrics, setStakingMetrics] = useState<StakingMetrics>(
+  const [stakingMetrics, setStakingMetrics] = useState<APIStakingMetrics>(
     defaultStakingMetrics
   );
   const stakingMetricsRef = useRef(stakingMetrics);

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -7,7 +7,6 @@ import type BigNumber from 'bignumber.js';
 import type { ReactNode } from 'react';
 import type { AnyJson, NetworkName } from '../../types';
 import type { ApiStatus } from 'static/APIController/types';
-import type { StakingMetrics } from 'contexts/Staking/types';
 
 export interface APIProviderProps {
   children: ReactNode;
@@ -60,6 +59,17 @@ export interface APIPoolsConfig {
   globalMaxCommission: number;
 }
 
+export interface APIStakingMetrics {
+  totalNominators: BigNumber;
+  totalValidators: BigNumber;
+  lastReward: BigNumber;
+  lastTotalStake: BigNumber;
+  validatorCount: BigNumber;
+  maxValidatorsCount: BigNumber;
+  minNominatorBond: BigNumber;
+  totalStaked: BigNumber;
+}
+
 export interface APIContextInterface {
   api: ApiPromise | null;
   chainState: APIChainState;
@@ -73,6 +83,6 @@ export interface APIContextInterface {
   networkMetrics: APINetworkMetrics;
   activeEra: APIActiveEra;
   poolsConfig: APIPoolsConfig;
-  stakingMetrics: StakingMetrics;
+  stakingMetrics: APIStakingMetrics;
   isPagedRewardsActive: (era: BigNumber) => boolean;
 }

--- a/src/contexts/Api/types.ts
+++ b/src/contexts/Api/types.ts
@@ -7,6 +7,7 @@ import type BigNumber from 'bignumber.js';
 import type { ReactNode } from 'react';
 import type { AnyJson, NetworkName } from '../../types';
 import type { ApiStatus } from 'static/APIController/types';
+import type { StakingMetrics } from 'contexts/Staking/types';
 
 export interface APIProviderProps {
   children: ReactNode;
@@ -72,5 +73,6 @@ export interface APIContextInterface {
   networkMetrics: APINetworkMetrics;
   activeEra: APIActiveEra;
   poolsConfig: APIPoolsConfig;
+  stakingMetrics: StakingMetrics;
   isPagedRewardsActive: (era: BigNumber) => boolean;
 }

--- a/src/contexts/Staking/defaults.ts
+++ b/src/contexts/Staking/defaults.ts
@@ -7,20 +7,8 @@ import type {
   EraStakers,
   NominationStatuses,
   StakingContextInterface,
-  StakingMetrics,
   StakingTargets,
 } from 'contexts/Staking/types';
-
-export const defaultStakingMetrics: StakingMetrics = {
-  totalNominators: new BigNumber(0),
-  totalValidators: new BigNumber(0),
-  lastReward: new BigNumber(0),
-  lastTotalStake: new BigNumber(0),
-  validatorCount: new BigNumber(0),
-  maxValidatorsCount: new BigNumber(0),
-  minNominatorBond: new BigNumber(0),
-  totalStaked: new BigNumber(0),
-};
 
 export const defaultEraStakers: EraStakers = {
   activeAccountOwnStake: [],
@@ -51,7 +39,6 @@ export const defaultStakingContext: StakingContextInterface = {
   isNominating: () => false,
   inSetup: () => true,
   getLowestRewardFromStaker: (address) => defaultLowestReward,
-  staking: defaultStakingMetrics,
   eraStakers: defaultEraStakers,
   targets: defaultTargets,
   erasStakersSyncing: true,

--- a/src/contexts/Staking/types.ts
+++ b/src/contexts/Staking/types.ts
@@ -5,17 +5,6 @@ import type BigNumber from 'bignumber.js';
 import type { NominationStatus } from 'library/ValidatorList/ValidatorItem/types';
 import type { MaybeAddress } from 'types';
 
-export interface StakingMetrics {
-  totalNominators: BigNumber;
-  totalValidators: BigNumber;
-  lastReward: BigNumber;
-  lastTotalStake: BigNumber;
-  validatorCount: BigNumber;
-  maxValidatorsCount: BigNumber;
-  minNominatorBond: BigNumber;
-  totalStaked: BigNumber;
-}
-
 export interface ActiveAccountOwnStake {
   address: string;
   value: string;
@@ -79,7 +68,6 @@ export interface StakingContextInterface {
   isNominating: () => boolean;
   inSetup: () => boolean;
   getLowestRewardFromStaker: (a: MaybeAddress) => LowestReward;
-  staking: StakingMetrics;
   eraStakers: EraStakers;
   targets: StakingTargets;
   erasStakersSyncing: boolean;

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -22,10 +22,10 @@ export const UIContext = createContext<UIContextInterface>(
 export const useUi = () => useContext(UIContext);
 
 export const UIProvider = ({ children }: { children: ReactNode }) => {
-  const { staking, eraStakers } = useStaking();
+  const { eraStakers } = useStaking();
   const { balancesInitialSynced } = useBalances();
-  const { isReady, networkMetrics, activeEra } = useApi();
   const { synced: activePoolsSynced } = useActivePools();
+  const { isReady, networkMetrics, activeEra, stakingMetrics } = useApi();
 
   // Set whether the network has been synced.
   const [isNetworkSyncing, setIsNetworkSyncing] = useState<boolean>(false);
@@ -103,7 +103,7 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
     let poolSyncing = false;
 
     // staking metrics have synced
-    if (staking.lastReward === new BigNumber(0)) {
+    if (stakingMetrics.lastReward === new BigNumber(0)) {
       syncing = true;
       networkSyncing = true;
     }
@@ -137,7 +137,7 @@ export const UIProvider = ({ children }: { children: ReactNode }) => {
     setIsSyncing(syncing);
   }, [
     isReady,
-    staking,
+    stakingMetrics,
     networkMetrics,
     eraStakers,
     activePoolsSynced,

--- a/src/library/Form/Bond/BondFeedback.tsx
+++ b/src/library/Form/Bond/BondFeedback.tsx
@@ -6,7 +6,6 @@ import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useActivePools } from 'contexts/Pools/ActivePools';
-import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { useNetwork } from 'contexts/Network';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
@@ -33,12 +32,13 @@ export const BondFeedback = ({
   const {
     networkData: { units, unit },
   } = useNetwork();
-  const { staking } = useStaking();
   const { activeAccount } = useActiveAccounts();
   const { isDepositor } = useActivePools();
   const { getTransferOptions } = useTransferOptions();
-  const { minJoinBond, minCreateBond } = useApi().poolsConfig;
-  const { minNominatorBond } = staking;
+  const {
+    poolsConfig: { minJoinBond, minCreateBond },
+    stakingMetrics: { minNominatorBond },
+  } = useApi();
   const allTransferOptions = getTransferOptions(activeAccount);
 
   const defaultBondStr = defaultBond ? String(defaultBond) : '';

--- a/src/library/Form/NominateStatusBar/index.tsx
+++ b/src/library/Form/NominateStatusBar/index.tsx
@@ -7,7 +7,6 @@ import { ButtonHelp } from '@polkadot-cloud/react';
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
 import { useHelp } from 'contexts/Help';
-import { useStaking } from 'contexts/Staking';
 import { useUi } from 'contexts/UI';
 import { useNetwork } from 'contexts/Network';
 import type { NominateStatusBarProps } from '../types';
@@ -16,12 +15,11 @@ import { useApi } from 'contexts/Api';
 
 export const NominateStatusBar = ({ value }: NominateStatusBarProps) => {
   const { t } = useTranslation('library');
-  const { staking } = useStaking();
   const { isSyncing } = useUi();
   const { unit, units } = useNetwork().networkData;
-  const { minNominatorBond } = staking;
   const {
     networkMetrics: { minimumActiveStake },
+    stakingMetrics: { minNominatorBond },
   } = useApi();
   const { openHelp } = useHelp();
 

--- a/src/library/Form/Unbond/UnbondFeedback.tsx
+++ b/src/library/Form/Unbond/UnbondFeedback.tsx
@@ -6,7 +6,6 @@ import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useActivePools } from 'contexts/Pools/ActivePools';
-import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { useNetwork } from 'contexts/Network';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
@@ -30,13 +29,13 @@ export const UnbondFeedback = ({
   const {
     networkData: { units, unit },
   } = useNetwork();
-  const { staking } = useStaking();
   const { isDepositor } = useActivePools();
   const { activeAccount } = useActiveAccounts();
   const { getTransferOptions } = useTransferOptions();
-  const { minJoinBond, minCreateBond } = useApi().poolsConfig;
-
-  const { minNominatorBond } = staking;
+  const {
+    poolsConfig: { minJoinBond, minCreateBond },
+    stakingMetrics: { minNominatorBond },
+  } = useApi();
   const allTransferOptions = getTransferOptions(activeAccount);
   const defaultValue = defaultBond ? String(defaultBond) : '';
 

--- a/src/library/Hooks/useAverageRewardRate/index.tsx
+++ b/src/library/Hooks/useAverageRewardRate/index.tsx
@@ -7,19 +7,17 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import type { AverageRewardRate, UseAverageRewardRate } from './types';
 import { defaultAverageRewardRate } from './defaults';
 import { useNetwork } from 'contexts/Network';
-import { useStaking } from 'contexts/Staking';
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useApi } from 'contexts/Api';
 
 export const useAverageRewardRate = (): UseAverageRewardRate => {
-  const { staking } = useStaking();
   const { erasPerDay } = useErasPerDay();
+  const { lastTotalStake } = useApi().stakingMetrics;
   const {
     networkMetrics: { totalIssuance },
   } = useApi();
   const { units } = useNetwork().networkData;
   const { avgCommission, averageEraValidatorReward } = useValidators();
-  const { lastTotalStake } = staking;
 
   // Get average reward rates.
   const getAverageRewardRate = (compounded: boolean): AverageRewardRate => {

--- a/src/modals/Unbond/index.tsx
+++ b/src/modals/Unbond/index.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useBonded } from 'contexts/Bonded';
 import { useActivePools } from 'contexts/Pools/ActivePools';
-import { useStaking } from 'contexts/Staking';
 import { useTransferOptions } from 'contexts/TransferOptions';
 import { useTxMeta } from 'contexts/TxMeta';
 import { UnbondFeedback } from 'library/Form/Unbond/UnbondFeedback';
@@ -29,7 +28,6 @@ import { useActiveAccounts } from 'contexts/ActiveAccounts';
 export const Unbond = () => {
   const { t } = useTranslation('modals');
   const { txFees } = useTxMeta();
-  const { staking } = useStaking();
   const { activeAccount } = useActiveAccounts();
   const { notEnoughFunds } = useTxMeta();
   const { getBondedAccount } = useBonded();
@@ -40,6 +38,7 @@ export const Unbond = () => {
   const { getSignerWarnings } = useSignerWarnings();
   const { getTransferOptions } = useTransferOptions();
   const { isDepositor, selectedActivePool } = useActivePools();
+  const { minNominatorBond: minNominatorBondBn } = useApi().stakingMetrics;
   const {
     setModalStatus,
     setModalResize,
@@ -53,7 +52,6 @@ export const Unbond = () => {
 
   const { bondFor } = options;
   const controller = getBondedAccount(activeAccount);
-  const { minNominatorBond: minNominatorBondBn } = staking;
   const { bondDuration } = consts;
 
   const bondDurationFormatted = timeleftAsString(

--- a/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
+++ b/src/pages/Nominate/Active/Stats/MinimumNominatorBond.tsx
@@ -3,15 +3,14 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useStaking } from 'contexts/Staking';
 import { Number } from 'library/StatBoxList/Number';
 import { useNetwork } from 'contexts/Network';
+import { useApi } from 'contexts/Api';
 
 export const MinimumNominatorBondStat = () => {
   const { t } = useTranslation('pages');
-  const { staking } = useStaking();
   const { unit, units } = useNetwork().networkData;
-  const { minNominatorBond } = staking;
+  const { minNominatorBond } = useApi().stakingMetrics;
 
   const params = {
     label: t('nominate.minimumToNominate'),

--- a/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -13,7 +13,6 @@ import BigNumber from 'bignumber.js';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
-import { useStaking } from 'contexts/Staking';
 import { Announcement as AnnouncementLoader } from 'library/Loader/Announcement';
 import { useNetwork } from 'contexts/Network';
 import { Item } from './Wrappers';
@@ -22,15 +21,16 @@ import { useApi } from 'contexts/Api';
 
 export const Announcements = () => {
   const { t } = useTranslation('pages');
-  const { staking } = useStaking();
   const {
     network,
     networkData: { units, unit },
   } = useNetwork();
   const { bondedPools } = useBondedPools();
-  const { counterForPoolMembers } = useApi().poolsConfig;
+  const {
+    poolsConfig: { counterForPoolMembers },
+    stakingMetrics: { totalStaked },
+  } = useApi();
 
-  const { totalStaked } = staking;
   let totalPoolPoints = new BigNumber(0);
   bondedPools.forEach((b: BondedPool) => {
     totalPoolPoints = totalPoolPoints.plus(rmCommas(b.points));

--- a/src/pages/Overview/NetworkSats/index.tsx
+++ b/src/pages/Overview/NetworkSats/index.tsx
@@ -4,20 +4,20 @@
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
-import { useStaking } from 'contexts/Staking';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
 import { StatsHead } from 'library/StatsHead';
 import { Announcements } from './Announcements';
 import { Wrapper } from './Wrappers';
 import { useAverageRewardRate } from 'library/Hooks/useAverageRewardRate';
+import { useApi } from 'contexts/Api';
 
 export const NetworkStats = () => {
   const { t } = useTranslation('pages');
-  const { staking } = useStaking();
   const { bondedPools } = useBondedPools();
   const { getAverageRewardRate } = useAverageRewardRate();
+  const { totalNominators, totalValidators } = useApi().stakingMetrics;
+
   const { inflationToStakers } = getAverageRewardRate(false);
-  const { totalNominators, totalValidators } = staking;
 
   const items = [
     {

--- a/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -21,6 +21,7 @@ import { PageToggle } from './PageToggle';
 import { Syncing } from './Syncing';
 import { TipsWrapper } from './Wrappers';
 import type { TipDisplay } from './types';
+import { useApi } from 'contexts/Api';
 
 export const Tips = () => {
   const { i18n, t } = useTranslation();
@@ -29,10 +30,13 @@ export const Tips = () => {
   const { activeAccount } = useActiveAccounts();
   const { fillVariables } = useFillVariables();
   const { membership } = usePoolMemberships();
-  const { isNominating, staking } = useStaking();
+  const {
+    stakingMetrics: { minNominatorBond },
+  } = useApi();
+
+  const { isNominating } = useStaking();
   const { isOwner } = useActivePools();
   const { feeReserve, getTransferOptions } = useTransferOptions();
-  const { minNominatorBond } = staking;
   const transferOptions = getTransferOptions(activeAccount);
 
   // multiple tips per row is currently turned off.

--- a/src/pages/Overview/Stats/SupplyStaked.tsx
+++ b/src/pages/Overview/Stats/SupplyStaked.tsx
@@ -4,18 +4,18 @@
 import { planckToUnit } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useStaking } from 'contexts/Staking';
 import { Pie } from 'library/StatBoxList/Pie';
 import { useNetwork } from 'contexts/Network';
 import { useApi } from 'contexts/Api';
 
 export const SupplyStakedStat = () => {
   const { t } = useTranslation('pages');
-  const { networkMetrics } = useApi();
-  const { staking } = useStaking();
+  const {
+    networkMetrics,
+    stakingMetrics: { lastTotalStake },
+  } = useApi();
   const { units, unit } = useNetwork().networkData;
 
-  const { lastTotalStake } = staking;
   const { totalIssuance } = networkMetrics;
 
   // total supply as percent.

--- a/src/pages/Payouts/Stats/LastEraPayout.tsx
+++ b/src/pages/Payouts/Stats/LastEraPayout.tsx
@@ -3,15 +3,14 @@
 
 import { planckToUnit } from '@polkadot-cloud/utils';
 import { useTranslation } from 'react-i18next';
-import { useStaking } from 'contexts/Staking';
 import { Number } from 'library/StatBoxList/Number';
 import { useNetwork } from 'contexts/Network';
+import { useApi } from 'contexts/Api';
 
 export const LastEraPayoutStat = () => {
   const { t } = useTranslation('pages');
   const { unit, units } = useNetwork().networkData;
-  const { staking } = useStaking();
-  const { lastReward } = staking;
+  const { lastReward } = useApi().stakingMetrics;
 
   const lastRewardUnit = planckToUnit(lastReward, units).toNumber();
 

--- a/src/pages/Validators/Stats/ActiveValidators.tsx
+++ b/src/pages/Validators/Stats/ActiveValidators.tsx
@@ -6,13 +6,14 @@ import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { useStaking } from 'contexts/Staking';
 import { Pie } from 'library/StatBoxList/Pie';
+import { useApi } from 'contexts/Api';
 
 export const ActiveValidatorsStat = () => {
   const { t } = useTranslation('pages');
   const {
-    staking: { validatorCount },
     eraStakers: { activeValidators },
   } = useStaking();
+  const { validatorCount } = useApi().stakingMetrics;
 
   // active validators as percent. Avoiding dividing by zero.
   let activeValidatorsAsPercent = new BigNumber(0);

--- a/src/pages/Validators/Stats/TotalValidators.tsx
+++ b/src/pages/Validators/Stats/TotalValidators.tsx
@@ -4,13 +4,14 @@
 import { greaterThanZero } from '@polkadot-cloud/utils';
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
-import { useStaking } from 'contexts/Staking';
 import { Pie } from 'library/StatBoxList/Pie';
+import { useApi } from 'contexts/Api';
 
 export const TotalValidatorsStat = () => {
   const { t } = useTranslation('pages');
-  const { staking } = useStaking();
-  const { totalValidators, maxValidatorsCount } = staking;
+  const {
+    stakingMetrics: { totalValidators, maxValidatorsCount },
+  } = useApi();
 
   // total validators as percent
   let totalValidatorsAsPercent = 0;

--- a/src/static/APIController/index.ts
+++ b/src/static/APIController/index.ts
@@ -23,9 +23,9 @@ import type {
   APIConstants,
   APINetworkMetrics,
   APIPoolsConfig,
+  APIStakingMetrics,
 } from 'contexts/Api/types';
 import { WellKnownChain } from '@substrate/connect';
-import type { StakingMetrics } from 'contexts/Staking/types';
 import { defaultActiveEra } from 'contexts/Api/defaults';
 
 export class APIController {
@@ -240,7 +240,7 @@ export class APIController {
     networkMetrics: APINetworkMetrics;
     activeEra: APIActiveEra;
     poolsConfig: APIPoolsConfig;
-    stakingMetrics: StakingMetrics;
+    stakingMetrics: APIStakingMetrics;
   }> => {
     // Fetch network constants.
     const allPromises = [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,8 +12,8 @@ import type {
   APIActiveEra,
   APINetworkMetrics,
   APIPoolsConfig,
+  APIStakingMetrics,
 } from 'contexts/Api/types';
-import type { StakingMetrics } from 'contexts/Staking/types';
 
 declare global {
   interface Window {
@@ -28,7 +28,7 @@ declare global {
     'new-active-era': CustomEvent<{ activeEra: APIActiveEra }>;
     'new-pools-config': CustomEvent<{ poolsConfig: APIPoolsConfig }>;
     'new-staking-metrics': CustomEvent<{
-      stakingMetrics: StakingMetrics;
+      stakingMetrics: APIStakingMetrics;
     }>;
     'new-external-account': CustomEvent<{ address: string }>;
     'new-account-balance': CustomEvent<ActiveBalance & { address: string }>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ import type {
   APINetworkMetrics,
   APIPoolsConfig,
 } from 'contexts/Api/types';
+import type { StakingMetrics } from 'contexts/Staking/types';
 
 declare global {
   interface Window {
@@ -26,6 +27,9 @@ declare global {
     }>;
     'new-active-era': CustomEvent<{ activeEra: APIActiveEra }>;
     'new-pools-config': CustomEvent<{ poolsConfig: APIPoolsConfig }>;
+    'new-staking-metrics': CustomEvent<{
+      stakingMetrics: StakingMetrics;
+    }>;
     'new-external-account': CustomEvent<{ address: string }>;
     'new-account-balance': CustomEvent<ActiveBalance & { address: string }>;
     'subscan-data-updated': CustomEvent<{ keys: PayoutType[] }>;


### PR DESCRIPTION
Bootstraps staking metrics before subscription to prevent a re-render. deprecates staking metrics in `Staking` context and subscribes via `APIController`.