### PR TITLE
fix: Misc Subscan payout fixes

### DIFF
--- a/src/controllers/SubscanController/index.ts
+++ b/src/controllers/SubscanController/index.ts
@@ -113,12 +113,14 @@ export class SubscanController {
     if (!result?.list) {
       return { payouts: [], unclaimedPayouts: [] };
     }
+
     const payouts = result.list.filter(
-      (l: SubscanPayout) => l.block_timestamp !== 0
+      (l: SubscanPayout) => l.block_timestamp !== 0 && l.account !== ''
     );
     const unclaimedPayouts = result.list.filter(
-      (l: SubscanPayout) => l.block_timestamp === 0
+      (l: SubscanPayout) => l.block_timestamp === 0 && l.account !== ''
     );
+
     return { payouts, unclaimedPayouts };
   };
 
@@ -299,6 +301,9 @@ export class SubscanController {
       return undefined;
     }
     const filtered = this.removeNonZeroAmountAndSort(payouts || []);
+    if (!filtered.length) {
+      return undefined;
+    }
     return format(
       fromUnixTime(filtered[filtered.length - 1].block_timestamp),
       'do MMM',
@@ -314,6 +319,10 @@ export class SubscanController {
       return undefined;
     }
     const filtered = this.removeNonZeroAmountAndSort(payouts || []);
+    if (!filtered.length) {
+      return undefined;
+    }
+
     return format(fromUnixTime(filtered[0].block_timestamp), 'do MMM', {
       locale,
     });


### PR DESCRIPTION
- Fixes an issue where title formatting attempted to retrieve data from empty filtered payouts.
- Fixes an issue where payout items from Subscan with an empty `account` field were displayed. 