### PR TITLE
feat: Remove Parity RPC endpoint from westend

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -163,7 +163,6 @@ export const NetworkList: Networks = {
         LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
         RadiumBlock: 'wss://westend.public.curie.radiumblock.co/ws',
         Stakeworld: 'wss://wnd-rpc.stakeworld.io',
-        Parity: 'wss://westend-rpc.polkadot.io',
       },
     },
     namespace: 'e143f23803ac50e8f6f8e62695d1ce9e',


### PR DESCRIPTION
Removes Parity RPC endpoint from westend network config.