### PR TITLE
feat(refactor): persist Subscan results to class

### DIFF
--- a/src/canvas/PoolMembers/Lists/FetchPage.tsx
+++ b/src/canvas/PoolMembers/Lists/FetchPage.tsx
@@ -70,8 +70,10 @@ export const MembersListInner = ({
     if (poolId > 0 && !fetchingMemberList.current) {
       fetchingMemberList.current = true;
 
-      const newMembers: PoolMember[] =
-        await SubscanController.handleFetchPoolMembers(poolId, page);
+      const newMembers = (await SubscanController.handleFetchPoolMembers(
+        poolId,
+        page
+      )) as PoolMember[];
 
       fetchingMemberList.current = false;
       setPoolMembersApi([...newMembers]);

--- a/src/contexts/Plugins/index.tsx
+++ b/src/contexts/Plugins/index.tsx
@@ -47,11 +47,6 @@ export const PluginsProvider = ({ children }: { children: ReactNode }) => {
   // Check if a plugin is currently enabled.
   const pluginEnabled = (key: Plugin) => pluginsRef.current.includes(key);
 
-  // Reset payouts on Subscan network on `activeAccount` switch.
-  useEffectIgnoreInitial(() => {
-    SubscanController.resetData();
-  }, [network, activeAccount]);
-
   // Reset payouts on Subscan plugin not enabled. Otherwise fetch payouts.
   useEffectIgnoreInitial(() => {
     if (!plugins.includes('subscan')) {

--- a/src/modals/ClaimPayouts/Forms.tsx
+++ b/src/modals/ClaimPayouts/Forms.tsx
@@ -115,13 +115,13 @@ export const Forms = forwardRef(
         setModalStatus('closing');
       },
       callbackInBlock: () => {
-        if (payouts) {
+        if (payouts && activeAccount) {
           // Remove Subscan unclaimed payout record(s) if they exist.
           const eraPayouts: string[] = [];
           payouts.forEach(({ era }) => {
             eraPayouts.push(String(era));
           });
-          SubscanController.removeUnclaimedPayouts(eraPayouts);
+          SubscanController.removeUnclaimedPayouts(activeAccount, eraPayouts);
 
           // Deduct from `unclaimedPayouts` in Payouts context.
           payouts.forEach(({ era, paginatedValidators }) => {

--- a/src/static/SubscanController/types.ts
+++ b/src/static/SubscanController/types.ts
@@ -91,3 +91,8 @@ export interface SubscanPoolMember {
 export interface SubscanPoolDetails {
   member_count: number;
 }
+
+export interface SubscanEraPoints {
+  era: number;
+  reward_point: number;
+}


### PR DESCRIPTION
Persists subscan results to `SubscanController` to prevent re-fetching the same request during a visit. (does not persist to local storage so results still need to be re-fetched on subsequent page visits).