### PR TITLE
fix: Reset filters to default when switching tabs

### DIFF
--- a/src/library/PoolList/Default.tsx
+++ b/src/library/PoolList/Default.tsx
@@ -57,6 +57,11 @@ export const PoolList = ({
   const excludes = getFilters('exclude', 'pools');
   const searchTerm = getSearchTerm('pools');
 
+  useEffect(() => {
+    setSearchTerm('pools', '');
+  }, []);
+
+
   // current page
   const [page, setPage] = useState<number>(1);
 
@@ -171,10 +176,10 @@ export const PoolList = ({
   // Set default filters.
   useEffect(() => {
     if (defaultFilters?.includes?.length) {
-      setMultiFilters('include', 'pools', defaultFilters?.includes, false);
+      setMultiFilters('include', 'pools', defaultFilters?.includes, true);
     }
     if (defaultFilters?.excludes?.length) {
-      setMultiFilters('exclude', 'pools', defaultFilters?.excludes, false);
+      setMultiFilters('exclude', 'pools', defaultFilters?.excludes, true);
     }
   }, []);
 

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -95,6 +95,10 @@ export const ValidatorListInner = ({
   const actionsAll = [...actions].filter((action) => !action.onSelected);
   const actionsSelected = [...actions].filter((action) => action.onSelected);
 
+  useEffect(() => {
+    setSearchTerm('validators', '');
+  }, []);
+
   // Determine the nominator of the validator list. Fallback to activeAccount if not provided.
   const nominator = initialNominator || activeAccount;
 
@@ -253,7 +257,7 @@ export const ValidatorListInner = ({
           'include',
           'validators',
           defaultFilters?.includes,
-          false
+          true
         );
       }
       if (defaultFilters?.excludes?.length) {
@@ -261,7 +265,7 @@ export const ValidatorListInner = ({
           'exclude',
           'validators',
           defaultFilters?.excludes,
-          false
+          true
         );
       }
 


### PR DESCRIPTION
Issue:
See recording
https://github.com/paritytech/polkadot-staking-dashboard/assets/51565705/0a04f1e7-2668-476c-8208-c72392f6efa9

After fix:
https://github.com/paritytech/polkadot-staking-dashboard/assets/51565705/1b72d2d5-01a6-470f-bf89-77dad5b2e5bb

When switching tabs, it doesn't reset the filters (search text & selected subtab).

There can be two ways to fix this.
- Introduce a new state to save the selected subtab
- Reset filters to default when switching tabs or landing on pools tab

This PR handles in the second way.
Happy to contribute!