### PR TITLE
feat(ux): Check SubWallet Mobile and filter Subwallet extension

### DIFF
--- a/src/modals/Connect/Utils.ts
+++ b/src/modals/Connect/Utils.ts
@@ -1,0 +1,24 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable no-useless-escape */
+
+// Checks if in mobile browser.
+// NOTE: taken from `http://detectmobilebrowsers.com/`.
+export const mobileCheck = () => {
+  let check = false;
+  ((a) => {
+    if (
+      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(
+        a
+      ) ||
+      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
+        a.substring(0, 4)
+      )
+    ) {
+      check = true;
+    }
+  })(
+    navigator.userAgent || navigator.vendor || (window.opera && 'opera m') || ''
+  );
+  return check;
+};

--- a/src/modals/Connect/Utils.ts
+++ b/src/modals/Connect/Utils.ts
@@ -3,6 +3,7 @@
 /* eslint-disable no-useless-escape */
 
 // Checks if in mobile browser.
+//
 // NOTE: taken from `http://detectmobilebrowsers.com/`.
 export const mobileCheck = () => {
   let check = false;

--- a/src/modals/Connect/index.tsx
+++ b/src/modals/Connect/index.tsx
@@ -29,19 +29,25 @@ import { Vault } from './Vault';
 import { ExtensionsWrapper } from './Wrappers';
 import { ButtonPrimaryInvert } from 'kits/Buttons/ButtonPrimaryInvert';
 import { ButtonTab } from 'kits/Buttons/ButtonTab';
+import { mobileCheck } from './Utils';
 
 export const Connect = () => {
   const { t } = useTranslation('modals');
   const { extensionsStatus } = useExtensions();
   const { replaceModal, setModalHeight, modalMaxHeight } = useOverlay().modal;
 
+  // Whether the app is running in Nova Wallet.
   const inNova = !!window?.walletExtension?.isNovaWallet || false;
 
-  // If in Nova Wallet, only display it in extension options, otherwise, remove developer tool extensions from web options.
-  const developerTools = ['polkadot-js'];
-  const web = !inNova
-    ? ExtensionsArray.filter((a) => !developerTools.includes(a.id))
-    : ExtensionsArray.filter((a) => a.id === 'polkadot-js');
+  // Whether the app is running in a SubWallet Mobile.
+  const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && mobileCheck();
+
+  // If in Nova Wallet, keep `polkadot-js` for overwriting its metadata with Nova's.
+  const web = inNova
+    ? ExtensionsArray.filter((a) => a.id === 'polkadot-js')
+    : inSubWallet
+      ? ExtensionsArray.filter((a) => a.id === 'subwallet-js')
+      : ExtensionsArray.filter((a) => a.id !== 'polkadot-js');
 
   const installed = web.filter((a) =>
     Object.keys(extensionsStatus).find((key) => key === a.id)
@@ -114,9 +120,9 @@ export const Connect = () => {
     </>
   );
 
-  // Display hardware before extensions.
-  // If in Nova Wallet, display extensions before hardware.
-  const ConnectCombinedJSX = !inNova ? (
+  // Display hardware before extensions. If in Nova Wallet or SubWallet Mobile, display extension
+  // before hardware.
+  const ConnectCombinedJSX = !(inNova || inSubWallet) ? (
     <>
       {ConnectHardwareJSX}
       {ConnectExtensionsJSX}

--- a/src/modals/Connect/index.tsx
+++ b/src/modals/Connect/index.tsx
@@ -42,12 +42,14 @@ export const Connect = () => {
   // Whether the app is running in a SubWallet Mobile.
   const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && mobileCheck();
 
-  // If in Nova Wallet, keep `polkadot-js` for overwriting its metadata with Nova's.
+  // If in Nova Wallet, keep `polkadot-js` only for overwriting its metadata with Nova's.
   const web = inNova
     ? ExtensionsArray.filter((a) => a.id === 'polkadot-js')
-    : inSubWallet
+    : // If in SubWallet Mobile, keep `subwallet-js` only.
+      inSubWallet
       ? ExtensionsArray.filter((a) => a.id === 'subwallet-js')
-      : ExtensionsArray.filter((a) => a.id !== 'polkadot-js');
+      : // Otherwise, keep all extensions except `polkadot-js`.
+        ExtensionsArray.filter((a) => a.id !== 'polkadot-js');
 
   const installed = web.filter((a) =>
     Object.keys(extensionsStatus).find((key) => key === a.id)

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ import type { CSSProperties } from 'styled-components';
 declare global {
   interface Window {
     injectedWeb3?: Record<string, ExtensionInjected>;
+    opera?: boolean;
   }
   interface DocumentEventMap {
     notification: CustomEvent<NotificationItem>;


### PR DESCRIPTION
If the dashboard is currently being used in SubWallet Mobile, the SubWallet extension is prioritised at the top of connect options, and the rest of the web extensions are removed.