### PR TITLE
feat(refactor): Menu refresh with mouse-based position

### DIFF
--- a/src/canvas/PoolMembers/Lists/Member.tsx
+++ b/src/canvas/PoolMembers/Lists/Member.tsx
@@ -39,8 +39,8 @@ export const Member = ({
   const { activeEra } = useApi();
   const { meta } = usePoolMembers();
   const { selectActive } = useList();
+  const { openMenu, open } = useMenu();
   const { openPromptWith } = usePrompt();
-  const { openMenu, setMenuInner, open } = useMenu();
   const { activePool, isOwner, isBouncer } = useActivePool();
 
   // Ref for the member container.
@@ -109,8 +109,7 @@ export const Member = ({
   // Handler for opening menu.
   const toggleMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
-      setMenuInner(<MenuList items={menuItems} />);
-      openMenu(ev);
+      openMenu(ev, <MenuList items={menuItems} />);
     }
   };
 

--- a/src/canvas/PoolMembers/Lists/Member.tsx
+++ b/src/canvas/PoolMembers/Lists/Member.tsx
@@ -28,6 +28,7 @@ import { UnbondMember } from '../Prompts/UnbondMember';
 import { WithdrawMember } from '../Prompts/WithdrawMember';
 import { motion } from 'framer-motion';
 import { useApi } from 'contexts/Api';
+import { MenuList } from 'library/Menu/List';
 
 export const Member = ({
   who,
@@ -43,7 +44,7 @@ export const Member = ({
   const { meta } = usePoolMembers();
   const { selectActive } = useList();
   const { openPromptWith } = usePrompt();
-  const { setMenuPosition, setMenuItems, open } = useMenu();
+  const { setMenuPosition, setMenuInner, open } = useMenu();
   const { activePool, isOwner, isBouncer } = useActivePool();
 
   // Ref for the member container.
@@ -113,7 +114,7 @@ export const Member = ({
   const posRef = useRef(null);
   const toggleMenu = () => {
     if (!open) {
-      setMenuItems(menuItems);
+      setMenuInner(<MenuList items={menuItems} />);
       setMenuPosition(posRef);
     }
   };

--- a/src/canvas/PoolMembers/Lists/Member.tsx
+++ b/src/canvas/PoolMembers/Lists/Member.tsx
@@ -7,6 +7,7 @@ import {
   faUnlockAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMenu } from 'contexts/Menu';
@@ -16,12 +17,7 @@ import { useList } from 'library/List/context';
 import { Identity } from 'library/ListItem/Labels/Identity';
 import { PoolMemberBonded } from 'library/ListItem/Labels/PoolMemberBonded';
 import { Select } from 'library/ListItem/Labels/Select';
-import {
-  Labels,
-  MenuPosition,
-  Separator,
-  Wrapper,
-} from 'library/ListItem/Wrappers';
+import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
 import type { AnyJson } from 'types';
 import { usePrompt } from 'contexts/Prompt';
 import { UnbondMember } from '../Prompts/UnbondMember';
@@ -44,7 +40,7 @@ export const Member = ({
   const { meta } = usePoolMembers();
   const { selectActive } = useList();
   const { openPromptWith } = usePrompt();
-  const { setMenuPosition, setMenuInner, open } = useMenu();
+  const { openMenu, setMenuInner, open } = useMenu();
   const { activePool, isOwner, isBouncer } = useActivePool();
 
   // Ref for the member container.
@@ -110,12 +106,11 @@ export const Member = ({
     }
   }
 
-  // configure floating menu
-  const posRef = useRef(null);
-  const toggleMenu = () => {
+  // Handler for opening menu.
+  const toggleMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
       setMenuInner(<MenuList items={menuItems} />);
-      setMenuPosition(posRef);
+      openMenu(ev);
     }
   };
 
@@ -136,7 +131,6 @@ export const Member = ({
     >
       <Wrapper className="member">
         <div className="inner canvas">
-          <MenuPosition ref={posRef} />
           <div className="row top">
             {selectActive && <Select item={{ address: who }} />}
             <Identity address={who} />
@@ -147,7 +141,7 @@ export const Member = ({
                     type="button"
                     className="label"
                     disabled={!member}
-                    onClick={() => toggleMenu()}
+                    onClick={(ev) => toggleMenu(ev)}
                   >
                     <FontAwesomeIcon icon={faBars} />
                   </button>

--- a/src/contexts/Menu/defaults.ts
+++ b/src/contexts/Menu/defaults.ts
@@ -5,13 +5,12 @@
 import type { MenuContextInterface } from './types';
 
 export const defaultMenuContext: MenuContextInterface = {
-  openMenu: () => {},
-  closeMenu: () => {},
-  setMenuPosition: (r) => {},
-  checkMenuPosition: (r) => {},
-  setMenuInner: (items) => {},
-  open: 0,
-  show: 0,
-  position: [0, 0],
+  open: false,
+  show: false,
   inner: null,
+  position: [0, 0],
+  openMenu: (ev) => {},
+  closeMenu: () => {},
+  setMenuInner: (inner) => {},
+  checkMenuPosition: (menuRef) => {},
 };

--- a/src/contexts/Menu/defaults.ts
+++ b/src/contexts/Menu/defaults.ts
@@ -9,8 +9,8 @@ export const defaultMenuContext: MenuContextInterface = {
   show: false,
   inner: null,
   position: [0, 0],
-  openMenu: (ev) => {},
+  openMenu: (ev, newInner) => {},
   closeMenu: () => {},
-  setMenuInner: (inner) => {},
+  setMenuInner: (newInner) => {},
   checkMenuPosition: (menuRef) => {},
 };

--- a/src/contexts/Menu/defaults.ts
+++ b/src/contexts/Menu/defaults.ts
@@ -9,9 +9,9 @@ export const defaultMenuContext: MenuContextInterface = {
   closeMenu: () => {},
   setMenuPosition: (r) => {},
   checkMenuPosition: (r) => {},
-  setMenuItems: (items) => {},
+  setMenuInner: (items) => {},
   open: 0,
   show: 0,
   position: [0, 0],
-  items: [],
+  inner: null,
 };

--- a/src/contexts/Menu/index.tsx
+++ b/src/contexts/Menu/index.tsx
@@ -1,14 +1,10 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-  ReactNode,
-  RefObject,
-  MouseEvent as ReactMouseEvent,
-} from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { createContext, useContext, useState } from 'react';
 import { defaultMenuContext } from './defaults';
-import type { MenuContextInterface } from './types';
+import type { MenuContextInterface, MenuMouseEvent } from './types';
 
 export const MenuContext =
   createContext<MenuContextInterface>(defaultMenuContext);
@@ -24,7 +20,7 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
   const [show, setShow] = useState<boolean>(false);
 
   // The components to be displayed in the menu.
-  const [inner, setInner] = useState<ReactNode | null>(null);
+  const [inner, setInner] = useState<ReactNode>(null);
 
   // The menu position coordinates.
   const [position, setPosition] = useState<[number, number]>([0, 0]);
@@ -34,13 +30,17 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
 
   // Sets the menu position and opens it. Only succeeds if the menu has been instantiated and is not
   // currently open.
-  const openMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const openMenu = (ev: MenuMouseEvent, newInner?: ReactNode) => {
     if (open) {
       return;
     }
     const bodyRect = document.body.getBoundingClientRect();
     const x = ev.clientX - bodyRect.left;
     const y = ev.clientY - bodyRect.top;
+
+    if (newInner) {
+      setInner(newInner);
+    }
 
     setPosition([x, y]);
     setOpen(true);
@@ -53,7 +53,7 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
   };
 
   // Sets the inner JSX of the menu.
-  const setMenuInner = (newInner: ReactNode | null) => {
+  const setMenuInner = (newInner: ReactNode) => {
     setInner(newInner);
   };
 

--- a/src/contexts/Menu/index.tsx
+++ b/src/contexts/Menu/index.tsx
@@ -4,7 +4,7 @@
 import type { ReactNode, RefObject } from 'react';
 import { createContext, useContext, useState } from 'react';
 import { defaultMenuContext } from './defaults';
-import type { MenuContextInterface, MenuItem } from './types';
+import type { MenuContextInterface } from './types';
 
 export const MenuContext =
   createContext<MenuContextInterface>(defaultMenuContext);
@@ -14,7 +14,7 @@ export const useMenu = () => useContext(MenuContext);
 export const MenuProvider = ({ children }: { children: ReactNode }) => {
   const [open, setOpen] = useState<number>(0);
   const [show, setShow] = useState<number>(0);
-  const [items, setItems] = useState<MenuItem[]>([]);
+  const [inner, setInner] = useState<ReactNode>([]);
 
   const [position, setPosition] = useState<[number, number]>([0, 0]);
 
@@ -74,8 +74,8 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
     setShow(1);
   };
 
-  const setMenuItems = (_items: MenuItem[]) => {
-    setItems(_items);
+  const setMenuInner = (newInner: ReactNode) => {
+    setInner(newInner);
   };
 
   return (
@@ -85,11 +85,11 @@ export const MenuProvider = ({ children }: { children: ReactNode }) => {
         closeMenu,
         setMenuPosition,
         checkMenuPosition,
-        setMenuItems,
+        setMenuInner,
         open,
         show,
         position,
-        items,
+        inner,
       }}
     >
       {children}

--- a/src/contexts/Menu/index.tsx
+++ b/src/contexts/Menu/index.tsx
@@ -1,7 +1,11 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { ReactNode, RefObject } from 'react';
+import type {
+  ReactNode,
+  RefObject,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 import { createContext, useContext, useState } from 'react';
 import { defaultMenuContext } from './defaults';
 import type { MenuContextInterface } from './types';
@@ -12,84 +16,83 @@ export const MenuContext =
 export const useMenu = () => useContext(MenuContext);
 
 export const MenuProvider = ({ children }: { children: ReactNode }) => {
-  const [open, setOpen] = useState<number>(0);
-  const [show, setShow] = useState<number>(0);
-  const [inner, setInner] = useState<ReactNode>([]);
+  // Whether the menu is currently open. This initiates menu state but does not reflect whether the
+  // menu is being displayed.
+  const [open, setOpen] = useState<boolean>(false);
 
+  // Whether the menu is currently showing.
+  const [show, setShow] = useState<boolean>(false);
+
+  // The components to be displayed in the menu.
+  const [inner, setInner] = useState<ReactNode | null>(null);
+
+  // The menu position coordinates.
   const [position, setPosition] = useState<[number, number]>([0, 0]);
 
-  const openMenu = () => {
+  // Padding from the window edge.
+  const DocumentPadding = 20;
+
+  // Sets the menu position and opens it. Only succeeds if the menu has been instantiated and is not
+  // currently open.
+  const openMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (open) {
       return;
     }
-    setOpen(1);
-  };
-
-  const closeMenu = () => {
-    setShow(0);
-    setTimeout(() => {
-      setOpen(0);
-    }, 100);
-  };
-
-  const setMenuPosition = (ref: RefObject<HTMLDivElement>) => {
-    if (open || !ref?.current) {
-      return;
-    }
     const bodyRect = document.body.getBoundingClientRect();
-    const elemRect = ref.current.getBoundingClientRect();
-
-    const x = elemRect.left - bodyRect.left;
-    const y = elemRect.top - bodyRect.top;
+    const x = ev.clientX - bodyRect.left;
+    const y = ev.clientY - bodyRect.top;
 
     setPosition([x, y]);
-    openMenu();
+    setOpen(true);
   };
 
+  // Hides the menu and closes.
+  const closeMenu = () => {
+    setShow(false);
+    setOpen(false);
+  };
+
+  // Sets the inner JSX of the menu.
+  const setMenuInner = (newInner: ReactNode | null) => {
+    setInner(newInner);
+  };
+
+  // Adjusts menu position and shows the menu.
   const checkMenuPosition = (ref: RefObject<HTMLDivElement>) => {
     if (!ref?.current) {
       return;
     }
 
+    // Adjust menu position if it is leaking out of the window, otherwise keep it at the current
+    // position.
     const bodyRect = document.body.getBoundingClientRect();
     const menuRect = ref.current.getBoundingClientRect();
+    const hiddenRight = menuRect.right > bodyRect.right;
+    const hiddenBottom = menuRect.bottom > bodyRect.bottom;
 
-    let x = menuRect.left - bodyRect.left;
-    let y = menuRect.top - bodyRect.top;
-    const right = menuRect.right;
-    const bottom = menuRect.bottom;
+    const x = hiddenRight
+      ? window.innerWidth - menuRect.width - DocumentPadding
+      : position[0];
 
-    // small offset from menu start
-    y -= 10;
+    const y = hiddenBottom
+      ? window.innerHeight - menuRect.height - DocumentPadding
+      : position[1];
 
-    const documentPadding = 20;
-
-    if (right > bodyRect.right) {
-      x = bodyRect.right - ref.current.offsetWidth - documentPadding;
-    }
-    if (bottom > bodyRect.bottom) {
-      y = bodyRect.bottom - ref.current.offsetHeight - documentPadding;
-    }
     setPosition([x, y]);
-    setShow(1);
-  };
-
-  const setMenuInner = (newInner: ReactNode) => {
-    setInner(newInner);
+    setShow(true);
   };
 
   return (
     <MenuContext.Provider
       value={{
-        openMenu,
-        closeMenu,
-        setMenuPosition,
-        checkMenuPosition,
-        setMenuInner,
         open,
         show,
-        position,
         inner,
+        position,
+        closeMenu,
+        openMenu,
+        setMenuInner,
+        checkMenuPosition,
       }}
     >
       {children}

--- a/src/contexts/Menu/types.ts
+++ b/src/contexts/Menu/types.ts
@@ -12,7 +12,7 @@ export interface MenuContextInterface {
   show: boolean;
   inner: ReactNode | null;
   position: [number, number];
-  openMenu: (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  openMenu: (ev: MenuMouseEvent, newInner?: ReactNode) => void;
   closeMenu: () => void;
   setMenuInner: (items: ReactNode) => void;
   checkMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
@@ -23,3 +23,7 @@ export interface MenuItem {
   title: string;
   cb: () => void;
 }
+
+export type MenuMouseEvent =
+  | MouseEvent
+  | ReactMouseEvent<HTMLButtonElement, MouseEvent>;

--- a/src/contexts/Menu/types.ts
+++ b/src/contexts/Menu/types.ts
@@ -1,18 +1,21 @@
 // Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { ReactNode, RefObject } from 'react';
+import type {
+  ReactNode,
+  RefObject,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 
 export interface MenuContextInterface {
-  openMenu: () => void;
-  closeMenu: () => void;
-  setMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
-  checkMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
-  setMenuInner: (items: ReactNode) => void;
-  open: number;
-  show: number;
+  open: boolean;
+  show: boolean;
+  inner: ReactNode | null;
   position: [number, number];
-  inner: ReactNode;
+  openMenu: (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  closeMenu: () => void;
+  setMenuInner: (items: ReactNode) => void;
+  checkMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
 }
 
 export interface MenuItem {

--- a/src/contexts/Menu/types.ts
+++ b/src/contexts/Menu/types.ts
@@ -8,11 +8,11 @@ export interface MenuContextInterface {
   closeMenu: () => void;
   setMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
   checkMenuPosition: (ref: RefObject<HTMLDivElement>) => void;
-  setMenuItems: (items: MenuItem[]) => void;
+  setMenuInner: (items: ReactNode) => void;
   open: number;
   show: number;
   position: [number, number];
-  items: MenuItem[];
+  inner: ReactNode;
 }
 
 export interface MenuItem {

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -289,15 +289,6 @@ export const Separator = styled.div`
   opacity: 0.7;
 `;
 
-export const MenuPosition = styled.div`
-  position: absolute;
-  top: -10px;
-  right: 10px;
-  width: 0;
-  height: 0;
-  opacity: 0;
-`;
-
 export const TooltipTrigger = styled.div`
   z-index: 1;
   width: 130%;

--- a/src/library/Menu/List.tsx
+++ b/src/library/Menu/List.tsx
@@ -1,0 +1,28 @@
+import type { MenuItem } from 'contexts/Menu/types';
+import { ItemWrapper } from './Wrappers';
+import { useMenu } from 'contexts/Menu';
+
+export const MenuList = ({ items }: { items: MenuItem[] }) => {
+  const { closeMenu } = useMenu();
+
+  return (
+    <>
+      {items.map((item, i: number) => {
+        const { icon, title, cb } = item;
+
+        return (
+          <ItemWrapper
+            key={`menu_item_${i}`}
+            onClick={() => {
+              cb();
+              closeMenu();
+            }}
+          >
+            {icon}
+            <div className="title">{title}</div>
+          </ItemWrapper>
+        );
+      })}
+    </>
+  );
+};

--- a/src/library/Menu/index.tsx
+++ b/src/library/Menu/index.tsx
@@ -3,8 +3,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useMenu } from 'contexts/Menu';
-import { ItemWrapper, Wrapper } from './Wrappers';
-import type { AnyJson } from 'types';
+import { Wrapper } from './Wrappers';
 import { useOutsideAlerter } from 'hooks/useOutsideAlerter';
 
 export const Menu = () => {
@@ -51,22 +50,7 @@ export const Menu = () => {
           opacity: menu.show === 1 ? 1 : 0,
         }}
       >
-        {menu.items.map((item: AnyJson, i: number) => {
-          const { icon, title, cb } = item;
-
-          return (
-            <ItemWrapper
-              key={`menu_item_${i}`}
-              onClick={() => {
-                cb();
-                menu.closeMenu();
-              }}
-            >
-              {icon}
-              <div className="title">{title}</div>
-            </ItemWrapper>
-          );
-        })}
+        {menu.inner}
       </Wrapper>
     )
   );

--- a/src/library/Menu/index.tsx
+++ b/src/library/Menu/index.tsx
@@ -7,18 +7,35 @@ import { Wrapper } from './Wrappers';
 import { useOutsideAlerter } from 'hooks/useOutsideAlerter';
 
 export const Menu = () => {
-  const menu = useMenu();
-  const { position } = menu;
+  const {
+    open,
+    show,
+    inner,
+    closeMenu,
+    position: [x, y],
+    checkMenuPosition,
+  } = useMenu();
 
-  const ref = useRef(null);
+  const menuRef = useRef(null);
 
+  // Handler for closing the menu on window resize.
+  const resizeCallback = () => {
+    closeMenu();
+  };
+
+  // Close the menu if clicked outside of its container.
+  useOutsideAlerter(menuRef, () => {
+    closeMenu();
+  });
+
+  // Check position and show the menu if menu has been opened.
   useEffect(() => {
-    if (menu.open === 1) {
-      menu.checkMenuPosition(ref);
-      // check position
+    if (open) {
+      checkMenuPosition(menuRef);
     }
-  }, [menu.open]);
+  }, [open]);
 
+  // Close the menu on window resize.
   useEffect(() => {
     window.addEventListener('resize', resizeCallback);
     return () => {
@@ -26,31 +43,19 @@ export const Menu = () => {
     };
   }, []);
 
-  const resizeCallback = () => {
-    menu.closeMenu();
-  };
-
-  useOutsideAlerter(
-    ref,
-    () => {
-      menu.closeMenu();
-    },
-    ['ignore-open-menu-button']
-  );
-
   return (
-    menu.open === 1 && (
+    open && (
       <Wrapper
-        ref={ref}
+        ref={menuRef}
         style={{
           position: 'absolute',
-          left: `${position[0]}px`,
-          top: `${position[1]}px`,
-          zIndex: 99,
-          opacity: menu.show === 1 ? 1 : 0,
+          left: `${x}px`,
+          top: `${y}px`,
+          zIndex: 999,
+          opacity: show ? 1 : 0,
         }}
       >
-        {menu.inner}
+        {inner}
       </Wrapper>
     )
   );

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -34,6 +34,7 @@ import { NotificationsController } from 'static/NotificationsController';
 import type { MenuItem } from 'contexts/Menu/types';
 import { useBalances } from 'contexts/Balances';
 import { useSyncing } from 'hooks/useSyncing';
+import { MenuList } from 'library/Menu/List';
 
 export const Pool = ({ pool }: PoolProps) => {
   const { t } = useTranslation('library');
@@ -47,7 +48,7 @@ export const Pool = ({ pool }: PoolProps) => {
   const { syncing } = useSyncing(['active-pools']);
   const { isReadOnlyAccount } = useImportedAccounts();
   const { getCurrentCommission } = usePoolCommission();
-  const { setMenuPosition, setMenuItems, open } = useMenu();
+  const { setMenuPosition, setMenuInner, open } = useMenu();
 
   const membership = getPoolMembership(activeAccount);
   const currentCommission = getCurrentCommission(id);
@@ -124,7 +125,7 @@ export const Pool = ({ pool }: PoolProps) => {
   // toggle menu handler
   const toggleMenu = () => {
     if (!open) {
-      setMenuItems(menuItems);
+      setMenuInner(<MenuList items={menuItems} />);
       setMenuPosition(posRef);
     }
   };

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -34,6 +34,7 @@ import { MenuList } from 'library/Menu/List';
 export const Pool = ({ pool }: PoolProps) => {
   const { t } = useTranslation('library');
   const { memberCounter, addresses, id, state } = pool;
+  const { openMenu, open } = useMenu();
   const { validators } = useValidators();
   const { setActiveTab } = usePoolsTabs();
   const { openModal } = useOverlay().modal;
@@ -41,7 +42,6 @@ export const Pool = ({ pool }: PoolProps) => {
   const { poolsNominations } = useBondedPools();
   const { activeAccount } = useActiveAccounts();
   const { syncing } = useSyncing(['active-pools']);
-  const { openMenu, setMenuInner, open } = useMenu();
   const { isReadOnlyAccount } = useImportedAccounts();
   const { getCurrentCommission } = usePoolCommission();
 
@@ -117,8 +117,7 @@ export const Pool = ({ pool }: PoolProps) => {
   // Handler for opening menu.
   const toggleMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
-      setMenuInner(<MenuList items={menuItems} />);
-      openMenu(ev);
+      openMenu(ev, <MenuList items={menuItems} />);
     }
   };
 

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -4,7 +4,7 @@
 import { faCopy } from '@fortawesome/free-regular-svg-icons';
 import { faBars, faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useRef } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMenu } from 'contexts/Menu';
 import type { NotificationText } from 'static/NotificationsController/types';
@@ -15,12 +15,7 @@ import { FavoritePool } from 'library/ListItem/Labels/FavoritePool';
 import { PoolBonded } from 'library/ListItem/Labels/PoolBonded';
 import { PoolCommission } from 'library/ListItem/Labels/PoolCommission';
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity';
-import {
-  Labels,
-  MenuPosition,
-  Separator,
-  Wrapper,
-} from 'library/ListItem/Wrappers';
+import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
 import { usePoolsTabs } from 'pages/Pools/Home/context';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
@@ -46,9 +41,9 @@ export const Pool = ({ pool }: PoolProps) => {
   const { poolsNominations } = useBondedPools();
   const { activeAccount } = useActiveAccounts();
   const { syncing } = useSyncing(['active-pools']);
+  const { openMenu, setMenuInner, open } = useMenu();
   const { isReadOnlyAccount } = useImportedAccounts();
   const { getCurrentCommission } = usePoolCommission();
-  const { setMenuPosition, setMenuInner, open } = useMenu();
 
   const membership = getPoolMembership(activeAccount);
   const currentCommission = getCurrentCommission(id);
@@ -63,9 +58,6 @@ export const Pool = ({ pool }: PoolProps) => {
   const targetValidators = validators.filter(({ address }) =>
     targets.includes(address)
   );
-
-  // configure floating menu position
-  const posRef = useRef(null);
 
   // copy address notification
   const notificationCopyAddress = (
@@ -122,11 +114,11 @@ export const Pool = ({ pool }: PoolProps) => {
     },
   });
 
-  // toggle menu handler
-  const toggleMenu = () => {
+  // Handler for opening menu.
+  const toggleMenu = (ev: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
       setMenuInner(<MenuList items={menuItems} />);
-      setMenuPosition(posRef);
+      openMenu(ev);
     }
   };
 
@@ -140,14 +132,13 @@ export const Pool = ({ pool }: PoolProps) => {
   return (
     <Wrapper className={displayJoin ? 'pool-join' : 'pool'}>
       <div className="inner">
-        <MenuPosition ref={posRef} />
         <div className="row top">
           <PoolIdentity pool={pool} />
           <div>
             <Labels>
               <FavoritePool address={addresses.stash} />
               <div className="label">
-                <button type="button" onClick={() => toggleMenu()}>
+                <button type="button" onClick={(ev) => toggleMenu(ev)}>
                   <FontAwesomeIcon icon={faBars} transform="shrink-2" />
                 </button>
               </div>

--- a/src/library/ValidatorList/ValidatorItem/Default.tsx
+++ b/src/library/ValidatorList/ValidatorItem/Default.tsx
@@ -38,9 +38,9 @@ export const Default = ({
 }: ValidatorItemProps) => {
   const { t } = useTranslation('library');
   const { selectActive } = useList();
+  const { openMenu, open } = useMenu();
   const { pluginEnabled } = usePlugins();
   const { openModal } = useOverlay().modal;
-  const { openMenu, setMenuInner, open } = useMenu();
   const { validatorIdentities, validatorSupers } = useValidators();
 
   const { address, prefs, validatorStatus, totalStake } = validator;
@@ -88,8 +88,7 @@ export const Default = ({
   // Handler for opening menu.
   const toggleMenu = (ev: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
-      setMenuInner(<MenuList items={menuItems} />);
-      openMenu(ev);
+      openMenu(ev, <MenuList items={menuItems} />);
     }
   };
 

--- a/src/library/ValidatorList/ValidatorItem/Default.tsx
+++ b/src/library/ValidatorList/ValidatorItem/Default.tsx
@@ -34,6 +34,7 @@ import { Select } from '../../ListItem/Labels/Select';
 import { getIdentityDisplay } from './Utils';
 import type { ValidatorItemProps } from './types';
 import { Pulse } from './Pulse';
+import { MenuList } from 'library/Menu/List';
 
 export const Default = ({
   validator,
@@ -45,7 +46,7 @@ export const Default = ({
   const { selectActive } = useList();
   const { pluginEnabled } = usePlugins();
   const { openModal } = useOverlay().modal;
-  const { setMenuPosition, setMenuItems, open } = useMenu();
+  const { setMenuPosition, setMenuInner, open } = useMenu();
   const { validatorIdentities, validatorSupers } = useValidators();
 
   const { address, prefs, validatorStatus, totalStake } = validator;
@@ -93,7 +94,7 @@ export const Default = ({
 
   const toggleMenu = () => {
     if (!open) {
-      setMenuItems(menuItems);
+      setMenuInner(<MenuList items={menuItems} />);
       setMenuPosition(posRef);
     }
   };

--- a/src/library/ValidatorList/ValidatorItem/Default.tsx
+++ b/src/library/ValidatorList/ValidatorItem/Default.tsx
@@ -7,17 +7,11 @@ import {
   faGlobe,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMenu } from 'contexts/Menu';
 import { CopyAddress } from 'library/ListItem/Labels/CopyAddress';
 import { ParaValidator } from 'library/ListItem/Labels/ParaValidator';
-import {
-  Labels,
-  MenuPosition,
-  Separator,
-  Wrapper,
-} from 'library/ListItem/Wrappers';
+import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
 import { useOverlay } from '@polkadot-cloud/react/hooks';
 import { usePlugins } from 'contexts/Plugins';
 import type { AnyJson } from 'types';
@@ -46,7 +40,7 @@ export const Default = ({
   const { selectActive } = useList();
   const { pluginEnabled } = usePlugins();
   const { openModal } = useOverlay().modal;
-  const { setMenuPosition, setMenuInner, open } = useMenu();
+  const { openMenu, setMenuInner, open } = useMenu();
   const { validatorIdentities, validatorSupers } = useValidators();
 
   const { address, prefs, validatorStatus, totalStake } = validator;
@@ -57,8 +51,7 @@ export const Default = ({
     validatorSupers[address]
   );
 
-  // configure floating menu
-  const posRef = useRef(null);
+  // Configure menu.
   const menuItems: AnyJson[] = [];
   menuItems.push({
     icon: <FontAwesomeIcon icon={faChartLine} transform="shrink-3" />,
@@ -92,17 +85,17 @@ export const Default = ({
     });
   }
 
-  const toggleMenu = () => {
+  // Handler for opening menu.
+  const toggleMenu = (ev: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (!open) {
       setMenuInner(<MenuList items={menuItems} />);
-      setMenuPosition(posRef);
+      openMenu(ev);
     }
   };
 
   return (
     <Wrapper>
       <div className={`inner ${displayFor}`}>
-        <MenuPosition ref={posRef} />
         <div className="row top">
           {selectActive && <Select item={validator} />}
           <Identity address={address} />
@@ -114,7 +107,7 @@ export const Default = ({
               {/* restrict opening modal within a canvas */}
               {displayFor === 'default' && showMenu && (
                 <div className="label">
-                  <button type="button" onClick={() => toggleMenu()}>
+                  <button type="button" onClick={(ev) => toggleMenu(ev)}>
                     <FontAwesomeIcon icon={faBars} transform="shrink-2" />
                   </button>
                 </div>


### PR DESCRIPTION
This PR iterates on `MenuProvider`, which relies on the mouse position when opening a floating menu. Context API has been tidied up and simplified. The menu now takes an arbitrary `ReactNode` instead of an opinionated list of `MenuItem`s.