### PR TITLE
feat(refactor): create pool accounts to hooks

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -23,7 +23,7 @@ import { ActivePoolsProvider } from 'contexts/Pools/ActivePools';
 import { BondedPoolsProvider } from 'contexts/Pools/BondedPools';
 import { PoolMembersProvider } from 'contexts/Pools/PoolMembers';
 import { PoolMembershipsProvider } from 'contexts/Pools/PoolMemberships';
-import { PoolsConfigProvider } from 'contexts/Pools/PoolsConfig';
+import { FavoritePoolsProvider } from 'contexts/Pools/FavoritePools';
 import { ProxiesProvider } from 'contexts/Proxies';
 import { SetupProvider } from 'contexts/Setup';
 import { StakingProvider } from 'contexts/Staking';
@@ -47,7 +47,6 @@ import { ImportedAccountsProvider } from 'contexts/Connect/ImportedAccounts';
 import { PoolPerformanceProvider } from 'contexts/Pools/PoolPerformance';
 import { ExternalAccountsProvider } from 'contexts/Connect/ExternalAccounts';
 
-// Embed providers from hook.
 export const Providers = () => {
   const {
     network,
@@ -76,7 +75,7 @@ export const Providers = () => {
     BondedProvider,
     BalancesProvider,
     StakingProvider,
-    PoolsConfigProvider,
+    FavoritePoolsProvider,
     BondedPoolsProvider,
     PoolMembershipsProvider,
     PoolMembersProvider,

--- a/src/contexts/Pools/ActivePools/index.tsx
+++ b/src/contexts/Pools/ActivePools/index.tsx
@@ -21,12 +21,12 @@ import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { useApi } from '../../Api';
 import { useBondedPools } from '../BondedPools';
 import { usePoolMemberships } from '../PoolMemberships';
-import { usePoolsConfig } from '../PoolsConfig';
 import * as defaults from './defaults';
 import { usePoolMembers } from '../PoolMembers';
 import type { ActivePool, ActivePoolsContextState, PoolTargets } from './types';
 import type { PoolAddresses } from '../BondedPools/types';
 import { SubscanController } from 'static/SubscanController';
+import { useCreatePoolAccounts } from 'library/Hooks/useCreatePoolAccounts';
 
 export const ActivePoolsContext = createContext<ActivePoolsContextState>(
   defaults.defaultActivePoolContext
@@ -40,8 +40,8 @@ export const ActivePoolsProvider = ({ children }: { children: ReactNode }) => {
   const { eraStakers } = useStaking();
   const { pluginEnabled } = usePlugins();
   const { membership } = usePoolMemberships();
-  const { createAccounts } = usePoolsConfig();
   const { activeAccount } = useActiveAccounts();
+  const createPoolAccounts = useCreatePoolAccounts();
   const { getMembersOfPoolFromNode } = usePoolMembers();
   const { getAccountPools, bondedPools } = useBondedPools();
 
@@ -155,7 +155,7 @@ export const ActivePoolsProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    const addresses: PoolAddresses = createAccounts(poolId);
+    const addresses: PoolAddresses = createPoolAccounts(poolId);
 
     // new active pool subscription
     const subscribeActivePool = async (id: number) => {

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -18,8 +18,8 @@ import { useEffectIgnoreInitial } from '@polkadot-cloud/react/hooks';
 import { useNetwork } from 'contexts/Network';
 import type { AnyJson } from '@polkadot-cloud/react/types';
 import { useApi } from '../../Api';
-import { usePoolsConfig } from '../PoolsConfig';
 import { defaultBondedPoolsContext } from './defaults';
+import { useCreatePoolAccounts } from 'library/Hooks/useCreatePoolAccounts';
 
 export const BondedPoolsContext = createContext<BondedPoolsContextState>(
   defaultBondedPoolsContext
@@ -35,7 +35,7 @@ export const BondedPoolsProvider = ({ children }: { children: ReactNode }) => {
     activeEra,
     poolsConfig: { lastPoolId },
   } = useApi();
-  const { createAccounts } = usePoolsConfig();
+  const createPoolAccounts = useCreatePoolAccounts();
   const { getNominationsStatusFromTargets } = useStaking();
 
   // Store bonded pools.
@@ -135,7 +135,7 @@ export const BondedPoolsProvider = ({ children }: { children: ReactNode }) => {
     }
     return {
       id,
-      addresses: createAccounts(id),
+      addresses: createPoolAccounts(id),
       ...bondedPool,
     };
   };
@@ -192,7 +192,7 @@ export const BondedPoolsProvider = ({ children }: { children: ReactNode }) => {
   const getPoolWithAddresses = (id: number, pool: BondedPool) => ({
     ...pool,
     id,
-    addresses: createAccounts(id),
+    addresses: createPoolAccounts(id),
   });
 
   const getBondedPool = (poolId: MaybePool) =>

--- a/src/contexts/Pools/FavoritePools/defaults.ts
+++ b/src/contexts/Pools/FavoritePools/defaults.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
-import type { PoolsConfigContextState } from './types';
+import type { FavoritePoolsContextState } from './types';
 import type { PoolAddresses } from '../BondedPools/types';
 
-export const defaultPoolsConfigContext: PoolsConfigContextState = {
-  addFavorite: () => {},
-  removeFavorite: () => {},
+export const defaultFavoritePoolsContext: FavoritePoolsContextState = {
   favorites: [],
+  addFavorite: (address: string) => {},
+  removeFavorite: (address: string) => {},
 };
 
 export const poolAddresses: PoolAddresses = {

--- a/src/contexts/Pools/FavoritePools/index.tsx
+++ b/src/contexts/Pools/FavoritePools/index.tsx
@@ -3,17 +3,21 @@
 
 import type { ReactNode } from 'react';
 import { createContext, useContext, useState } from 'react';
-import type { PoolsConfigContextState } from './types';
+import type { FavoritePoolsContextState } from './types';
 import { useNetwork } from 'contexts/Network';
-import { defaultPoolsConfigContext } from './defaults';
+import { defaultFavoritePoolsContext } from './defaults';
 
-export const PoolsConfigContext = createContext<PoolsConfigContextState>(
-  defaultPoolsConfigContext
+export const FavoritePoolsContext = createContext<FavoritePoolsContextState>(
+  defaultFavoritePoolsContext
 );
 
-export const usePoolsConfig = () => useContext(PoolsConfigContext);
+export const useFavoritePools = () => useContext(FavoritePoolsContext);
 
-export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
+export const FavoritePoolsProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
   const { network } = useNetwork();
 
   // get favorite pools from local storage.
@@ -40,7 +44,7 @@ export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
   };
 
   /*
-   * Removes a favorite validator if they exist.
+   * Removes a favorite pool if they exist.
    */
   const removeFavorite = (address: string) => {
     let newFavorites = Object.assign(favorites);
@@ -55,7 +59,7 @@ export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <PoolsConfigContext.Provider
+    <FavoritePoolsContext.Provider
       value={{
         addFavorite,
         removeFavorite,
@@ -63,6 +67,6 @@ export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
       }}
     >
       {children}
-    </PoolsConfigContext.Provider>
+    </FavoritePoolsContext.Provider>
   );
 };

--- a/src/contexts/Pools/FavoritePools/index.tsx
+++ b/src/contexts/Pools/FavoritePools/index.tsx
@@ -20,13 +20,13 @@ export const FavoritePoolsProvider = ({
 }) => {
   const { network } = useNetwork();
 
-  // get favorite pools from local storage.
+  // Get favorite pools from local storage.
   const getLocalFavorites = () => {
     const localFavorites = localStorage.getItem(`${network}_favorite_pools`);
     return localFavorites !== null ? JSON.parse(localFavorites) : [];
   };
 
-  // stores the user's favorite pools
+  // Stores the user's favorite pools.
   const [favorites, setFavorites] = useState<string[]>(getLocalFavorites());
 
   // Adds a favorite validator.
@@ -43,12 +43,9 @@ export const FavoritePoolsProvider = ({
     setFavorites([...newFavorites]);
   };
 
-  /*
-   * Removes a favorite pool if they exist.
-   */
+  // Removes a favorite pool if they exist.
   const removeFavorite = (address: string) => {
-    let newFavorites = Object.assign(favorites);
-    newFavorites = newFavorites.filter(
+    const newFavorites = Object.assign(favorites).filter(
       (validator: string) => validator !== address
     );
     localStorage.setItem(
@@ -61,9 +58,9 @@ export const FavoritePoolsProvider = ({
   return (
     <FavoritePoolsContext.Provider
       value={{
+        favorites,
         addFavorite,
         removeFavorite,
-        favorites,
       }}
     >
       {children}

--- a/src/contexts/Pools/FavoritePools/types.ts
+++ b/src/contexts/Pools/FavoritePools/types.ts
@@ -1,8 +1,8 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-export interface PoolsConfigContextState {
-  addFavorite: (a: string) => void;
-  removeFavorite: (a: string) => void;
+export interface FavoritePoolsContextState {
   favorites: string[];
+  addFavorite: (address: string) => void;
+  removeFavorite: (address: string) => void;
 }

--- a/src/contexts/Pools/PoolsConfig/defaults.ts
+++ b/src/contexts/Pools/PoolsConfig/defaults.ts
@@ -8,7 +8,6 @@ import type { PoolAddresses } from '../BondedPools/types';
 export const defaultPoolsConfigContext: PoolsConfigContextState = {
   addFavorite: () => {},
   removeFavorite: () => {},
-  createAccounts: () => poolAddresses,
   favorites: [],
 };
 

--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -1,15 +1,10 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { bnToU8a, u8aConcat } from '@polkadot/util';
-import BigNumber from 'bignumber.js';
-import BN from 'bn.js';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useState } from 'react';
-import { EmptyH256, ModPrefix, U32Opts } from 'consts';
 import type { PoolsConfigContextState } from './types';
 import { useNetwork } from 'contexts/Network';
-import { useApi } from '../../Api';
 import { defaultPoolsConfigContext } from './defaults';
 
 export const PoolsConfigContext = createContext<PoolsConfigContextState>(
@@ -20,8 +15,6 @@ export const usePoolsConfig = () => useContext(PoolsConfigContext);
 
 export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useNetwork();
-  const { api, consts } = useApi();
-  const { poolsPalletId } = consts;
 
   // get favorite pools from local storage.
   const getLocalFavorites = () => {
@@ -61,39 +54,11 @@ export const PoolsConfigProvider = ({ children }: { children: ReactNode }) => {
     setFavorites([...newFavorites]);
   };
 
-  // Helper: generates pool stash and reward accounts. assumes poolsPalletId is synced.
-  const createAccounts = (poolId: number) => {
-    const poolIdBigNumber = new BigNumber(poolId);
-    return {
-      stash: createAccount(poolIdBigNumber, 0),
-      reward: createAccount(poolIdBigNumber, 1),
-    };
-  };
-
-  const createAccount = (poolId: BigNumber, index: number): string => {
-    if (!api) {
-      return '';
-    }
-    return api.registry
-      .createType(
-        'AccountId32',
-        u8aConcat(
-          ModPrefix,
-          poolsPalletId,
-          new Uint8Array([index]),
-          bnToU8a(new BN(poolId.toString()), U32Opts),
-          EmptyH256
-        )
-      )
-      .toString();
-  };
-
   return (
     <PoolsConfigContext.Provider
       value={{
         addFavorite,
         removeFavorite,
-        createAccounts,
         favorites,
       }}
     >

--- a/src/contexts/Pools/PoolsConfig/types.ts
+++ b/src/contexts/Pools/PoolsConfig/types.ts
@@ -1,11 +1,8 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { PoolAddresses } from '../BondedPools/types';
-
 export interface PoolsConfigContextState {
   addFavorite: (a: string) => void;
   removeFavorite: (a: string) => void;
-  createAccounts: (p: number) => PoolAddresses;
   favorites: string[];
 }

--- a/src/contexts/Validators/types.ts
+++ b/src/contexts/Validators/types.ts
@@ -36,8 +36,8 @@ export interface AverageEraValidatorReward {
 }
 
 export interface FavoriteValidatorsContextInterface {
-  addFavorite: (a: string) => void;
-  removeFavorite: (a: string) => void;
+  addFavorite: (address: string) => void;
+  removeFavorite: (address: string) => void;
   favorites: string[];
   favoritesList: Validator[] | null;
 }

--- a/src/library/Hooks/useCreatePoolAccounts/index.tsx
+++ b/src/library/Hooks/useCreatePoolAccounts/index.tsx
@@ -1,0 +1,42 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { bnToU8a, u8aConcat } from '@polkadot/util';
+import BigNumber from 'bignumber.js';
+import { BN } from 'bn.js';
+import { EmptyH256, ModPrefix, U32Opts } from 'consts';
+import { useApi } from 'contexts/Api';
+
+export const useCreatePoolAccounts = () => {
+  const { api, consts } = useApi();
+  const { poolsPalletId } = consts;
+
+  // Generates pool stash and reward accounts. Assumes `poolsPalletId` is synced.
+  const createPoolAccounts = (poolId: number) => {
+    const poolIdBigNumber = new BigNumber(poolId);
+    return {
+      stash: createAccount(poolIdBigNumber, 0),
+      reward: createAccount(poolIdBigNumber, 1),
+    };
+  };
+
+  const createAccount = (poolId: BigNumber, index: number): string => {
+    if (!api) {
+      return '';
+    }
+    return api.registry
+      .createType(
+        'AccountId32',
+        u8aConcat(
+          ModPrefix,
+          poolsPalletId,
+          new Uint8Array([index]),
+          bnToU8a(new BN(poolId.toString()), U32Opts),
+          EmptyH256
+        )
+      )
+      .toString();
+  };
+
+  return createPoolAccounts;
+};

--- a/src/library/ListItem/Labels/FavoritePool.tsx
+++ b/src/library/ListItem/Labels/FavoritePool.tsx
@@ -5,7 +5,7 @@ import { faHeart as faHeartRegular } from '@fortawesome/free-regular-svg-icons';
 import { faHeart } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
-import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
+import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { useTooltip } from 'contexts/Tooltip';
 import { TooltipTrigger } from 'library/ListItem/Wrappers';
 import type { FavoriteProps } from '../types';
@@ -14,7 +14,7 @@ import { NotificationsController } from 'static/NotificationsController';
 export const FavoritePool = ({ address }: FavoriteProps) => {
   const { t } = useTranslation('library');
   const { setTooltipTextAndOpen } = useTooltip();
-  const { favorites, addFavorite, removeFavorite } = usePoolsConfig();
+  const { favorites, addFavorite, removeFavorite } = useFavoritePools();
 
   const isFavorite = favorites.includes(address);
 

--- a/src/modals/UnlockChunks/Forms.tsx
+++ b/src/modals/UnlockChunks/Forms.tsx
@@ -19,7 +19,7 @@ import { useActivePools } from 'contexts/Pools/ActivePools';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
-import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
+import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { Warning } from 'library/Form/Warning';
 import { useSignerWarnings } from 'library/Hooks/useSignerWarnings';
 import { useSubmitExtrinsic } from 'library/Hooks/useSubmitExtrinsic';
@@ -40,12 +40,12 @@ export const Forms = forwardRef(
     const {
       networkData: { units, unit },
     } = useNetwork();
-    const { activeAccount } = useActiveAccounts();
-    const { removeFavorite: removeFavoritePool } = usePoolsConfig();
     const { membership } = usePoolMemberships();
+    const { activeAccount } = useActiveAccounts();
+    const { removePoolMember } = usePoolMembers();
     const { selectedActivePool } = useActivePools();
     const { removeFromBondedPools } = useBondedPools();
-    const { removePoolMember } = usePoolMembers();
+    const { removeFavorite: removeFavoritePool } = useFavoritePools();
     const {
       setModalStatus,
       config: { options },

--- a/src/pages/Pools/Home/Favorites/index.tsx
+++ b/src/pages/Pools/Home/Favorites/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
-import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
+import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { useUi } from 'contexts/UI';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { PoolList } from 'library/PoolList/Default';
@@ -19,7 +19,7 @@ export const PoolFavorites = () => {
   const { isReady } = useApi();
   const { isPoolSyncing } = useUi();
   const { bondedPools } = useBondedPools();
-  const { favorites, removeFavorite } = usePoolsConfig();
+  const { favorites, removeFavorite } = useFavoritePools();
 
   // Store local favorite list and update when favorites list is mutated.
   const [favoritesList, setFavoritesList] = useState<BondedPool[]>([]);

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -10,7 +10,7 @@ import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { CardWrapper } from 'library/Card/Wrappers';
 import { PoolList } from 'library/PoolList/Default';
 import { StatBoxList } from 'library/StatBoxList';
-import { usePoolsConfig } from 'contexts/Pools/PoolsConfig';
+import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { PoolListProvider } from 'library/PoolList/context';
@@ -29,9 +29,9 @@ import { useApi } from 'contexts/Api';
 
 export const HomeInner = () => {
   const { t } = useTranslation('pages');
+  const { favorites } = useFavoritePools();
   const { openModal } = useOverlay().modal;
   const { activeAccount } = useActiveAccounts();
-  const { favorites } = usePoolsConfig();
   const { activeTab, setActiveTab } = usePoolsTabs();
   const { counterForBondedPools } = useApi().poolsConfig;
   const { bondedPools, getAccountPools } = useBondedPools();


### PR DESCRIPTION
Moves pool account creation to a hook and renames `PoolsConfig` to `FavoritePools`.