### PR TITLE
fix: Fix errornous unclaimed payouts from Subscan

### DIFF
--- a/src/controllers/SubscanController/index.ts
+++ b/src/controllers/SubscanController/index.ts
@@ -133,8 +133,6 @@ export class SubscanController {
         )
     );
 
-    console.log(unclaimedPayouts);
-
     return { payouts, unclaimedPayouts };
   };
 

--- a/src/controllers/SubscanController/index.ts
+++ b/src/controllers/SubscanController/index.ts
@@ -104,32 +104,20 @@ export class SubscanController {
     payouts: SubscanPayout[];
     unclaimedPayouts: SubscanPayout[];
   }> => {
-    const [resultClaimed, resultUnclaimed] = await Promise.all([
-      this.makeRequest(this.ENDPOINTS.rewardSlash, {
-        address,
-        is_stash: true,
-        claimed_filter: 'claimed',
-        row: 50,
-        page: 0,
-      }),
-      this.makeRequest(this.ENDPOINTS.rewardSlash, {
-        address,
-        is_stash: true,
-        claimed_filter: 'unclaimed',
-        row: 50,
-        page: 0,
-      }),
-    ]);
+    const result = await this.makeRequest(this.ENDPOINTS.rewardSlash, {
+      address,
+      is_stash: true,
+      row: 100,
+      page: 0,
+    });
 
     const payouts =
-      resultClaimed?.list?.filter(
+      result?.list?.filter(
         ({ block_timestamp }: SubscanPayout) => block_timestamp !== 0
       ) || [];
 
     let unclaimedPayouts =
-      resultUnclaimed?.list?.filter(
-        (l: SubscanPayout) => l.block_timestamp === 0
-      ) || [];
+      result?.list?.filter((l: SubscanPayout) => l.block_timestamp === 0) || [];
 
     // Further filter unclaimed payouts to ensure that payout records of `stash` and `validator_stash` are not repeated.
     unclaimedPayouts = unclaimedPayouts.filter(

--- a/src/controllers/SubscanController/index.ts
+++ b/src/controllers/SubscanController/index.ts
@@ -119,7 +119,10 @@ export class SubscanController {
     let unclaimedPayouts =
       result?.list?.filter((l: SubscanPayout) => l.block_timestamp === 0) || [];
 
-    // Further filter unclaimed payouts to ensure that payout records of `stash` and `validator_stash` are not repeated.
+    // Further filter unclaimed payouts to ensure that payout records of `stash` and
+    // `validator_stash` are not repeated for an era. NOTE: This was introduced to remove errornous
+    // data where there were duplicated payout records (with different amounts) for a stash -
+    // validator - era record. from Subscan.
     unclaimedPayouts = unclaimedPayouts.filter(
       (u: SubscanPayout) =>
         !payouts.find(

--- a/src/controllers/SubscanController/types.ts
+++ b/src/controllers/SubscanController/types.ts
@@ -20,6 +20,7 @@ export type RewardSlashRequestBody = SubscanRequestPagination & {
 
 export type RewardRewardsRequestBody = SubscanRequestPagination & {
   address: string;
+  claimed_filter?: 'claimed' | 'unclaimed';
 };
 
 export type RewardMembersRequestBody = SubscanRequestPagination & {


### PR DESCRIPTION
Fixes an issue where incorrect unclaimed payouts fetched from Subscan were being displayed in payout graphs. Additional filters have been introduced to check if `unclaimedPayouts` records for a stash, with a validator, at an era, have already been included in `payouts`.