### PR TITLE
feat(ux): Add dedicated withdraw prompt for active unlock chunks

### DIFF
--- a/src/hooks/useActiveBalances/index.tsx
+++ b/src/hooks/useActiveBalances/index.tsx
@@ -164,19 +164,17 @@ export const useActiveBalances = ({
   // has not yet synced or the provided account is still `null`. In these cases a
   // `new-account-balance` event will be emitted when the balance is ready to be sycned with the UI.
   useEffect(() => {
-    // Adds an active balance record if it exists in `BalancesController`.
-    const getBalances = (account: MaybeAddress) => {
+    // Construct new active balances state.
+    const newActiveBalances: ActiveBalancesState = {};
+
+    for (const account of uniqueAccounts) {
+      // Adds an active balance record if it exists in `BalancesController`.
       if (account) {
         const accountBalances = BalancesController.getAccountBalances(account);
         if (accountBalances) {
           newActiveBalances[account] = accountBalances;
         }
       }
-    };
-    // Construct new active balances state.
-    const newActiveBalances: ActiveBalancesState = {};
-    for (const account of uniqueAccounts) {
-      getBalances(account);
     }
     // Commit new active balances to state.
     setStateWithRef(newActiveBalances, setActiveBalances, activeBalancesRef);

--- a/src/library/WithdrawPrompt/index.tsx
+++ b/src/library/WithdrawPrompt/index.tsx
@@ -25,8 +25,8 @@ export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
   const { consts } = useApi();
   const { openModal } = useOverlay().modal;
   const { colors } = useNetwork().networkData;
-  const { activeAccount } = useActiveAccounts();
   const { syncing } = useSyncing(['balances']);
+  const { activeAccount } = useActiveAccounts();
   const { erasToSeconds } = useErasToTimeLeft();
   const { getTransferOptions } = useTransferOptions();
 
@@ -45,7 +45,7 @@ export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
     true
   );
 
-  // Check whether there are ongonig unlock chunks.
+  // Check whether there are active unlock chunks.
   const displayPrompt = totalUnlockChunks > 0;
 
   return (

--- a/src/library/WithdrawPrompt/index.tsx
+++ b/src/library/WithdrawPrompt/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faLockOpen } from '@fortawesome/free-solid-svg-icons';
+import { PageRow } from 'kits/Structure/PageRow';
+import { useTheme } from 'contexts/Themes';
+import { useTransferOptions } from 'contexts/TransferOptions';
+import { CardWrapper } from 'library/Card/Wrappers';
+import { useOverlay } from 'kits/Overlay/Provider';
+import { useNetwork } from 'contexts/Network';
+import { useActiveAccounts } from 'contexts/ActiveAccounts';
+import { useSyncing } from 'hooks/useSyncing';
+import { ButtonPrimary } from 'kits/Buttons/ButtonPrimary';
+import { ButtonRow } from 'kits/Structure/ButtonRow';
+import { timeleftAsString } from 'hooks/useTimeLeft/utils';
+import { getUnixTime } from 'date-fns';
+import { useErasToTimeLeft } from 'hooks/useErasToTimeLeft';
+import { useApi } from 'contexts/Api';
+import { useTranslation } from 'react-i18next';
+import type { BondFor } from 'types';
+
+export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
+  const { t } = useTranslation('modals');
+  const { mode } = useTheme();
+  const { consts } = useApi();
+  const { openModal } = useOverlay().modal;
+  const { colors } = useNetwork().networkData;
+  const { activeAccount } = useActiveAccounts();
+  const { syncing } = useSyncing(['balances']);
+  const { erasToSeconds } = useErasToTimeLeft();
+  const { getTransferOptions } = useTransferOptions();
+
+  const { bondDuration } = consts;
+  const allTransferOptions = getTransferOptions(activeAccount);
+
+  const totalUnlockChunks =
+    bondFor === 'nominator'
+      ? allTransferOptions.nominate.totalUnlockChunks
+      : allTransferOptions.pool.totalUnlockChunks;
+
+  const bondDurationFormatted = timeleftAsString(
+    t,
+    getUnixTime(new Date()) + 1,
+    erasToSeconds(bondDuration),
+    true
+  );
+
+  // Check whether there are ongonig unlock chunks.
+  const displayPrompt = totalUnlockChunks > 0;
+
+  return (
+    displayPrompt && (
+      <PageRow>
+        <CardWrapper style={{ border: `1px solid ${colors.secondary[mode]}` }}>
+          <div className="content">
+            <h3>{t('unlocksInProgress')}</h3>
+            <h4>{t('youHaveActiveUnlocks', { bondDurationFormatted })}</h4>
+            <ButtonRow yMargin>
+              <ButtonPrimary
+                iconLeft={faLockOpen}
+                text={t('manageUnlocks')}
+                disabled={syncing}
+                onClick={() =>
+                  openModal({
+                    key: 'UnlockChunks',
+                    options: {
+                      bondFor: 'pool',
+                      poolClosure: true,
+                      disableWindowResize: true,
+                      disableScroll: true,
+                    },
+                    size: 'sm',
+                  })
+                }
+              />
+            </ButtonRow>
+          </div>
+        </CardWrapper>
+      </PageRow>
+    )
+  );
+};

--- a/src/library/WithdrawPrompt/index.tsx
+++ b/src/library/WithdrawPrompt/index.tsx
@@ -64,10 +64,12 @@ export const WithdrawPrompt = ({ bondFor }: { bondFor: BondFor }) => {
                   openModal({
                     key: 'UnlockChunks',
                     options: {
-                      bondFor: 'pool',
-                      poolClosure: true,
+                      bondFor,
                       disableWindowResize: true,
                       disableScroll: true,
+                      // NOTE: This will always be false as a different prompt is displayed when a
+                      // pool is being destroyed.
+                      poolClosure: false,
                     },
                     size: 'sm',
                   })

--- a/src/locale/cn/modals.json
+++ b/src/locale/cn/modals.json
@@ -136,6 +136,7 @@
     "manageCommission": "管理佣金值",
     "manageNominations": "提名管理",
     "managePool": "管理池",
+    "manageUnlocks": "管理解锁",
     "maxCommission": "最高佣金值",
     "maximumCommissionUpdated": "最高佣金值最新值",
     "methodNotSupported": "调用方法不受支持,无法签署交易",
@@ -267,6 +268,7 @@
     "unlocks": "解锁",
     "unlocksAfter": "解锁于",
     "unlocksInEra": "解锁于Era",
+    "unlocksInProgress": "解锁正在进行中",
     "unstake": "解除抵押",
     "unstakeStopNominating": "停止提名 {{count}} 个验证人",
     "unstakeUnbond": "解除质押 {{bond}} {{unit}}",
@@ -290,8 +292,6 @@
     "withdrawSubtitle": "资金将在取款后立即转作可用余额",
     "withdrawUnlocked": "取出己解锁",
     "years": "年",
-    "unlocksInProgress": "解锁正在进行中",
-    "youHaveActiveUnlocks": "您有主动解锁。 一旦 {{bondDurationFormatted}} 的解锁期过后，就可以撤回解锁。",
-    "manageUnlocks": "管理解锁"
+    "youHaveActiveUnlocks": "您有主动解锁。 一旦 {{bondDurationFormatted}} 的解锁期过后，就可以撤回解锁。"
   }
 }

--- a/src/locale/cn/modals.json
+++ b/src/locale/cn/modals.json
@@ -289,6 +289,9 @@
     "withdrawRemoveNote": "取款后将从提名池中删除此成员",
     "withdrawSubtitle": "资金将在取款后立即转作可用余额",
     "withdrawUnlocked": "取出己解锁",
-    "years": "年"
+    "years": "年",
+    "unlocksInProgress": "解锁正在进行中",
+    "youHaveActiveUnlocks": "您有主动解锁。 一旦 {{bondDurationFormatted}} 的解锁期过后，就可以撤回解锁。",
+    "manageUnlocks": "管理解锁"
   }
 }

--- a/src/locale/en/modals.json
+++ b/src/locale/en/modals.json
@@ -304,6 +304,9 @@
     "withdrawRemoveNote": "Withdrawing will remove this member from the pool.",
     "withdrawSubtitle": "Funds will be immediately available as free balance after withdrawing.",
     "withdrawUnlocked": "Withdraw Unlocked",
-    "years": "Years"
+    "years": "Years",
+    "unlocksInProgress": "Unlocks in Progress",
+    "youHaveActiveUnlocks": "You have active unlocks. Unlocks can be withdrawn once the unlock period of {{bondDurationFormatted}} has passed.",
+    "manageUnlocks": "Manage Unlocks"
   }
 }

--- a/src/locale/en/modals.json
+++ b/src/locale/en/modals.json
@@ -146,6 +146,7 @@
     "manageCommission": "Manage Commission",
     "manageNominations": "Manage Nominations",
     "managePool": "Manage Pool",
+    "manageUnlocks": "Manage Unlocks",
     "maxCommission": "Max Commission",
     "maximumCommissionUpdated": "Maximum Commission Updated",
     "methodNotSupported": "Call method not supported, cannot sign.",
@@ -280,6 +281,7 @@
     "unlocks": "Unlocks",
     "unlocksAfter": "Unlocks after",
     "unlocksInEra": "Unlocks in Era",
+    "unlocksInProgress": "Unlocks in Progress",
     "unstake": "Unstake",
     "unstakeStopNominating_one": "Stop Nominating {{count}} Validator",
     "unstakeStopNominating_other": "Stop Nominating {{count}} Validators",
@@ -305,8 +307,6 @@
     "withdrawSubtitle": "Funds will be immediately available as free balance after withdrawing.",
     "withdrawUnlocked": "Withdraw Unlocked",
     "years": "Years",
-    "unlocksInProgress": "Unlocks in Progress",
-    "youHaveActiveUnlocks": "You have active unlocks. Unlocks can be withdrawn once the unlock period of {{bondDurationFormatted}} has passed.",
-    "manageUnlocks": "Manage Unlocks"
+    "youHaveActiveUnlocks": "You have active unlocks. Unlocks can be withdrawn once the unlock period of {{bondDurationFormatted}} has passed."
   }
 }

--- a/src/modals/Accounts/index.tsx
+++ b/src/modals/Accounts/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { faChevronLeft, faLinkSlash } from '@fortawesome/free-solid-svg-icons';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useProxies } from 'contexts/Proxies';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
@@ -16,7 +16,6 @@ import type {
   AccountNominatingAndInPool,
   AccountNotStaking,
 } from './types';
-import type { ImportedAccount } from '@w3ux/react-connect-kit/types';
 import { useActiveBalances } from 'hooks/useActiveBalances';
 import type { MaybeAddress } from 'types';
 import { useTransferOptions } from 'contexts/TransferOptions';
@@ -45,14 +44,10 @@ export const Accounts = () => {
   const { activeAccount, setActiveAccount, setActiveProxy } =
     useActiveAccounts();
 
-  // Store local copy of accounts.
-  const [localAccounts, setLocalAccounts] =
-    useState<ImportedAccount[]>(accounts);
-
   // Listen to balance updates for entire accounts list.
   const { getLocks, getBalance, getEdReserved, getPoolMembership } =
     useActiveBalances({
-      accounts: localAccounts.map(({ address }) => address),
+      accounts: accounts.map(({ address }) => address),
     });
 
   // Calculate transferrable balance of an address.
@@ -72,7 +67,7 @@ export const Accounts = () => {
 
   const stashes: string[] = [];
   // accumulate imported stash accounts
-  for (const { address } of localAccounts) {
+  for (const { address } of accounts) {
     const { locks } = getLocks(address);
 
     // account is a stash if they have an active `staking` lock
@@ -87,7 +82,7 @@ export const Accounts = () => {
   const nominatingAndPool: AccountNominatingAndInPool[] = [];
   const notStaking: AccountNotStaking[] = [];
 
-  for (const { address } of localAccounts) {
+  for (const { address } of accounts) {
     let isNominating = false;
     let isInPool = false;
     const isStash = stashes[stashes.indexOf(address)] ?? null;
@@ -155,9 +150,6 @@ export const Accounts = () => {
       inPool.push({ ...poolMember, delegates });
     }
   }
-
-  // Refresh local accounts state when context accounts change.
-  useEffect(() => setLocalAccounts(accounts), [accounts]);
 
   // Resize if modal open upon state changes.
   useEffect(() => {

--- a/src/modals/Accounts/index.tsx
+++ b/src/modals/Accounts/index.tsx
@@ -4,7 +4,6 @@
 import { faChevronLeft, faLinkSlash } from '@fortawesome/free-solid-svg-icons';
 import { Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBonded } from 'contexts/Bonded';
 import { useProxies } from 'contexts/Proxies';
 import { useActiveAccounts } from 'contexts/ActiveAccounts';
 import { useImportedAccounts } from 'contexts/Connect/ImportedAccounts';
@@ -36,7 +35,6 @@ export const Accounts = () => {
     consts: { existentialDeposit },
   } = useApi();
   const { getDelegates } = useProxies();
-  const { bondedAccounts } = useBonded();
   const {
     replaceModal,
     status: modalStatus,
@@ -168,12 +166,10 @@ export const Accounts = () => {
     }
   }, [
     activeAccount,
-    accounts,
-    bondedAccounts,
-    nominating,
-    inPool,
-    nominatingAndPool,
-    notStaking,
+    JSON.stringify(nominating),
+    JSON.stringify(inPool),
+    JSON.stringify(nominatingAndPool),
+    JSON.stringify(notStaking),
   ]);
 
   return (

--- a/src/pages/Nominate/Active/index.tsx
+++ b/src/pages/Nominate/Active/index.tsx
@@ -27,6 +27,7 @@ import { ButtonPrimary } from 'kits/Buttons/ButtonPrimary';
 import { PageTitle } from 'kits/Structure/PageTitle';
 import { PageRow } from 'kits/Structure/PageRow';
 import { RowSection } from 'kits/Structure/RowSection';
+import { WithdrawPrompt } from 'library/WithdrawPrompt';
 
 export const Active = () => {
   const { t } = useTranslation();
@@ -50,6 +51,9 @@ export const Active = () => {
         <MinimumNominatorBondStat />
         <MinimumActiveStakeStat />
       </StatBoxList>
+
+      <WithdrawPrompt bondFor="nominator" />
+
       <ControllerNotStash />
       <UnstakePrompts />
       <PageRow>

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -30,6 +30,7 @@ import { PageTitle } from 'kits/Structure/PageTitle';
 import type { PageTitleTabProps } from 'kits/Structure/PageTitleTabs/types';
 import { PageRow } from 'kits/Structure/PageRow';
 import { RowSection } from 'kits/Structure/RowSection';
+import { WithdrawPrompt } from 'library/WithdrawPrompt';
 
 export const HomeInner = () => {
   const { t } = useTranslation('pages');
@@ -41,7 +42,9 @@ export const HomeInner = () => {
   const { activeTab, setActiveTab } = usePoolsTabs();
   const { getPoolRoles, activePool } = useActivePool();
   const { counterForBondedPools } = useApi().poolsConfig;
+
   const membership = getPoolMembership(activeAccount);
+  const { state } = activePool?.bondedPool || {};
 
   const { activePools } = useActivePools({
     poolIds: '*',
@@ -108,7 +111,11 @@ export const HomeInner = () => {
             <MinCreateBondStat />
           </StatBoxList>
 
-          <ClosurePrompts />
+          {state === 'Destroying' ? (
+            <ClosurePrompts />
+          ) : (
+            <WithdrawPrompt bondFor="pool" />
+          )}
 
           <PageRow>
             <RowSection hLast>


### PR DESCRIPTION
Introduces a prompt on the Nominate and Pools page if there are unlock chunks active for an account.

This prompt does not display on the Pools page if the pool is being destroyed, as there is a dedicated prompt to manage that process.

Also touches the account list and useActiveBalance useEffect hooks to fix re-rendering issues.