### PR TITLE
fix: Search bar initial value on Pools/Validators page

### DIFF
--- a/src/library/List/SearchInput.tsx
+++ b/src/library/List/SearchInput.tsx
@@ -6,12 +6,14 @@ import { SearchInputWrapper } from '.';
 import type { SearchInputProps } from './types';
 
 export const SearchInput = ({
+  value,
   handleChange,
   placeholder,
 }: SearchInputProps) => (
   <SearchInputWrapper>
     <input
       type="text"
+      value={value}
       className="search"
       placeholder={placeholder}
       onChange={(e: FormEvent<HTMLInputElement>) => handleChange(e)}

--- a/src/library/List/types.ts
+++ b/src/library/List/types.ts
@@ -22,6 +22,7 @@ export interface PaginationProps {
 }
 
 export interface SearchInputProps {
+  value: string;
   handleChange: (e: FormEvent<HTMLInputElement>) => void;
   placeholder: string;
 }

--- a/src/library/PoolList/Default.tsx
+++ b/src/library/PoolList/Default.tsx
@@ -183,6 +183,7 @@ export const PoolList = ({
       <List $flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
         {allowSearch && poolsDefault.length > 0 && (
           <SearchInput
+            value={searchTerm ?? ''}
             handleChange={handleSearchChange}
             placeholder={t('search')}
           />

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -333,6 +333,7 @@ export const ValidatorListInner = ({
       <List $flexBasisLarge={allowMoreCols ? '33.33%' : '50%'}>
         {allowSearch && (
           <SearchInput
+            value={searchTerm ?? ''}
             handleChange={handleSearchChange}
             placeholder={t('searchAddress')}
           />


### PR DESCRIPTION
What does this PR fix?

Check the recording video. The search bar input value is not set correctly after switching back to back different tabs/pages.

https://github.com/paritytech/polkadot-staking-dashboard/assets/51565705/eb9783c6-f621-47b7-8d82-c7c296a18993

