### PR TITLE
fix: check BalancesController unsub before calling

### DIFF
--- a/src/static/BalancesController/index.ts
+++ b/src/static/BalancesController/index.ts
@@ -129,7 +129,7 @@ export class BalancesController {
     );
     // Unsubscribe from removed account subscriptions.
     accountsRemoved.forEach((account) => {
-      if (this._unsubs?.[account]) {
+      if (this._unsubs[account]) {
         this._unsubs[account]();
       }
       delete this._unsubs[account];

--- a/src/static/BalancesController/index.ts
+++ b/src/static/BalancesController/index.ts
@@ -129,7 +129,9 @@ export class BalancesController {
     );
     // Unsubscribe from removed account subscriptions.
     accountsRemoved.forEach((account) => {
-      this._unsubs[account]();
+      if (this._unsubs?.[account]) {
+        this._unsubs[account]();
+      }
       delete this._unsubs[account];
       delete this.ledgers[account];
       delete this.balances[account];


### PR DESCRIPTION
Fixes an issue where BalancesController sometimes would call unsub on a non-existing key.