### PR TITLE
feat(ux): Update detect SubWallet in SubWallet in-app browser (#1983)

### DIFF
--- a/src/modals/Connect/index.tsx
+++ b/src/modals/Connect/index.tsx
@@ -36,18 +36,24 @@ export const Connect = () => {
   const { extensionsStatus } = useExtensions();
   const { replaceModal, setModalHeight, modalMaxHeight } = useOverlay().modal;
 
+  // Whether the app is running on mobile.
+  const isMobile = mobileCheck();
+
   // Whether the app is running in Nova Wallet.
   const inNova = !!window?.walletExtension?.isNovaWallet || false;
 
   // Whether the app is running in a SubWallet Mobile.
-  const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && mobileCheck();
+  const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && isMobile;
+
+  // Whether the app is running on of mobile wallets.
+  const inMobileWallet = inNova || inSubWallet;
 
   // If in Nova Wallet, keep `polkadot-js` only for overwriting its metadata with Nova's.
-  const web = inNova
-    ? ExtensionsArray.filter((a) => a.id === 'polkadot-js')
+  const web = inSubWallet
+    ? ExtensionsArray.filter((a) => a.id === 'subwallet-js')
     : // If in SubWallet Mobile, keep `subwallet-js` only.
-      inSubWallet
-      ? ExtensionsArray.filter((a) => a.id === 'subwallet-js')
+      inNova
+      ? ExtensionsArray.filter((a) => a.id === 'polkadot-js')
       : // Otherwise, keep all extensions except `polkadot-js`.
         ExtensionsArray.filter((a) => a.id !== 'polkadot-js');
 
@@ -124,7 +130,7 @@ export const Connect = () => {
 
   // Display hardware before extensions. If in Nova Wallet or SubWallet Mobile, display extension
   // before hardware.
-  const ConnectCombinedJSX = !(inNova || inSubWallet) ? (
+  const ConnectCombinedJSX = !inMobileWallet ? (
     <>
       {ConnectHardwareJSX}
       {ConnectExtensionsJSX}
@@ -198,7 +204,7 @@ export const Connect = () => {
         <div className="section">
           <ModalPadding horizontalOnly ref={homeRef}>
             {ConnectCombinedJSX}
-            {!inNova && (
+            {!inMobileWallet && (
               <>
                 <ActionItem text={t('developerTools')} />
                 <ExtensionsWrapper>


### PR DESCRIPTION
Updated:
- Fix issue can not detect SubWallet in SubWallet Mobile
- Hide `developerTools` in SubWallet Mobile

Demo link:
https://sw-staking-demo.pages.dev/

Tested on:
- [x] Desktop browser
- [x] Mobile browser
- [x] SubWallet Mobile
- [x] Nova

Desktop Browser:
![image](https://github.com/paritytech/polkadot-staking-dashboard/assets/11567273/914a7c51-070d-4298-baf0-cb7315834a39)

Mobile Browser:
![image](https://github.com/paritytech/polkadot-staking-dashboard/assets/11567273/80ccea40-37e1-4ded-8dcd-32c90369f845)

SubWallet Mobile:
![image](https://github.com/paritytech/polkadot-staking-dashboard/assets/11567273/0ce2ae9e-993a-4cd4-ad84-a08277523d23)

Nova:
![image](https://github.com/paritytech/polkadot-staking-dashboard/assets/11567273/d2d887e0-d9e8-4a4f-8c92-c415147bdc9b)

