### PR TITLE
fix: Ensure signer fallback on corrupt source

### DIFF
--- a/src/library/SubmitTx/ManualSign/index.tsx
+++ b/src/library/SubmitTx/ManualSign/index.tsx
@@ -24,10 +24,12 @@ export const ManualSign = (props: SubmitProps & { buttons?: ReactNode[] }) => {
     }
   }, [getTxSignature()]);
 
-  return (
-    <>
-      {source === 'ledger' && <Ledger {...props} />}
-      {source === 'vault' && <Vault {...props} />}
-    </>
-  );
+  // Determine which signing method to use. NOTE: Falls back to `ledger` on all other sources to
+  // ensure submit button is displayed.
+  switch (source) {
+    case 'vault':
+      return <Vault {...props} />;
+    default:
+      return <Ledger {...props} />;
+  }
 };


### PR DESCRIPTION
This PR ensures that a manual sign button is always displayed when submitting transactions by displaying the ledger sign button. There have been edge cases where corrupt local data on Ledger devices have resulted in no button being displayed.

A more thorough analysis followed by fixes need to be carried out for the local storage management, but this fix will allow the button to be shown in the interim.