### PR TITLE
fix: Accounts render safeguard, pool useEffect fixes 

### DIFF
--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -467,7 +467,7 @@ export const ActivePoolsProvider = ({ children }: { children: ReactNode }) => {
       setStateWithRef('syncing', setSynced, syncedRef);
       handlePoolSubscriptions();
     }
-  }, [network, isReady, syncedRef.current]);
+  }, [network, isReady, synced]);
 
   // re-calculate pending rewards when membership changes
   useEffectIgnoreInitial(() => {


### PR DESCRIPTION
Introduces a safe-guard to prevent unnecessary re-renders on account updates. Since the UI only cares about the address and name of the account, accounts are ordered and stringified with these properties only. The result of this function is used as hook dependencies in `ImportedAccounts`.

Miscellaneous useEffect fixes for pools also have been applied to prevent resetting of memberships state.