### PR TITLE
feat: Pool performance data to batches. Per-page fetching, pool join subset.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "buffer": "^6.0.3",
     "chart.js": "^4.4.2",
     "chroma-js": "^2.4.2",
-    "crypto-js": "^4.2.0",
     "date-fns": "^3.3.1",
     "framer-motion": "^11.0.24",
     "html5-qrcode": "^2.3.8",
@@ -68,7 +67,6 @@
   "devDependencies": {
     "@ledgerhq/logs": "^6.12.0",
     "@types/chroma-js": "^2.4.4",
-    "@types/crypto-js": "^4",
     "@types/lodash.debounce": "^4.0.9",
     "@types/lodash.throttle": "^4.1.9",
     "@types/react": "^18.2.73",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "buffer": "^6.0.3",
     "chart.js": "^4.4.2",
     "chroma-js": "^2.4.2",
+    "crypto-js": "^4.2.0",
     "date-fns": "^3.3.1",
     "framer-motion": "^11.0.24",
     "html5-qrcode": "^2.3.8",
@@ -67,6 +68,7 @@
   "devDependencies": {
     "@ledgerhq/logs": "^6.12.0",
     "@types/chroma-js": "^2.4.4",
+    "@types/crypto-js": "^4",
     "@types/lodash.debounce": "^4.0.9",
     "@types/lodash.throttle": "^4.1.9",
     "@types/react": "^18.2.73",

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -44,6 +44,7 @@ import type { Provider } from 'hooks/withProviders';
 import { withProviders } from 'hooks/withProviders';
 import { CommunityProvider } from 'contexts/Community';
 import { OverlayProvider } from 'kits/Overlay/Provider';
+import { JoinPoolsProvider } from 'contexts/Pools/JoinPools';
 
 export const Providers = () => {
   const {
@@ -83,6 +84,7 @@ export const Providers = () => {
     FastUnstakeProvider,
     PayoutsProvider,
     PoolPerformanceProvider,
+    JoinPoolsProvider,
     SetupProvider,
     MenuProvider,
     TooltipProvider,

--- a/src/canvas/JoinPool/Header.tsx
+++ b/src/canvas/JoinPool/Header.tsx
@@ -25,19 +25,21 @@ export const Header = ({
   autoSelected,
   setActiveTab,
   setSelectedPoolId,
-  setSelectedPoolCount,
 }: JoinPoolHeaderProps) => {
   const { t } = useTranslation();
   const { closeCanvas } = useOverlay().canvas;
 
   // Randomly select a new pool to display.
   const handleChooseNewPool = () => {
-    // Trigger refresh of memoied selected bonded pool.
-    setSelectedPoolCount((prev: number) => prev + 1);
+    // Remove current pool from filtered so it is not selected again.
+    const filteredPools = filteredBondedPools.filter(
+      (pool) => String(pool.id) !== String(bondedPool.id)
+    );
 
     // Randomly select a filtered bonded pool and set it as the selected pool.
-    const index = Math.ceil(Math.random() * filteredBondedPools.length - 1);
-    setSelectedPoolId(filteredBondedPools[index].id);
+    const index = Math.ceil(Math.random() * filteredPools.length - 1);
+    console.log(filteredPools[index].id);
+    setSelectedPoolId(filteredPools[index].id);
   };
 
   return (

--- a/src/canvas/JoinPool/Header.tsx
+++ b/src/canvas/JoinPool/Header.tsx
@@ -38,7 +38,6 @@ export const Header = ({
 
     // Randomly select a filtered bonded pool and set it as the selected pool.
     const index = Math.ceil(Math.random() * filteredPools.length - 1);
-    console.log(filteredPools[index].id);
     setSelectedPoolId(filteredPools[index].id);
   };
 

--- a/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
+++ b/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
@@ -46,7 +46,7 @@ export const PerformanceGraph = ({ bondedPool }: OverviewSectionProps) => {
   const { colors } = useNetwork().networkData;
   const { getPoolRewardPoints } = usePoolPerformance();
 
-  const poolRewardPoints = getPoolRewardPoints('pool_list');
+  const poolRewardPoints = getPoolRewardPoints('pool_join');
   const rawEraRewardPoints = poolRewardPoints[bondedPool.addresses.stash] || {};
 
   // Ref to the graph container.

--- a/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
+++ b/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
@@ -14,7 +14,7 @@ import {
 } from 'chart.js';
 import { useNetwork } from 'contexts/Network';
 import { GraphWrapper, HeadingWrapper } from '../Wrappers';
-import { Bar } from 'react-chartjs-2';
+import { Line } from 'react-chartjs-2';
 import BigNumber from 'bignumber.js';
 import type { AnyJson } from 'types';
 import { graphColors } from 'theme/graphs';
@@ -102,6 +102,7 @@ export const PerformanceGraph = ({ bondedPool }: OverviewSectionProps) => {
       },
       y: {
         stacked: true,
+        beginAtZero: true,
         ticks: {
           font: {
             size: 10,
@@ -134,6 +135,10 @@ export const PerformanceGraph = ({ bondedPool }: OverviewSectionProps) => {
           title: () => [],
           label: (context: AnyJson) =>
             `${new BigNumber(context.parsed.y).decimalPlaces(0).toFormat()} ${t('eraPoints', { ns: 'library' })}`,
+        },
+        intersect: false,
+        interaction: {
+          mode: 'nearest',
         },
       },
     },
@@ -174,7 +179,7 @@ export const PerformanceGraph = ({ bondedPool }: OverviewSectionProps) => {
             height,
           }}
         >
-          <Bar options={options} data={data} />
+          <Line options={options} data={data} />
         </div>
       </GraphWrapper>
     </div>

--- a/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
+++ b/src/canvas/JoinPool/Overview/PerformanceGraph.tsx
@@ -44,7 +44,9 @@ export const PerformanceGraph = ({ bondedPool }: OverviewSectionProps) => {
   const { mode } = useTheme();
   const { openHelp } = useHelp();
   const { colors } = useNetwork().networkData;
-  const { poolRewardPoints } = usePoolPerformance();
+  const { getPoolRewardPoints } = usePoolPerformance();
+
+  const poolRewardPoints = getPoolRewardPoints('pool_list');
   const rawEraRewardPoints = poolRewardPoints[bondedPool.addresses.stash] || {};
 
   // Ref to the graph container.

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -22,7 +22,7 @@ export const JoinPool = () => {
   const { getPoolRewardPoints } = usePoolPerformance();
   const { poolsMetaData, bondedPools } = useBondedPools();
 
-  const poolRewardPoints = getPoolRewardPoints('pool_list');
+  const poolRewardPoints = getPoolRewardPoints('pool_join');
 
   // The active canvas tab.
   const [activeTab, setActiveTab] = useState<number>(0);

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -19,8 +19,10 @@ export const JoinPool = () => {
     config: { options },
   } = useOverlay().canvas;
   const { eraStakers } = useStaking();
-  const { poolRewardPoints } = usePoolPerformance();
+  const { getPoolRewardPoints } = usePoolPerformance();
   const { poolsMetaData, bondedPools } = useBondedPools();
+
+  const poolRewardPoints = getPoolRewardPoints('pool_list');
 
   // The active canvas tab.
   const [activeTab, setActiveTab] = useState<number>(0);

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -12,6 +12,7 @@ import { Nominations } from './Nominations';
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 import { MaxEraRewardPointsEras } from 'consts';
 import { useStaking } from 'contexts/Staking';
+import { useJoinPools } from 'contexts/Pools/JoinPools';
 
 export const JoinPool = () => {
   const {
@@ -19,9 +20,9 @@ export const JoinPool = () => {
     config: { options },
   } = useOverlay().canvas;
   const { eraStakers } = useStaking();
+  const { poolsForJoin } = useJoinPools();
   const { getPoolRewardPoints } = usePoolPerformance();
   const { poolsMetaData, bondedPools } = useBondedPools();
-
   const poolRewardPoints = getPoolRewardPoints('pool_join');
 
   // The active canvas tab.
@@ -35,7 +36,7 @@ export const JoinPool = () => {
   // active era.
   const filteredBondedPools = useMemo(
     () =>
-      bondedPools
+      poolsForJoin
         .filter((pool) => {
           // Fetch reward point data for the pool.
           const rawEraRewardPoints =
@@ -55,7 +56,7 @@ export const JoinPool = () => {
             staker.others.find(({ who }) => who !== pool.addresses.stash)
           )
         ),
-    [bondedPools, poolRewardPoints]
+    [poolsForJoin, poolRewardPoints]
   );
 
   // The bonded pool to display. Use the provided `poolId`, or assign a random eligible filtered

--- a/src/canvas/JoinPool/types.ts
+++ b/src/canvas/JoinPool/types.ts
@@ -12,7 +12,6 @@ export interface JoinPoolHeaderProps {
   autoSelected: boolean;
   setActiveTab: (tab: number) => void;
   setSelectedPoolId: Dispatch<SetStateAction<number>>;
-  setSelectedPoolCount: Dispatch<SetStateAction<number>>;
 }
 
 export interface NominationsProps {

--- a/src/canvas/PoolMembers/Lists/Default.tsx
+++ b/src/canvas/PoolMembers/Lists/Default.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { isNotZero } from '@w3ux/utils';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listItemsPerBatch, listItemsPerPage } from 'library/List/defaults';
+import { listItemsPerPage } from 'library/List/defaults';
 import { useApi } from 'contexts/Api';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { List, ListStatusHeader, Wrapper as ListWrapper } from 'library/List';
@@ -20,7 +20,6 @@ export const MembersListInner = ({
   pagination,
   batchKey,
   members: initialMembers,
-  disableThrottle = false,
 }: DefaultMembersListProps) => {
   const { t } = useTranslation('pages');
   const { isReady, activeEra } = useApi();
@@ -28,9 +27,6 @@ export const MembersListInner = ({
 
   // current page
   const [page, setPage] = useState<number>(1);
-
-  // current render iteration
-  const [renderIteration, setRenderIterationState] = useState<number>(1);
 
   // default list of validators
   const [membersDefault, setMembersDefault] =
@@ -42,23 +38,10 @@ export const MembersListInner = ({
   // is this the initial fetch
   const [fetched, setFetched] = useState<Sync>('unsynced');
 
-  // render throttle iteration
-  const renderIterationRef = useRef(renderIteration);
-  const setRenderIteration = (iter: number) => {
-    renderIterationRef.current = iter;
-    setRenderIterationState(iter);
-  };
-
   // pagination
   const totalPages = Math.ceil(members.length / listItemsPerPage);
   const pageEnd = page * listItemsPerPage - 1;
   const pageStart = pageEnd - (listItemsPerPage - 1);
-
-  // render batch
-  const batchEnd = Math.min(
-    renderIteration * listItemsPerBatch - 1,
-    listItemsPerPage
-  );
 
   // get throttled subset or entire list
   const listMembers = members.slice(pageStart).slice(0, listItemsPerPage);
@@ -84,15 +67,6 @@ export const MembersListInner = ({
       setupMembersList();
     }
   }, [isReady, fetched, activeEra.index]);
-
-  // Render throttle.
-  useEffect(() => {
-    if (!(batchEnd >= pageEnd || disableThrottle)) {
-      setTimeout(() => {
-        setRenderIteration(renderIterationRef.current + 1);
-      }, 500);
-    }
-  }, [renderIterationRef.current]);
 
   return !members.length ? null : (
     <ListWrapper>

--- a/src/canvas/PoolMembers/Lists/Default.tsx
+++ b/src/canvas/PoolMembers/Lists/Default.tsx
@@ -4,7 +4,7 @@
 import { isNotZero } from '@w3ux/utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listItemsPerPage } from 'library/List/defaults';
+import { poolMembersPerPage } from 'library/List/defaults';
 import { useApi } from 'contexts/Api';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
 import { List, ListStatusHeader, Wrapper as ListWrapper } from 'library/List';
@@ -39,12 +39,12 @@ export const MembersListInner = ({
   const [fetched, setFetched] = useState<Sync>('unsynced');
 
   // pagination
-  const totalPages = Math.ceil(members.length / listItemsPerPage);
-  const pageEnd = page * listItemsPerPage - 1;
-  const pageStart = pageEnd - (listItemsPerPage - 1);
+  const totalPages = Math.ceil(members.length / poolMembersPerPage);
+  const pageEnd = page * poolMembersPerPage - 1;
+  const pageStart = pageEnd - (poolMembersPerPage - 1);
 
   // get throttled subset or entire list
-  const listMembers = members.slice(pageStart).slice(0, listItemsPerPage);
+  const listMembers = members.slice(pageStart).slice(0, poolMembersPerPage);
 
   // handle validator list bootstrapping
   const setupMembersList = () => {

--- a/src/canvas/PoolMembers/Lists/FetchPage.tsx
+++ b/src/canvas/PoolMembers/Lists/FetchPage.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listItemsPerBatch, listItemsPerPage } from 'library/List/defaults';
+import { listItemsPerPage } from 'library/List/defaults';
 import { usePlugins } from 'contexts/Plugins';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
@@ -21,7 +21,6 @@ import { SubscanController } from 'controllers/SubscanController';
 export const MembersListInner = ({
   pagination,
   batchKey,
-  disableThrottle = false,
   memberCount,
 }: FetchpageMembersListProps) => {
   const { t } = useTranslation('pages');
@@ -40,26 +39,10 @@ export const MembersListInner = ({
   // current page.
   const [page, setPage] = useState<number>(1);
 
-  // current render iteration.
-  const [renderIteration, setRenderIterationState] = useState<number>(1);
-
-  // render throttle iteration.
-  const renderIterationRef = useRef(renderIteration);
-  const setRenderIteration = (iter: number) => {
-    renderIterationRef.current = iter;
-    setRenderIterationState(iter);
-  };
-
   // pagination
   const totalPages = Math.ceil(Number(memberCount) / listItemsPerPage);
   const pageEnd = listItemsPerPage - 1;
   const pageStart = pageEnd - (listItemsPerPage - 1);
-
-  // render batch
-  const batchEnd = Math.min(
-    renderIteration * listItemsPerBatch - 1,
-    listItemsPerPage
-  );
 
   // handle validator list bootstrapping
   const fetchingMemberList = useRef<boolean>(false);
@@ -108,15 +91,6 @@ export const MembersListInner = ({
       setupMembersList();
     }
   }, [fetchedPoolMembersApi, activePool]);
-
-  // Render throttle.
-  useEffect(() => {
-    if (!(batchEnd >= pageEnd || disableThrottle)) {
-      setTimeout(() => {
-        setRenderIteration(renderIterationRef.current + 1);
-      }, 500);
-    }
-  }, [renderIterationRef.current]);
 
   return (
     <ListWrapper>

--- a/src/canvas/PoolMembers/Lists/FetchPage.tsx
+++ b/src/canvas/PoolMembers/Lists/FetchPage.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listItemsPerPage } from 'library/List/defaults';
+import { poolMembersPerPage } from 'library/List/defaults';
 import { usePlugins } from 'contexts/Plugins';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { usePoolMembers } from 'contexts/Pools/PoolMembers';
@@ -40,9 +40,9 @@ export const MembersListInner = ({
   const [page, setPage] = useState<number>(1);
 
   // pagination
-  const totalPages = Math.ceil(Number(memberCount) / listItemsPerPage);
-  const pageEnd = listItemsPerPage - 1;
-  const pageStart = pageEnd - (listItemsPerPage - 1);
+  const totalPages = Math.ceil(Number(memberCount) / poolMembersPerPage);
+  const pageEnd = poolMembersPerPage - 1;
+  const pageStart = pageEnd - (poolMembersPerPage - 1);
 
   // handle validator list bootstrapping
   const fetchingMemberList = useRef<boolean>(false);
@@ -68,7 +68,7 @@ export const MembersListInner = ({
   // get throttled subset or entire list
   const listMembers = poolMembersApi
     .slice(pageStart)
-    .slice(0, listItemsPerPage);
+    .slice(0, poolMembersPerPage);
 
   // Refetch list when page changes.
   useEffect(() => {

--- a/src/canvas/PoolMembers/Lists/types.ts
+++ b/src/canvas/PoolMembers/Lists/types.ts
@@ -6,7 +6,6 @@ import type { AnyJson } from 'types';
 export interface MembersListProps {
   pagination: boolean;
   batchKey: string;
-  disableThrottle?: boolean;
   selectToggleable?: boolean;
 }
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -37,4 +37,4 @@ export const TipsThresholdMedium = 1200;
  * Misc Values
  */
 export const MaxPayoutDays = 60;
-export const MaxEraRewardPointsEras = 14;
+export const MaxEraRewardPointsEras = 10;

--- a/src/contexts/Filters/defaults.ts
+++ b/src/contexts/Filters/defaults.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
-import type { FiltersContextInterface } from './types';
+import type { FilterItem, FiltersContextInterface } from './types';
 
 export const defaultFiltersInterface: FiltersContextInterface = {
   getFilters: (type, group) => [],
@@ -18,3 +18,17 @@ export const defaultFiltersInterface: FiltersContextInterface = {
   applyFilters: (type, g, l, f) => {},
   applyOrder: (g, l, f) => {},
 };
+
+export const defaultIncludes: FilterItem[] = [
+  {
+    key: 'pools',
+    filters: ['active'],
+  },
+];
+
+export const defaultExcludes: FilterItem[] = [
+  {
+    key: 'pools',
+    filters: ['locked', 'destroying'],
+  },
+];

--- a/src/contexts/Filters/index.tsx
+++ b/src/contexts/Filters/index.tsx
@@ -4,7 +4,11 @@
 import type { ReactNode } from 'react';
 import { createContext, useContext, useState } from 'react';
 import type { AnyFunction, AnyJson } from 'types';
-import { defaultFiltersInterface } from './defaults';
+import {
+  defaultExcludes,
+  defaultFiltersInterface,
+  defaultIncludes,
+} from './defaults';
 import type {
   FilterItem,
   FilterItems,
@@ -24,10 +28,10 @@ export const useFilters = () => useContext(FiltersContext);
 
 export const FiltersProvider = ({ children }: { children: ReactNode }) => {
   // groups along with their includes
-  const [includes, setIncludes] = useState<FilterItems>([]);
+  const [includes, setIncludes] = useState<FilterItems>(defaultIncludes);
 
   // groups along with their excludes.
-  const [excludes, setExcludes] = useState<FilterItems>([]);
+  const [excludes, setExcludes] = useState<FilterItems>(defaultExcludes);
 
   // groups along with their order.
   const [orders, setOrders] = useState<FilterOrders>([]);

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -19,4 +19,6 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   poolsMetaData: {},
   poolsNominations: {},
   updatePoolNominations: (id, nominations) => {},
+  poolListActiveTab: 'Active',
+  setPoolListActiveTab: (tab) => {},
 };

--- a/src/contexts/Pools/BondedPools/defaults.ts
+++ b/src/contexts/Pools/BondedPools/defaults.ts
@@ -14,7 +14,7 @@ export const defaultBondedPoolsContext: BondedPoolsContextState = {
   getPoolNominationStatusCode: (statuses) => '',
   getAccountPoolRoles: (address) => null,
   replacePoolRoles: (poolId, roleEdits) => {},
-  poolSearchFilter: (filteredPools, searchTerm) => {},
+  poolSearchFilter: (filteredPools, searchTerm) => [],
   bondedPools: [],
   poolsMetaData: {},
   poolsNominations: {},

--- a/src/contexts/Pools/BondedPools/index.tsx
+++ b/src/contexts/Pools/BondedPools/index.tsx
@@ -12,6 +12,7 @@ import type {
   MaybePool,
   NominationStatuses,
   PoolNominations,
+  PoolTab,
 } from './types';
 import { useStaking } from 'contexts/Staking';
 import type { AnyApi, AnyJson, MaybeAddress, Sync } from 'types';
@@ -55,6 +56,9 @@ export const BondedPoolsProvider = ({ children }: { children: ReactNode }) => {
   const [poolsNominations, setPoolsNominations] = useState<
     Record<number, PoolNominations>
   >({});
+
+  // Store pool list active tab. Defaults to `Active` tab.
+  const [poolListActiveTab, setPoolListActiveTab] = useState<PoolTab>('Active');
 
   // Fetch all bonded pool entries and their metadata.
   const fetchBondedPools = async () => {
@@ -425,6 +429,8 @@ export const BondedPoolsProvider = ({ children }: { children: ReactNode }) => {
         poolsMetaData,
         poolsNominations,
         updatePoolNominations,
+        poolListActiveTab,
+        setPoolListActiveTab,
       }}
     >
       {children}

--- a/src/contexts/Pools/BondedPools/types.ts
+++ b/src/contexts/Pools/BondedPools/types.ts
@@ -4,6 +4,7 @@
 import type { AnyApi, AnyJson, MaybeAddress } from 'types';
 import type { ActiveBondedPool } from '../ActivePool/types';
 import type { AnyFilter } from 'library/Filter/types';
+import type { Dispatch, SetStateAction } from 'react';
 
 export interface BondedPoolsContextState {
   queryBondedPool: (poolId: number) => AnyApi;
@@ -23,6 +24,8 @@ export interface BondedPoolsContextState {
   poolsMetaData: Record<number, string>;
   poolsNominations: Record<number, PoolNominations>;
   updatePoolNominations: (id: number, nominations: string[]) => void;
+  poolListActiveTab: PoolTab;
+  setPoolListActiveTab: Dispatch<SetStateAction<PoolTab>>;
 }
 
 export type BondedPool = ActiveBondedPool & {
@@ -60,3 +63,5 @@ export type AccountPoolRoles = {
   nominator: number[];
   bouncer: number[];
 } | null;
+
+export type PoolTab = 'All' | 'Active' | 'Locked' | 'Destroying';

--- a/src/contexts/Pools/BondedPools/types.ts
+++ b/src/contexts/Pools/BondedPools/types.ts
@@ -18,7 +18,7 @@ export interface BondedPoolsContextState {
   getPoolNominationStatusCode: (statuses: NominationStatuses | null) => string;
   getAccountPoolRoles: (address: MaybeAddress) => AnyApi;
   replacePoolRoles: (poolId: number, roleEdits: AnyJson) => void;
-  poolSearchFilter: (filteredPools: AnyFilter, searchTerm: string) => void;
+  poolSearchFilter: (filteredPools: AnyFilter, searchTerm: string) => AnyJson[];
   bondedPools: BondedPool[];
   poolsMetaData: Record<number, string>;
   poolsNominations: Record<number, PoolNominations>;

--- a/src/contexts/Pools/JoinPools/defaults.ts
+++ b/src/contexts/Pools/JoinPools/defaults.ts
@@ -1,10 +1,12 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
 import type { JoinPoolsContextInterface } from './types';
 
 export const defaultJoinPoolsContext: JoinPoolsContextInterface = {
   poolsForJoin: [],
+  startJoinPoolFetch: () => {},
 };
 
-export const MaxPoolsForJoin = 15;
+export const MaxPoolsForJoin = 8;

--- a/src/contexts/Pools/JoinPools/defaults.ts
+++ b/src/contexts/Pools/JoinPools/defaults.ts
@@ -1,0 +1,10 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { JoinPoolsContextInterface } from './types';
+
+export const defaultJoinPoolsContext: JoinPoolsContextInterface = {
+  poolsForJoin: [],
+};
+
+export const MaxPoolsForJoin = 15;

--- a/src/contexts/Pools/JoinPools/index.tsx
+++ b/src/contexts/Pools/JoinPools/index.tsx
@@ -23,7 +23,7 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
   const { api, activeEra } = useApi();
   const { bondedPools } = useBondedPools();
   const { erasRewardPointsFetched } = useValidators();
-  const { getPerformanceFetchedKey, startGetPoolPerformance } =
+  const { getPoolPerformanceTask, startPoolRewardPointsFetch } =
     usePoolPerformance();
 
   // Save the bonded pools subset for pool joining.
@@ -36,7 +36,7 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
       bondedPools.length &&
       activeEra.index.isGreaterThan(0) &&
       erasRewardPointsFetched === 'synced' &&
-      getPerformanceFetchedKey('pool_join')?.status === 'unsynced'
+      getPoolPerformanceTask('pool_join')?.status === 'unsynced'
     ) {
       // Generate a subset of pools to fetch performance data for. TODO: Send pools to JoinPool
       // canvas and only select those. Move this logic to a separate context.
@@ -46,7 +46,7 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
 
       setPoolsToJoin(poolJoinSelection);
 
-      startGetPoolPerformance(
+      startPoolRewardPointsFetch(
         'pool_join',
         poolJoinSelection.map(({ addresses }) => addresses.stash)
       );
@@ -55,7 +55,7 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
     bondedPools,
     activeEra,
     erasRewardPointsFetched,
-    getPerformanceFetchedKey('pool_join'),
+    getPoolPerformanceTask('pool_join'),
   ]);
 
   return (

--- a/src/contexts/Pools/JoinPools/index.tsx
+++ b/src/contexts/Pools/JoinPools/index.tsx
@@ -29,6 +29,14 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
   // Save the bonded pools subset for pool joining.
   const [poolsForJoin, setPoolsToJoin] = useState<BondedPool[]>([]);
 
+  // Start finding pools to join.
+  const startJoinPoolFetch = () => {
+    startPoolRewardPointsFetch(
+      'pool_join',
+      poolsForJoin.map(({ addresses }) => addresses.stash)
+    );
+  };
+
   // Trigger worker to calculate join pool performance data.
   useEffectIgnoreInitial(() => {
     if (
@@ -45,11 +53,6 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
       ).slice(0, MaxPoolsForJoin);
 
       setPoolsToJoin(poolJoinSelection);
-
-      startPoolRewardPointsFetch(
-        'pool_join',
-        poolJoinSelection.map(({ addresses }) => addresses.stash)
-      );
     }
   }, [
     bondedPools,
@@ -59,7 +62,7 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
   ]);
 
   return (
-    <JoinPoolsContext.Provider value={{ poolsForJoin }}>
+    <JoinPoolsContext.Provider value={{ poolsForJoin, startJoinPoolFetch }}>
       {children}
     </JoinPoolsContext.Provider>
   );

--- a/src/contexts/Pools/JoinPools/index.tsx
+++ b/src/contexts/Pools/JoinPools/index.tsx
@@ -1,0 +1,66 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ReactNode } from 'react';
+import { createContext, useContext, useState } from 'react';
+import type { JoinPoolsContextInterface } from './types';
+import { MaxPoolsForJoin, defaultJoinPoolsContext } from './defaults';
+import { useEffectIgnoreInitial } from '@w3ux/hooks';
+import { useBondedPools } from '../BondedPools';
+import { useApi } from 'contexts/Api';
+import { useValidators } from 'contexts/Validators/ValidatorEntries';
+import { usePoolPerformance } from '../PoolPerformance';
+import type { BondedPool } from '../BondedPools/types';
+import { shuffle } from '@w3ux/utils';
+
+export const JoinPoolsContext = createContext<JoinPoolsContextInterface>(
+  defaultJoinPoolsContext
+);
+
+export const useJoinPools = () => useContext(JoinPoolsContext);
+
+export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
+  const { api, activeEra } = useApi();
+  const { bondedPools } = useBondedPools();
+  const { erasRewardPointsFetched } = useValidators();
+  const { getPerformanceFetchedKey, startGetPoolPerformance } =
+    usePoolPerformance();
+
+  // Save the bonded pools subset for pool joining.
+  const [poolsForJoin, setPoolsToJoin] = useState<BondedPool[]>([]);
+
+  // Trigger worker to calculate join pool performance data.
+  useEffectIgnoreInitial(() => {
+    if (
+      api &&
+      bondedPools.length &&
+      activeEra.index.isGreaterThan(0) &&
+      erasRewardPointsFetched === 'synced' &&
+      getPerformanceFetchedKey('pool_join')?.status === 'unsynced'
+    ) {
+      // Generate a subset of pools to fetch performance data for. TODO: Send pools to JoinPool
+      // canvas and only select those. Move this logic to a separate context.
+      const poolJoinSelection = shuffle(
+        bondedPools.filter(({ state }) => state === 'Open')
+      ).slice(0, MaxPoolsForJoin);
+
+      setPoolsToJoin(poolJoinSelection);
+
+      startGetPoolPerformance(
+        'pool_join',
+        poolJoinSelection.map(({ addresses }) => addresses.stash)
+      );
+    }
+  }, [
+    bondedPools,
+    activeEra,
+    erasRewardPointsFetched,
+    getPerformanceFetchedKey('pool_join'),
+  ]);
+
+  return (
+    <JoinPoolsContext.Provider value={{ poolsForJoin }}>
+      {children}
+    </JoinPoolsContext.Provider>
+  );
+};

--- a/src/contexts/Pools/JoinPools/types.ts
+++ b/src/contexts/Pools/JoinPools/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { BondedPool } from '../BondedPools/types';
+
+export interface JoinPoolsContextInterface {
+  poolsForJoin: BondedPool[];
+}

--- a/src/contexts/Pools/JoinPools/types.ts
+++ b/src/contexts/Pools/JoinPools/types.ts
@@ -5,4 +5,5 @@ import type { BondedPool } from '../BondedPools/types';
 
 export interface JoinPoolsContextInterface {
   poolsForJoin: BondedPool[];
+  startJoinPoolFetch: () => void;
 }

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -11,6 +11,7 @@ import type {
 export const defaultPoolPerformanceTask: PoolPerformanceTaskStatus = {
   status: 'unsynced',
   addresses: [],
+  startEra: BigNumber(0),
   currentEra: BigNumber(0),
   endEra: BigNumber(0),
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -6,5 +6,5 @@ import type { PoolPerformanceContextInterface } from './types';
 
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   poolRewardPointsFetched: 'unsynced',
-  poolRewardPoints: {},
+  getPoolRewardPoints: () => ({}),
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -9,4 +9,5 @@ export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   getPerformanceFetchedKey: (key) => ({ status: 'unsynced', addresses: [] }),
   setPerformanceFetchedKey: (key, status, addresses) => {},
   updatePerformanceFetchedKey: (key, status) => {},
+  startGetPoolPerformance: (key, addresses) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -6,6 +6,7 @@ import type { PoolPerformanceContextInterface } from './types';
 
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   getPoolRewardPoints: () => ({}),
-  getPerformanceFetchedKey: (key) => 'unsynced',
-  setPerformanceFetchedKey: (key, fetched) => {},
+  getPerformanceFetchedKey: (key) => ({ status: 'unsynced', hash: '' }),
+  setPerformanceFetchedKey: (key, status, hash) => {},
+  updatePerformanceFetchedKey: (key, status) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -5,8 +5,7 @@
 import type { PoolPerformanceContextInterface } from './types';
 
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
-  poolRewardPointsFetched: 'unsynced',
   getPoolRewardPoints: () => ({}),
-  getPerformanceFetchedKey: (key) => false,
+  getPerformanceFetchedKey: (key) => 'unsynced',
   setPerformanceFetchedKey: (key, fetched) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -6,7 +6,7 @@ import type { PoolPerformanceContextInterface } from './types';
 
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   getPoolRewardPoints: () => ({}),
-  getPerformanceFetchedKey: (key) => ({ status: 'unsynced', hash: '' }),
-  setPerformanceFetchedKey: (key, status, hash) => {},
+  getPerformanceFetchedKey: (key) => ({ status: 'unsynced', addresses: [] }),
+  setPerformanceFetchedKey: (key, status, addresses) => {},
   updatePerformanceFetchedKey: (key, status) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
-import type { PoolPerformanceContextInterface } from './types';
+import BigNumber from 'bignumber.js';
+import type {
+  PoolPerformanceContextInterface,
+  PoolPerformanceFetchingStatus,
+} from './types';
 
+export const defaultPerformanceFetched: PoolPerformanceFetchingStatus = {
+  status: 'unsynced',
+  addresses: [],
+  currentEra: BigNumber(0),
+  endEra: BigNumber(0),
+};
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   getPoolRewardPoints: () => ({}),
-  getPerformanceFetchedKey: (key) => ({ status: 'unsynced', addresses: [] }),
+  getPerformanceFetchedKey: (key) => defaultPerformanceFetched,
   setPerformanceFetchedKey: (key, status, addresses) => {},
   updatePerformanceFetchedKey: (key, status) => {},
   startGetPoolPerformance: (key, addresses) => {},

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -1,10 +1,12 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
 import type { PoolPerformanceContextInterface } from './types';
 
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   poolRewardPointsFetched: 'unsynced',
   getPoolRewardPoints: () => ({}),
+  getPerformanceFetchedKey: (key) => false,
+  setPerformanceFetchedKey: (key, fetched) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/defaults.ts
+++ b/src/contexts/Pools/PoolPerformance/defaults.ts
@@ -5,10 +5,10 @@
 import BigNumber from 'bignumber.js';
 import type {
   PoolPerformanceContextInterface,
-  PoolPerformanceFetchingStatus,
+  PoolPerformanceTaskStatus,
 } from './types';
 
-export const defaultPerformanceFetched: PoolPerformanceFetchingStatus = {
+export const defaultPoolPerformanceTask: PoolPerformanceTaskStatus = {
   status: 'unsynced',
   addresses: [],
   currentEra: BigNumber(0),
@@ -16,8 +16,8 @@ export const defaultPerformanceFetched: PoolPerformanceFetchingStatus = {
 };
 export const defaultPoolPerformanceContext: PoolPerformanceContextInterface = {
   getPoolRewardPoints: () => ({}),
-  getPerformanceFetchedKey: (key) => defaultPerformanceFetched,
-  setPerformanceFetchedKey: (key, status, addresses) => {},
-  updatePerformanceFetchedKey: (key, status) => {},
-  startGetPoolPerformance: (key, addresses) => {},
+  getPoolPerformanceTask: (key) => defaultPoolPerformanceTask,
+  setNewPoolPerformanceTask: (key, status, addresses) => {},
+  updatePoolPerformanceTask: (key, status) => {},
+  startPoolRewardPointsFetch: (key, addresses) => {},
 };

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -198,13 +198,14 @@ export const PoolPerformanceProvider = ({
     if (message) {
       const { data } = message;
       const { task, key, addresses } = data;
+
       if (task !== 'processNominationPoolsRewardData') {
         return;
       }
 
       // If addresses for the given key have changed or been removed, ignore the result.
-      const fetchStatus = getPerformanceFetchedKey(key);
-      if (JSON.stringify(fetchStatus.addresses) !== JSON.stringify(addresses)) {
+      const current = getPerformanceFetchedKey(key);
+      if (current.addresses.toString() !== addresses.toString()) {
         return;
       }
 

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -86,10 +86,12 @@ export const PoolPerformanceProvider = ({
     currentEra: BigNumber,
     endEra: BigNumber
   ) => {
+    const startEra = activeEra.index;
+
     setStateWithRef(
       {
         ...tasksRef.current,
-        [key]: { status, addresses, endEra, currentEra },
+        [key]: { status, addresses, startEra, endEra, currentEra },
       },
       setTasks,
       tasksRef

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -276,9 +276,6 @@ export const PoolPerformanceProvider = ({
         'pool_join',
         bondedPools.map(({ addresses }) => addresses.stash)
       );
-
-      // TODO: Get subset of pools for JoinPool form and call `startGetPoolPerformance` for its key
-      // here.
     }
   }, [
     bondedPools,

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -8,7 +8,6 @@ import { useEffectIgnoreInitial } from '@w3ux/hooks';
 import Worker from 'workers/poolPerformance?worker';
 import { useNetwork } from 'contexts/Network';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
-import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useApi } from 'contexts/Api';
 import BigNumber from 'bignumber.js';
 import { mergeDeep, setStateWithRef } from '@w3ux/utils';
@@ -40,10 +39,9 @@ export const PoolPerformanceProvider = ({
   children: ReactNode;
 }) => {
   const { network } = useNetwork();
-  const { bondedPools } = useBondedPools();
   const { getPagedErasStakers } = useStaking();
   const { api, activeEra, isPagedRewardsActive } = useApi();
-  const { erasRewardPointsFetched, erasRewardPoints } = useValidators();
+  const { erasRewardPoints } = useValidators();
 
   // Store whether pool performance data is being fetched under a given key. NOTE: Requires a ref to
   // be accessed in `processEra` before re-render.
@@ -247,42 +245,6 @@ export const PoolPerformanceProvider = ({
       }
     }
   };
-
-  // Trigger worker to calculate pool reward data for garaphs once:
-  //
-  // - active era is synced.
-  // - era reward points are fetched.
-  // - bonded pools have been fetched.
-  //
-  // Re-calculates when any of the above change.
-  useEffectIgnoreInitial(() => {
-    if (
-      api &&
-      bondedPools.length &&
-      activeEra.index.isGreaterThan(0) &&
-      erasRewardPointsFetched === 'synced' &&
-      getPerformanceFetchedKey('pool_join')?.status === 'unsynced'
-    ) {
-      // Generate a subset of pools to fetch performance data for. TODO: Send pools to JoinPool
-      // canvas and only select those. Move this logic to a separate context.
-      // const poolJoinSelection = shuffle(
-      //   bondedPools
-      //     .filter(({ state }) => state === 'Open')
-      //     .map(({ addresses }) => addresses.stash)
-      // ).slice(0, 25);
-      // console.log(poolJoinSelection);
-
-      startGetPoolPerformance(
-        'pool_join',
-        bondedPools.map(({ addresses }) => addresses.stash)
-      );
-    }
-  }, [
-    bondedPools,
-    activeEra,
-    erasRewardPointsFetched,
-    getPerformanceFetchedKey('pool_join'),
-  ]);
 
   // Reset state data on network change.
   useEffectIgnoreInitial(() => {

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -116,8 +116,13 @@ export const PoolPerformanceProvider = ({
     key: PoolRewardPointsBatchKey,
     addresses: string[]
   ) => {
-    setPerformanceFetchedKey(key, 'syncing', addresses);
+    // Set as synced and exit early if there are no addresses to process.
+    if (!addresses.length) {
+      setPerformanceFetchedKey(key, 'synced', addresses);
+      return;
+    }
 
+    setPerformanceFetchedKey(key, 'syncing', addresses);
     setFinishEra(
       BigNumber.max(activeEra.index.minus(MaxEraRewardPointsEras), 1)
     );
@@ -207,6 +212,9 @@ export const PoolPerformanceProvider = ({
         'pool_list',
         bondedPools.map(({ addresses }) => addresses.stash)
       );
+
+      // TODO: Get subset of pools for JoinPool form and call `startGetPoolPerformance` for its key
+      // here.
     }
   }, [
     bondedPools,

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -11,7 +11,7 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useApi } from 'contexts/Api';
 import BigNumber from 'bignumber.js';
-import { mergeDeep, setStateWithRef, shuffle } from '@w3ux/utils';
+import { mergeDeep, setStateWithRef } from '@w3ux/utils';
 import { useStaking } from 'contexts/Staking';
 import { formatRawExposures } from 'contexts/Staking/Utils';
 import type {
@@ -265,12 +265,12 @@ export const PoolPerformanceProvider = ({
     ) {
       // Generate a subset of pools to fetch performance data for. TODO: Send pools to JoinPool
       // canvas and only select those. Move this logic to a separate context.
-      const poolJoinSelection = shuffle(
-        bondedPools
-          .filter(({ state }) => state === 'Open')
-          .map(({ addresses }) => addresses.stash)
-      ).slice(0, 25);
-      console.log(poolJoinSelection);
+      // const poolJoinSelection = shuffle(
+      //   bondedPools
+      //     .filter(({ state }) => state === 'Open')
+      //     .map(({ addresses }) => addresses.stash)
+      // ).slice(0, 25);
+      // console.log(poolJoinSelection);
 
       startGetPoolPerformance(
         'pool_join',

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -238,6 +238,7 @@ export const PoolPerformanceProvider = ({
         getPerformanceFetchedKey,
         setPerformanceFetchedKey,
         updatePerformanceFetchedKey,
+        startGetPoolPerformance,
       }}
     >
       {children}

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -11,7 +11,7 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useApi } from 'contexts/Api';
 import BigNumber from 'bignumber.js';
-import { mergeDeep, setStateWithRef } from '@w3ux/utils';
+import { mergeDeep, setStateWithRef, shuffle } from '@w3ux/utils';
 import { useStaking } from 'contexts/Staking';
 import { formatRawExposures } from 'contexts/Staking/Utils';
 import type {
@@ -261,10 +261,19 @@ export const PoolPerformanceProvider = ({
       bondedPools.length &&
       activeEra.index.isGreaterThan(0) &&
       erasRewardPointsFetched === 'synced' &&
-      getPerformanceFetchedKey('pool_list')?.status === 'unsynced'
+      getPerformanceFetchedKey('pool_join')?.status === 'unsynced'
     ) {
+      // Generate a subset of pools to fetch performance data for. TODO: Send pools to JoinPool
+      // canvas and only select those. Move this logic to a separate context.
+      const poolJoinSelection = shuffle(
+        bondedPools
+          .filter(({ state }) => state === 'Open')
+          .map(({ addresses }) => addresses.stash)
+      ).slice(0, 25);
+      console.log(poolJoinSelection);
+
       startGetPoolPerformance(
-        'pool_list',
+        'pool_join',
         bondedPools.map(({ addresses }) => addresses.stash)
       );
 
@@ -275,7 +284,7 @@ export const PoolPerformanceProvider = ({
     bondedPools,
     activeEra,
     erasRewardPointsFetched,
-    getPerformanceFetchedKey('pool_list'),
+    getPerformanceFetchedKey('pool_join'),
   ]);
 
   // Reset state data on network change.

--- a/src/contexts/Pools/PoolPerformance/index.tsx
+++ b/src/contexts/Pools/PoolPerformance/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ReactNode } from 'react';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useRef, useState } from 'react';
 import { MaxEraRewardPointsEras } from 'consts';
 import { useEffectIgnoreInitial } from '@w3ux/hooks';
 import Worker from 'workers/poolPerformance?worker';
@@ -16,6 +16,7 @@ import { useStaking } from 'contexts/Staking';
 import { formatRawExposures } from 'contexts/Staking/Utils';
 import type {
   PoolPerformanceContextInterface,
+  PoolPerformanceFetched,
   PoolRewardPoints,
   PoolRewardPointsBatch,
   PoolRewardPointsBatchKey,
@@ -41,6 +42,24 @@ export const PoolPerformanceProvider = ({
   const { api, activeEra, isPagedRewardsActive } = useApi();
   const { erasRewardPointsFetched, erasRewardPoints } = useValidators();
 
+  // Store whether pool performance data is being fetched under a given key.
+  const performanceFetched = useRef<PoolPerformanceFetched>({});
+
+  // Gets whether pool performance data is being fetched under a given key.
+  const getPerformanceFetchedKey = (key: PoolRewardPointsBatchKey) =>
+    performanceFetched.current[key] || false;
+
+  // Sets whether pool performance data is being fetched under a given key.
+  const setPerformanceFetchedKey = (
+    key: PoolRewardPointsBatchKey,
+    fetched: boolean
+  ) => {
+    performanceFetched.current = {
+      ...performanceFetched.current,
+      [key]: fetched,
+    };
+  };
+
   // Store whether pool performance data is being fetched.
   const [poolRewardPointsFetched, setPoolRewardPointsFetched] =
     useState<Sync>('unsynced');
@@ -49,7 +68,7 @@ export const PoolPerformanceProvider = ({
   const [poolRewardPoints, setPoolRewardPointsState] =
     useState<PoolRewardPointsBatch>({});
 
-  // Getes a batch of pool reward points, or returns an empty object otherwise.
+  // Gets a batch of pool reward points, or returns an empty object otherwise.
   const getPoolRewardPoints = (key: PoolRewardPointsBatchKey) =>
     poolRewardPoints[key] || {};
 
@@ -171,6 +190,8 @@ export const PoolPerformanceProvider = ({
       value={{
         poolRewardPointsFetched,
         getPoolRewardPoints,
+        getPerformanceFetchedKey,
+        setPerformanceFetchedKey,
       }}
     >
       {children}

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -32,6 +32,7 @@ export type PoolPerformanceTasks = Partial<
 export interface PoolPerformanceTaskStatus {
   status: Sync;
   addresses: string[];
+  startEra: BigNumber;
   currentEra: BigNumber;
   endEra: BigNumber;
 }

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -39,7 +39,7 @@ export interface PoolPerformanceFetchingStatus {
  */
 
 // Supported reward points batch keys.
-export type PoolRewardPointsBatchKey = 'pool_list' | 'join_pool';
+export type PoolRewardPointsBatchKey = 'pool_list' | 'pool_page' | 'join_pool';
 
 // Pool reward batches, keyed by batch key.
 export type PoolRewardPointsBatch = Partial<Record<string, PoolRewardPoints>>;

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -11,7 +11,7 @@ export interface PoolPerformanceContextInterface {
   setPerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
     status: Sync,
-    hash: string
+    addresses: string[]
   ) => void;
   updatePerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
@@ -27,7 +27,7 @@ export type PoolPerformanceFetched = Partial<
 // Performance fetching status.
 export interface PoolPerformanceFetchingStatus {
   status: Sync;
-  hash: string;
+  addresses: string[];
 }
 
 /*

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -5,34 +5,31 @@ import type BigNumber from 'bignumber.js';
 import type { Sync } from 'types';
 
 export interface PoolPerformanceContextInterface {
-  getPoolRewardPoints: (key: PoolRewardPointsBatchKey) => PoolRewardPoints;
-  getPerformanceFetchedKey: (
-    key: PoolRewardPointsBatchKey
-  ) => PoolPerformanceFetchingStatus;
-  setPerformanceFetchedKey: (
-    key: PoolRewardPointsBatchKey,
+  getPoolRewardPoints: (key: PoolRewardPointsKey) => PoolRewardPoints;
+  getPoolPerformanceTask: (
+    key: PoolRewardPointsKey
+  ) => PoolPerformanceTaskStatus;
+  setNewPoolPerformanceTask: (
+    key: PoolRewardPointsKey,
     status: Sync,
     addresses: string[],
     currentEra: BigNumber,
     endEra: BigNumber
   ) => void;
-  updatePerformanceFetchedKey: (
-    key: PoolRewardPointsBatchKey,
-    status: Sync
-  ) => void;
-  startGetPoolPerformance: (
-    key: PoolRewardPointsBatchKey,
+  updatePoolPerformanceTask: (key: PoolRewardPointsKey, status: Sync) => void;
+  startPoolRewardPointsFetch: (
+    key: PoolRewardPointsKey,
     addresses: string[]
   ) => void;
 }
 
 // Fetching status for keys.
-export type PoolPerformanceFetched = Partial<
-  Record<PoolRewardPointsBatchKey, PoolPerformanceFetchingStatus>
+export type PoolPerformanceTasks = Partial<
+  Record<PoolRewardPointsKey, PoolPerformanceTaskStatus>
 >;
 
 // Performance fetching status.
-export interface PoolPerformanceFetchingStatus {
+export interface PoolPerformanceTaskStatus {
   status: Sync;
   addresses: string[];
   currentEra: BigNumber;
@@ -44,10 +41,10 @@ export interface PoolPerformanceFetchingStatus {
  */
 
 // Supported reward points batch keys.
-export type PoolRewardPointsBatchKey = 'pool_join' | 'pool_page';
+export type PoolRewardPointsKey = 'pool_join' | 'pool_page';
 
 // Pool reward batches, keyed by batch key.
-export type PoolRewardPointsBatch = Partial<Record<string, PoolRewardPoints>>;
+export type PoolRewardPointsMap = Partial<Record<string, PoolRewardPoints>>;
 
 // Pool reward points are keyed by era, then by pool address.
 

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -5,17 +5,30 @@ import type { Sync } from 'types';
 
 export interface PoolPerformanceContextInterface {
   getPoolRewardPoints: (key: PoolRewardPointsBatchKey) => PoolRewardPoints;
-  getPerformanceFetchedKey: (key: PoolRewardPointsBatchKey) => Sync;
+  getPerformanceFetchedKey: (
+    key: PoolRewardPointsBatchKey
+  ) => PoolPerformanceFetchingStatus;
   setPerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
-    fetched: Sync
+    status: Sync,
+    hash: string
+  ) => void;
+  updatePerformanceFetchedKey: (
+    key: PoolRewardPointsBatchKey,
+    status: Sync
   ) => void;
 }
 
 // Fetching status for keys.
 export type PoolPerformanceFetched = Partial<
-  Record<PoolRewardPointsBatchKey, Sync>
+  Record<PoolRewardPointsBatchKey, PoolPerformanceFetchingStatus>
 >;
+
+// Performance fetching status.
+export interface PoolPerformanceFetchingStatus {
+  status: Sync;
+  hash: string;
+}
 
 /*
  * Batch Key -> Pool Address -> Era -> Points.

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -1,9 +1,35 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyJson, Sync } from 'types';
+import type { Sync } from 'types';
 
 export interface PoolPerformanceContextInterface {
   poolRewardPointsFetched: Sync;
-  poolRewardPoints: AnyJson;
+  getPoolRewardPoints: (key: PoolRewardPointsBatchKey) => PoolRewardPoints;
 }
+
+/*
+ * Batch Key -> Pool Address -> Era -> Points.
+ */
+
+// Supported reward points batch keys.
+
+export type PoolRewardPointsBatchKey = 'pool_list' | 'join_pool';
+
+// Pool reward batches, keyed by batch key.
+
+export type PoolRewardPointsBatch = Partial<Record<string, PoolRewardPoints>>;
+
+// Pool reward points are keyed by era, then by pool address.
+
+export type PoolRewardPoints = Record<PoolAddress, PointsByEra>;
+
+export type PointsByEra = Record<EraKey, EraPoints>;
+
+// Type aliases to better understand pool reward records.
+
+export type PoolAddress = string;
+
+export type EraKey = number;
+
+export type EraPoints = string;

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -6,18 +6,26 @@ import type { Sync } from 'types';
 export interface PoolPerformanceContextInterface {
   poolRewardPointsFetched: Sync;
   getPoolRewardPoints: (key: PoolRewardPointsBatchKey) => PoolRewardPoints;
+  getPerformanceFetchedKey: (key: PoolRewardPointsBatchKey) => boolean;
+  setPerformanceFetchedKey: (
+    key: PoolRewardPointsBatchKey,
+    fetched: boolean
+  ) => void;
 }
+
+// Fetching status for keys.
+export type PoolPerformanceFetched = Partial<
+  Record<PoolRewardPointsBatchKey, boolean>
+>;
 
 /*
  * Batch Key -> Pool Address -> Era -> Points.
  */
 
 // Supported reward points batch keys.
-
 export type PoolRewardPointsBatchKey = 'pool_list' | 'join_pool';
 
 // Pool reward batches, keyed by batch key.
-
 export type PoolRewardPointsBatch = Partial<Record<string, PoolRewardPoints>>;
 
 // Pool reward points are keyed by era, then by pool address.

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -17,6 +17,10 @@ export interface PoolPerformanceContextInterface {
     key: PoolRewardPointsBatchKey,
     status: Sync
   ) => void;
+  startGetPoolPerformance: (
+    key: PoolRewardPointsBatchKey,
+    addresses: string[]
+  ) => void;
 }
 
 // Fetching status for keys.

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -4,18 +4,17 @@
 import type { Sync } from 'types';
 
 export interface PoolPerformanceContextInterface {
-  poolRewardPointsFetched: Sync;
   getPoolRewardPoints: (key: PoolRewardPointsBatchKey) => PoolRewardPoints;
-  getPerformanceFetchedKey: (key: PoolRewardPointsBatchKey) => boolean;
+  getPerformanceFetchedKey: (key: PoolRewardPointsBatchKey) => Sync;
   setPerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
-    fetched: boolean
+    fetched: Sync
   ) => void;
 }
 
 // Fetching status for keys.
 export type PoolPerformanceFetched = Partial<
-  Record<PoolRewardPointsBatchKey, boolean>
+  Record<PoolRewardPointsBatchKey, Sync>
 >;
 
 /*

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -44,7 +44,7 @@ export interface PoolPerformanceFetchingStatus {
  */
 
 // Supported reward points batch keys.
-export type PoolRewardPointsBatchKey = 'pool_list' | 'pool_page' | 'join_pool';
+export type PoolRewardPointsBatchKey = 'pool_join' | 'pool_page';
 
 // Pool reward batches, keyed by batch key.
 export type PoolRewardPointsBatch = Partial<Record<string, PoolRewardPoints>>;

--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type BigNumber from 'bignumber.js';
 import type { Sync } from 'types';
 
 export interface PoolPerformanceContextInterface {
@@ -11,7 +12,9 @@ export interface PoolPerformanceContextInterface {
   setPerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
     status: Sync,
-    addresses: string[]
+    addresses: string[],
+    currentEra: BigNumber,
+    endEra: BigNumber
   ) => void;
   updatePerformanceFetchedKey: (
     key: PoolRewardPointsBatchKey,
@@ -32,6 +35,8 @@ export type PoolPerformanceFetched = Partial<
 export interface PoolPerformanceFetchingStatus {
   status: Sync;
   addresses: string[];
+  currentEra: BigNumber;
+  endEra: BigNumber;
 }
 
 /*

--- a/src/controllers/SubscanController/index.ts
+++ b/src/controllers/SubscanController/index.ts
@@ -12,7 +12,7 @@ import type {
 import type { Locale } from 'date-fns';
 import { format, fromUnixTime, getUnixTime, subDays } from 'date-fns';
 import type { PoolMember } from 'contexts/Pools/PoolMembers/types';
-import { listItemsPerPage } from 'library/List/defaults';
+import { poolMembersPerPage } from 'library/List/defaults';
 
 export class SubscanController {
   // ------------------------------------------------------
@@ -160,7 +160,7 @@ export class SubscanController {
   ): Promise<PoolMember[]> => {
     const result = await this.makeRequest(this.ENDPOINTS.poolMembers, {
       pool_id: poolId,
-      row: listItemsPerPage,
+      row: poolMembersPerPage,
       page: page - 1,
     });
     if (!result?.list) {

--- a/src/kits/Structure/Tx/Signer.tsx
+++ b/src/kits/Structure/Tx/Signer.tsx
@@ -23,7 +23,7 @@ export const Signer = ({
         / &nbsp;
         <FontAwesomeIcon
           icon={faWarning}
-          className="danger"
+          className="danger icon"
           transform="shrink-1"
         />
         <span className="danger">{dangerMessage}</span>

--- a/src/kits/Structure/Tx/Wrapper.ts
+++ b/src/kits/Structure/Tx/Wrapper.ts
@@ -127,13 +127,13 @@ export const SignerWrapper = styled.p`
 
   .not-enough {
     margin-left: 0.5rem;
-  }
 
-  .danger {
-    color: var(--status-danger-color);
-  }
+    > .danger {
+      color: var(--status-danger-color);
+    }
 
-  > .icon {
-    margin-right: 0.3rem;
+    > .icon {
+      margin-right: 0.3rem;
+    }
   }
 `;

--- a/src/library/CallToAction/index.tsx
+++ b/src/library/CallToAction/index.tsx
@@ -37,10 +37,20 @@ export const CallToActionWrapper = styled.div`
 
       &:nth-child(1) {
         flex-grow: 1;
-
         @media (min-width: 651px) {
           border-right: 1px solid var(--border-primary-color);
           padding-right: 1rem;
+
+          &.fixedWidth {
+            flex-grow: 0;
+            flex-basis: 70%;
+          }
+        }
+
+        @media (max-width: 650px) {
+          &.fixedWidth {
+            flex-basis: 100%;
+          }
         }
       }
 
@@ -170,8 +180,68 @@ export const CallToActionWrapper = styled.div`
             justify-content: center;
             flex-wrap: nowrap;
             font-size: 1.3rem;
+            line-height: 1.3rem;
             width: 100%;
 
+            .counter {
+              font-family: InterBold, sans-serif;
+              font-size: 1.1rem;
+              margin-left: 0.75rem;
+            }
+
+            .loader {
+              height: 0.8rem;
+              margin-left: 1.6rem;
+              aspect-ratio: 5;
+              --_g: no-repeat radial-gradient(farthest-side, white 94%, #0000);
+              background: var(--_g), var(--_g), var(--_g), var(--_g);
+              background-size: 20% 100%;
+              animation:
+                l40-1 0.75s infinite alternate,
+                l40-2 1.5s infinite alternate;
+            }
+            @keyframes l40-1 {
+              0%,
+              10% {
+                background-position:
+                  0 0,
+                  0 0,
+                  0 0,
+                  0 0;
+              }
+              33% {
+                background-position:
+                  0 0,
+                  calc(100% / 3) 0,
+                  calc(100% / 3) 0,
+                  calc(100% / 3) 0;
+              }
+              66% {
+                background-position:
+                  0 0,
+                  calc(100% / 3) 0,
+                  calc(2 * 100% / 3) 0,
+                  calc(2 * 100% / 3) 0;
+              }
+              90%,
+              100% {
+                background-position:
+                  0 0,
+                  calc(100% / 3) 0,
+                  calc(2 * 100% / 3) 0,
+                  100% 0;
+              }
+            }
+            @keyframes l40-2 {
+              0%,
+              49.99% {
+                transform: scale(1);
+              }
+              50%,
+              100% {
+                transform: scale(-1);
+              }
+            }
             &:disabled {
               cursor: default;
             }

--- a/src/library/CallToAction/index.tsx
+++ b/src/library/CallToAction/index.tsx
@@ -250,6 +250,12 @@ export const CallToActionWrapper = styled.div`
               margin: 0 0.75rem;
             }
           }
+
+          &.inactive {
+            > button {
+              cursor: default;
+            }
+          }
         }
       }
     }

--- a/src/library/Filter/Tabs.tsx
+++ b/src/library/Filter/Tabs.tsx
@@ -1,42 +1,47 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useState } from 'react';
 import { useFilters } from 'contexts/Filters';
 import { TabsWrapper, TabWrapper } from './Wrappers';
 import type { FilterTabsProps } from './types';
+import { useBondedPools } from 'contexts/Pools/BondedPools';
+import type { PoolTab } from 'contexts/Pools/BondedPools/types';
 
-export const Tabs = ({ config, activeIndex }: FilterTabsProps) => {
+export const Tabs = ({ config }: FilterTabsProps) => {
   const { resetFilters, setMultiFilters } = useFilters();
+  const { poolListActiveTab, setPoolListActiveTab } = useBondedPools();
 
-  const [active, setActive] = useState<number>(activeIndex);
-
+  console.log(config);
   return (
     <TabsWrapper>
-      {config.map((c, i) => (
-        <TabWrapper
-          key={`pools_tab_filter_${i}`}
-          $active={i === active}
-          disabled={i === active}
-          onClick={() => {
-            if (c.includes?.length) {
-              setMultiFilters('include', 'pools', c.includes, true);
-            } else {
-              resetFilters('include', 'pools');
-            }
+      {config.map((c, i) => {
+        const label = c.label as PoolTab;
 
-            if (c.excludes?.length) {
-              setMultiFilters('exclude', 'pools', c.excludes, true);
-            } else {
-              resetFilters('exclude', 'pools');
-            }
+        return (
+          <TabWrapper
+            key={`pools_tab_filter_${i}`}
+            $active={label === poolListActiveTab}
+            disabled={label === poolListActiveTab}
+            onClick={() => {
+              if (c.includes?.length) {
+                setMultiFilters('include', 'pools', c.includes, true);
+              } else {
+                resetFilters('include', 'pools');
+              }
 
-            setActive(i);
-          }}
-        >
-          {c.label}
-        </TabWrapper>
-      ))}
+              if (c.excludes?.length) {
+                setMultiFilters('exclude', 'pools', c.excludes, true);
+              } else {
+                resetFilters('exclude', 'pools');
+              }
+
+              setPoolListActiveTab(label);
+            }}
+          >
+            {label}
+          </TabWrapper>
+        );
+      })}
     </TabsWrapper>
   );
 };

--- a/src/library/Filter/Tabs.tsx
+++ b/src/library/Filter/Tabs.tsx
@@ -11,7 +11,6 @@ export const Tabs = ({ config }: FilterTabsProps) => {
   const { resetFilters, setMultiFilters } = useFilters();
   const { poolListActiveTab, setPoolListActiveTab } = useBondedPools();
 
-  console.log(config);
   return (
     <TabsWrapper>
       {config.map((c, i) => {

--- a/src/library/Filter/types.ts
+++ b/src/library/Filter/types.ts
@@ -19,7 +19,6 @@ export interface LargerFilterItemProps {
 }
 export interface FilterTabsProps {
   config: FilterConfig[];
-  activeIndex: number;
 }
 
 export interface FilterConfig {

--- a/src/library/List/defaults.ts
+++ b/src/library/List/defaults.ts
@@ -16,8 +16,5 @@ export const defaultContext: ListContextInterface = {
   selectToggleable: true,
 };
 
-// Total list items to show per page.
+// The default amount of list items to show per page.
 export const listItemsPerPage = 25;
-
-// If throttling a list of items, how many items to show per batch.
-export const listItemsPerBatch = 25;

--- a/src/library/List/defaults.ts
+++ b/src/library/List/defaults.ts
@@ -16,5 +16,14 @@ export const defaultContext: ListContextInterface = {
   selectToggleable: true,
 };
 
-// The default amount of list items to show per page.
-export const listItemsPerPage = 25;
+// The amount of pools per page.
+export const poolsPerPage = 21;
+
+// The amount of validators per page.
+export const validatorsPerPage = 30;
+
+// The amount of payouts per page.
+export const payoutsPerPage = 50;
+
+// The amount of pool members per page.
+export const poolMembersPerPage = 50;

--- a/src/library/Nominations/index.tsx
+++ b/src/library/Nominations/index.tsx
@@ -143,7 +143,6 @@ export const Nominations = ({
           format="nomination"
           refetchOnListUpdate
           allowMoreCols
-          disableThrottle
           allowListFormat={false}
         />
       ) : poolDestroying ? (

--- a/src/library/Pool/Rewards.tsx
+++ b/src/library/Pool/Rewards.tsx
@@ -24,7 +24,8 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
   const { isReady } = useApi();
   const { setTooltipTextAndOpen } = useTooltip();
   const { eraPointsBoundaries } = useValidators();
-  const { getPoolRewardPoints, poolRewardPointsFetched } = usePoolPerformance();
+  const { getPoolRewardPoints, getPerformanceFetchedKey } =
+    usePoolPerformance();
 
   const poolRewardPoints = getPoolRewardPoints('pool_list');
 
@@ -40,7 +41,8 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
   const prefilledPoints = prefillEraPoints(Object.values(normalisedPoints));
 
   const empty = Object.values(poolRewardPoints).length === 0;
-  const syncing = !isReady || poolRewardPointsFetched !== 'synced';
+  const syncing =
+    !isReady || getPerformanceFetchedKey('pool_list') !== 'synced';
   const tooltipText = `${MaxEraRewardPointsEras} ${t('dayPoolPerformance')}`;
 
   return (

--- a/src/library/Pool/Rewards.tsx
+++ b/src/library/Pool/Rewards.tsx
@@ -24,8 +24,7 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
   const { isReady } = useApi();
   const { setTooltipTextAndOpen } = useTooltip();
   const { eraPointsBoundaries } = useValidators();
-  const { getPoolRewardPoints, getPerformanceFetchedKey } =
-    usePoolPerformance();
+  const { getPoolRewardPoints, getPoolPerformanceTask } = usePoolPerformance();
 
   const poolRewardPoints = getPoolRewardPoints('pool_page');
 
@@ -42,7 +41,7 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
 
   const empty = Object.values(poolRewardPoints).length === 0;
   const syncing =
-    !isReady || getPerformanceFetchedKey('pool_page').status !== 'synced';
+    !isReady || getPoolPerformanceTask('pool_page').status !== 'synced';
   const tooltipText = `${MaxEraRewardPointsEras} ${t('dayPoolPerformance')}`;
 
   return (

--- a/src/library/Pool/Rewards.tsx
+++ b/src/library/Pool/Rewards.tsx
@@ -27,7 +27,7 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
   const { getPoolRewardPoints, getPerformanceFetchedKey } =
     usePoolPerformance();
 
-  const poolRewardPoints = getPoolRewardPoints('pool_list');
+  const poolRewardPoints = getPoolRewardPoints('pool_page');
 
   const eraRewardPoints = Object.fromEntries(
     Object.entries(poolRewardPoints[address] || {}).map(([k, v]: AnyJson) => [
@@ -42,7 +42,7 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
 
   const empty = Object.values(poolRewardPoints).length === 0;
   const syncing =
-    !isReady || getPerformanceFetchedKey('pool_list').status !== 'synced';
+    !isReady || getPerformanceFetchedKey('pool_page').status !== 'synced';
   const tooltipText = `${MaxEraRewardPointsEras} ${t('dayPoolPerformance')}`;
 
   return (

--- a/src/library/Pool/Rewards.tsx
+++ b/src/library/Pool/Rewards.tsx
@@ -24,7 +24,9 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
   const { isReady } = useApi();
   const { setTooltipTextAndOpen } = useTooltip();
   const { eraPointsBoundaries } = useValidators();
-  const { poolRewardPoints, poolRewardPointsFetched } = usePoolPerformance();
+  const { getPoolRewardPoints, poolRewardPointsFetched } = usePoolPerformance();
+
+  const poolRewardPoints = getPoolRewardPoints('pool_list');
 
   const eraRewardPoints = Object.fromEntries(
     Object.entries(poolRewardPoints[address] || {}).map(([k, v]: AnyJson) => [

--- a/src/library/Pool/Rewards.tsx
+++ b/src/library/Pool/Rewards.tsx
@@ -42,7 +42,7 @@ export const Rewards = ({ address, displayFor = 'default' }: RewardProps) => {
 
   const empty = Object.values(poolRewardPoints).length === 0;
   const syncing =
-    !isReady || getPerformanceFetchedKey('pool_list') !== 'synced';
+    !isReady || getPerformanceFetchedKey('pool_list').status !== 'synced';
   const tooltipText = `${MaxEraRewardPointsEras} ${t('dayPoolPerformance')}`;
 
   return (

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -123,12 +123,12 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      setPerformanceFetchedKey('pool_list', true);
+      setPerformanceFetchedKey('pool_list', 'syncing');
       console.log('Fetch pool performance data batch.', listPools.length, page);
 
       // TODO: replace with actual fetch call.
       setTimeout(() => {
-        setPerformanceFetchedKey('pool_list', false);
+        setPerformanceFetchedKey('pool_list', 'synced');
       }, 5000);
     }
   }, [JSON.stringify(listPools), page, erasRewardPointsFetched, bondedPools]);

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -123,6 +123,8 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
+      // TODO: if no pools provided, remove the fetch status.
+
       console.log('Fetch pool performance data batch.', listPools.length, page);
 
       // TODO: replace with actual fetch call.

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -99,13 +99,13 @@ export const PoolList = ({
 
   const handleSearchChange = (e: FormEvent<HTMLInputElement>) => {
     const newValue = e.currentTarget.value;
-    let filteredPools = Object.assign(poolsDefault);
+    let filteredPools: BondedPool[] = Object.assign(poolsDefault);
     filteredPools = applyFilter(includes, excludes, filteredPools);
     filteredPools = poolSearchFilter(filteredPools, newValue);
 
     // ensure no duplicates
     filteredPools = filteredPools.filter(
-      (value: BondedPool, index: number, self: BondedPool[]) =>
+      (value, index: number, self) =>
         index === self.findIndex((i) => i.id === value.id)
     );
     setPage(1);

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -123,8 +123,6 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      // TODO: if no pools provided, remove the fetch status.
-
       console.log('Fetch pool performance data batch.', listPools.length, page);
 
       // TODO: replace with actual fetch call.

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -5,7 +5,7 @@ import { faBars, faGripVertical } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { motion } from 'framer-motion';
 import type { FormEvent } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { listItemsPerPage } from 'library/List/defaults';
 import { useFilters } from 'contexts/Filters';
@@ -31,6 +31,7 @@ import { useSyncing } from 'hooks/useSyncing';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { useApi } from 'contexts/Api';
 import { useEffectIgnoreInitial } from '@w3ux/hooks';
+import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 
 export const PoolList = ({
   allowMoreCols,
@@ -50,6 +51,7 @@ export const PoolList = ({
   const { applyFilter } = usePoolFilters();
   const { erasRewardPointsFetched } = useValidators();
   const { listFormat, setListFormat } = usePoolList();
+  const { setPerformanceFetchedKey } = usePoolPerformance();
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters();
   const { poolSearchFilter, poolsNominations, bondedPools } = useBondedPools();
 
@@ -119,14 +121,15 @@ export const PoolList = ({
 
   // Fetch pool performance data when list items or page changes. Requires `erasRewardPoints` and
   // `bondedPools` to be fetched.
-  const fetchingPerformanceData = useRef<boolean>(false);
-
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      fetchingPerformanceData.current = true;
+      setPerformanceFetchedKey('pool_list', true);
       console.log('Fetch pool performance data batch.', listPools.length, page);
+
       // TODO: replace with actual fetch call.
-      setTimeout(() => (fetchingPerformanceData.current = false), 1000);
+      setTimeout(() => {
+        setPerformanceFetchedKey('pool_list', false);
+      }, 5000);
     }
   }, [JSON.stringify(listPools), page, erasRewardPointsFetched, bondedPools]);
 
@@ -190,7 +193,6 @@ export const PoolList = ({
                   excludes: [],
                 },
               ]}
-              activeIndex={1}
             />
           </div>
           <div>

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -7,7 +7,7 @@ import { motion } from 'framer-motion';
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listItemsPerPage } from 'library/List/defaults';
+import { poolsPerPage } from 'library/List/defaults';
 import { useFilters } from 'contexts/Filters';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useTheme } from 'contexts/Themes';
@@ -82,12 +82,12 @@ export const PoolList = ({
   const [synced, setSynced] = useState<boolean>(false);
 
   // pagination
-  const totalPages = Math.ceil(listPools.length / listItemsPerPage);
-  const pageEnd = page * listItemsPerPage - 1;
-  const pageStart = pageEnd - (listItemsPerPage - 1);
+  const totalPages = Math.ceil(listPools.length / poolsPerPage);
+  const pageEnd = page * poolsPerPage - 1;
+  const pageStart = pageEnd - (poolsPerPage - 1);
 
   // get paged subset of list items.
-  const poolsToDisplay = listPools.slice(pageStart).slice(0, listItemsPerPage);
+  const poolsToDisplay = listPools.slice(pageStart).slice(0, poolsPerPage);
 
   // Handle resetting of pool list when provided pools change.
   const resetPoolList = () => {

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -51,7 +51,7 @@ export const PoolList = ({
   const { applyFilter } = usePoolFilters();
   const { erasRewardPointsFetched } = useValidators();
   const { listFormat, setListFormat } = usePoolList();
-  const { startGetPoolPerformance } = usePoolPerformance();
+  const { startPoolRewardPointsFetch } = usePoolPerformance();
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters();
   const { poolSearchFilter, poolsNominations, bondedPools } = useBondedPools();
 
@@ -123,7 +123,7 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      startGetPoolPerformance(
+      startPoolRewardPointsFetch(
         'pool_page',
         poolsToDisplay.map(({ addresses }) => addresses.stash)
       );

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -51,7 +51,7 @@ export const PoolList = ({
   const { applyFilter } = usePoolFilters();
   const { erasRewardPointsFetched } = useValidators();
   const { listFormat, setListFormat } = usePoolList();
-  const { updatePerformanceFetchedKey } = usePoolPerformance();
+  const { startGetPoolPerformance } = usePoolPerformance();
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters();
   const { poolSearchFilter, poolsNominations, bondedPools } = useBondedPools();
 
@@ -86,7 +86,7 @@ export const PoolList = ({
   const pageEnd = page * listItemsPerPage - 1;
   const pageStart = pageEnd - (listItemsPerPage - 1);
 
-  // get throttled subset or entire list
+  // get paged subset of list items.
   const poolsToDisplay = listPools.slice(pageStart).slice(0, listItemsPerPage);
 
   // Handle resetting of pool list when provided pools change.
@@ -123,12 +123,10 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      console.log('Fetch pool performance data batch.', listPools.length, page);
-
-      // TODO: replace with actual fetch call.
-      setTimeout(() => {
-        updatePerformanceFetchedKey('pool_list', 'synced');
-      }, 5000);
+      startGetPoolPerformance(
+        'pool_page',
+        poolsToDisplay.map(({ addresses }) => addresses.stash)
+      );
     }
   }, [JSON.stringify(listPools), page, erasRewardPointsFetched, bondedPools]);
 

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -41,17 +41,17 @@ export const PoolList = ({
   allowListFormat = true,
 }: PoolListProps) => {
   const { t } = useTranslation('library');
-  const { mode } = useTheme();
-  const { isReady, activeEra } = useApi();
   const {
     networkData: { colors },
   } = useNetwork();
+  const { mode } = useTheme();
   const { syncing } = useSyncing();
+  const { isReady, activeEra } = useApi();
   const { applyFilter } = usePoolFilters();
   const { listFormat, setListFormat } = usePoolList();
+  const { poolSearchFilter, poolsNominations } = useBondedPools();
   const { getFilters, setMultiFilters, getSearchTerm, setSearchTerm } =
     useFilters();
-  const { poolSearchFilter, poolsNominations } = useBondedPools();
 
   const includes = getFilters('include', 'pools');
   const excludes = getFilters('exclude', 'pools');
@@ -131,6 +131,13 @@ export const PoolList = ({
     setListPools(filteredPools);
     setSearchTerm('pools', newValue);
   };
+
+  // Fetch pool performance data when pools change, or when page changes. Requires
+  // `erasRewardPoints` and `bondedPools` to be fetched.
+  useEffect(() => {
+    // TODO: more dependencies, implement.
+    // console.log('fetch pool performance data batch');
+  }, [pools, page]);
 
   // Refetch list when pool list changes.
   useEffect(() => {

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -51,7 +51,7 @@ export const PoolList = ({
   const { applyFilter } = usePoolFilters();
   const { erasRewardPointsFetched } = useValidators();
   const { listFormat, setListFormat } = usePoolList();
-  const { setPerformanceFetchedKey } = usePoolPerformance();
+  const { updatePerformanceFetchedKey } = usePoolPerformance();
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters();
   const { poolSearchFilter, poolsNominations, bondedPools } = useBondedPools();
 
@@ -123,12 +123,11 @@ export const PoolList = ({
   // `bondedPools` to be fetched.
   useEffect(() => {
     if (erasRewardPointsFetched && bondedPools.length) {
-      setPerformanceFetchedKey('pool_list', 'syncing');
       console.log('Fetch pool performance data batch.', listPools.length, page);
 
       // TODO: replace with actual fetch call.
       setTimeout(() => {
-        setPerformanceFetchedKey('pool_list', 'synced');
+        updatePerformanceFetchedKey('pool_list', 'synced');
       }, 5000);
     }
   }, [JSON.stringify(listPools), page, erasRewardPointsFetched, bondedPools]);

--- a/src/library/PoolList/types.ts
+++ b/src/library/PoolList/types.ts
@@ -13,7 +13,6 @@ export interface PoolListProps {
   allowMoreCols?: boolean;
   allowSearch?: boolean;
   pagination?: boolean;
-  disableThrottle?: boolean;
   refetchOnListUpdate?: string;
   allowListFormat?: boolean;
   pools?: BondedPool[];

--- a/src/library/PoolList/types.ts
+++ b/src/library/PoolList/types.ts
@@ -16,8 +16,4 @@ export interface PoolListProps {
   refetchOnListUpdate?: string;
   allowListFormat?: boolean;
   pools?: BondedPool[];
-  defaultFilters?: {
-    includes: string[] | null;
-    excludes: string[] | null;
-  };
 }

--- a/src/library/ValidatorList/ValidatorItem/Utils.tsx
+++ b/src/library/ValidatorList/ValidatorItem/Utils.tsx
@@ -72,7 +72,7 @@ export const normaliseEraPoints = (
   return Object.fromEntries(
     Object.entries(eraPoints).map(([era, points]) => [
       era,
-      points.dividedBy(percentile).multipliedBy(0.01).toNumber(),
+      Math.min(points.dividedBy(percentile).multipliedBy(0.01).toNumber(), 1),
     ])
   );
 };

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -35,7 +35,7 @@ import { FilterHeaders } from './Filters/FilterHeaders';
 import { FilterBadges } from './Filters/FilterBadges';
 import type { NominationStatus } from './ValidatorItem/types';
 import { useSyncing } from 'hooks/useSyncing';
-import { listItemsPerPage } from 'library/List/defaults';
+import { validatorsPerPage } from 'library/List/defaults';
 
 export const ValidatorListInner = ({
   // Default list values.
@@ -163,9 +163,9 @@ export const ValidatorListInner = ({
   const [isSearching, setIsSearching] = useState<boolean>(false);
 
   // Pagination.
-  const totalPages = Math.ceil(validators.length / listItemsPerPage);
-  const pageEnd = page * listItemsPerPage - 1;
-  const pageStart = pageEnd - (listItemsPerPage - 1);
+  const totalPages = Math.ceil(validators.length / validatorsPerPage);
+  const pageEnd = page * validatorsPerPage - 1;
+  const pageStart = pageEnd - (validatorsPerPage - 1);
 
   // handle filter / order update
   const handleValidatorsFilterUpdate = (
@@ -185,7 +185,9 @@ export const ValidatorListInner = ({
   };
 
   // get throttled subset or entire list
-  const listValidators = validators.slice(pageStart).slice(0, listItemsPerPage);
+  const listValidators = validators
+    .slice(pageStart)
+    .slice(0, validatorsPerPage);
 
   // if in modal, handle resize
   const maybeHandleModalResize = () => {

--- a/src/library/ValidatorList/index.tsx
+++ b/src/library/ValidatorList/index.tsx
@@ -35,7 +35,7 @@ import { FilterHeaders } from './Filters/FilterHeaders';
 import { FilterBadges } from './Filters/FilterBadges';
 import type { NominationStatus } from './ValidatorItem/types';
 import { useSyncing } from 'hooks/useSyncing';
-import { listItemsPerBatch, listItemsPerPage } from 'library/List/defaults';
+import { listItemsPerPage } from 'library/List/defaults';
 
 export const ValidatorListInner = ({
   // Default list values.
@@ -57,9 +57,8 @@ export const ValidatorListInner = ({
   allowListFormat = true,
   defaultOrder = undefined,
   defaultFilters = undefined,
-  // Throttling and re-fetching.
+  // Re-fetching.
   alwaysRefetchValidators = false,
-  disableThrottle = false,
 }: ValidatorListProps) => {
   const { t } = useTranslation('library');
   const {
@@ -163,26 +162,10 @@ export const ValidatorListInner = ({
   // Store whether the search bar is being used.
   const [isSearching, setIsSearching] = useState<boolean>(false);
 
-  // Current render iteration.
-  const [renderIteration, setRenderIterationState] = useState<number>(1);
-
-  // Render throttle iteration.
-  const renderIterationRef = useRef(renderIteration);
-  const setRenderIteration = (iter: number) => {
-    renderIterationRef.current = iter;
-    setRenderIterationState(iter);
-  };
-
   // Pagination.
   const totalPages = Math.ceil(validators.length / listItemsPerPage);
   const pageEnd = page * listItemsPerPage - 1;
   const pageStart = pageEnd - (listItemsPerPage - 1);
-
-  // Render batch.
-  const batchEnd = Math.min(
-    renderIteration * listItemsPerBatch - 1,
-    listItemsPerPage
-  );
 
   // handle filter / order update
   const handleValidatorsFilterUpdate = (
@@ -198,14 +181,11 @@ export const ValidatorListInner = ({
       }
       setValidators(filteredValidators);
       setPage(1);
-      setRenderIteration(1);
     }
   };
 
   // get throttled subset or entire list
-  const listValidators = disableThrottle
-    ? validators
-    : validators.slice(pageStart).slice(0, listItemsPerPage);
+  const listValidators = validators.slice(pageStart).slice(0, listItemsPerPage);
 
   // if in modal, handle resize
   const maybeHandleModalResize = () => {
@@ -233,7 +213,6 @@ export const ValidatorListInner = ({
     setValidators(filteredValidators);
     setPage(1);
     setIsSearching(e.currentTarget.value !== '');
-    setRenderIteration(1);
     setSearchTerm('validators', newValue);
   };
 
@@ -300,15 +279,6 @@ export const ValidatorListInner = ({
     }
   }, [isReady, activeEra.index, syncing, fetched]);
 
-  // Control render throttle.
-  useEffect(() => {
-    if (!(batchEnd >= pageEnd || disableThrottle)) {
-      setTimeout(() => {
-        setRenderIteration(renderIterationRef.current + 1);
-      }, 50);
-    }
-  }, [renderIterationRef.current]);
-
   // Trigger `onSelected` when selection changes.
   useEffect(() => {
     if (onSelected) {
@@ -326,7 +296,7 @@ export const ValidatorListInner = ({
   // Handle modal resize on list format change.
   useEffect(() => {
     maybeHandleModalResize();
-  }, [listFormat, renderIteration, validators, page]);
+  }, [listFormat, validators, page]);
 
   return (
     <ListWrapper>

--- a/src/library/ValidatorList/types.ts
+++ b/src/library/ValidatorList/types.ts
@@ -31,7 +31,6 @@ export interface ValidatorListProps {
   alwaysRefetchValidators?: boolean;
   defaultFilters?: AnyJson;
   defaultOrder?: string;
-  disableThrottle?: boolean;
   selectActive?: boolean;
   selectToggleable?: boolean;
   refetchOnListUpdate?: boolean;

--- a/src/locale/cn/library.json
+++ b/src/locale/cn/library.json
@@ -165,6 +165,7 @@
     "proxy": "代理账户",
     "randomValidator": "随机验证人",
     "reGenerate": "重新生成",
+    "readyToJoinPool": "Ready to Join Pool",
     "recentPerformance": "最近表现",
     "remove": "删除",
     "removeSelected": "移除选定项",

--- a/src/locale/cn/library.json
+++ b/src/locale/cn/library.json
@@ -183,7 +183,7 @@
     "signing": "签署中",
     "submitTransaction": "准备提交交易",
     "syncing": "正在同步",
-    "syncingPoolData": "Finding Pools to Join",
+    "syncingPoolData": "查找提名池中",
     "syncingPoolList": "同步提名池列表",
     "tooSmall": "质押金额太少",
     "top": "首",

--- a/src/locale/cn/library.json
+++ b/src/locale/cn/library.json
@@ -182,7 +182,7 @@
     "signing": "签署中",
     "submitTransaction": "准备提交交易",
     "syncing": "正在同步",
-    "syncingPoolData": "同步提名池数据中",
+    "syncingPoolData": "Finding Pools to Join",
     "syncingPoolList": "同步提名池列表",
     "tooSmall": "质押金额太少",
     "top": "首",

--- a/src/locale/cn/library.json
+++ b/src/locale/cn/library.json
@@ -165,7 +165,7 @@
     "proxy": "代理账户",
     "randomValidator": "随机验证人",
     "reGenerate": "重新生成",
-    "readyToJoinPool": "Ready to Join Pool",
+    "readyToJoinPool": "可加入提名池",
     "recentPerformance": "最近表现",
     "remove": "删除",
     "removeSelected": "移除选定项",

--- a/src/locale/cn/pages.json
+++ b/src/locale/cn/pages.json
@@ -137,7 +137,6 @@
       "bondedFunds": "己质押金额",
       "bouncer": "守护人",
       "browseMembers": "浏览成员",
-      "browsePools": "浏览提名池",
       "cancel": "取消",
       "closePool": "可提取己解锁金额并关闭池",
       "compound": "复利",

--- a/src/locale/en/library.json
+++ b/src/locale/en/library.json
@@ -185,7 +185,7 @@
     "signing": "Signing",
     "submitTransaction": "Ready to submit transaction.",
     "syncing": "Syncing",
-    "syncingPoolData": "Syncing Pool Data",
+    "syncingPoolData": "Finding Pools to Join",
     "syncingPoolList": "Syncing Pool list",
     "tooSmall": "Bond amount is too small.",
     "top": "Top",

--- a/src/locale/en/library.json
+++ b/src/locale/en/library.json
@@ -168,6 +168,7 @@
     "proxy": "Proxy",
     "randomValidator": "Random Validator",
     "reGenerate": "Re-Generate",
+    "readyToJoinPool": "Ready to Join Pool",
     "recentPerformance": "Recent Performance",
     "remove": "Remove",
     "removeSelected": "Remove Selected",

--- a/src/locale/en/pages.json
+++ b/src/locale/en/pages.json
@@ -139,7 +139,6 @@
       "bondedFunds": "Bonded Funds",
       "bouncer": "Bouncer",
       "browseMembers": "Browse Members",
-      "browsePools": "Browse Pools",
       "cancel": "Cancel",
       "closePool": "You can now withdraw and close the pool.",
       "compound": "Compound",

--- a/src/pages/Payouts/PayoutList/index.tsx
+++ b/src/pages/Payouts/PayoutList/index.tsx
@@ -25,7 +25,7 @@ import { useNetwork } from 'contexts/Network';
 import { ItemWrapper } from '../Wrappers';
 import type { PayoutListProps } from '../types';
 import { PayoutListProvider, usePayoutList } from './context';
-import { listItemsPerPage } from 'library/List/defaults';
+import { payoutsPerPage } from 'library/List/defaults';
 
 export const PayoutListInner = ({
   allowMoreCols,
@@ -53,9 +53,9 @@ export const PayoutListInner = ({
   const [fetched, setFetched] = useState<boolean>(false);
 
   // pagination
-  const totalPages = Math.ceil(payouts.length / listItemsPerPage);
-  const pageEnd = page * listItemsPerPage - 1;
-  const pageStart = pageEnd - (listItemsPerPage - 1);
+  const totalPages = Math.ceil(payouts.length / payoutsPerPage);
+  const pageEnd = page * payoutsPerPage - 1;
+  const pageStart = pageEnd - (payoutsPerPage - 1);
 
   // refetch list when list changes
   useEffect(() => {
@@ -74,7 +74,7 @@ export const PayoutListInner = ({
   let listPayouts = [];
 
   // get throttled subset or entire list
-  listPayouts = payouts.slice(pageStart).slice(0, listItemsPerPage);
+  listPayouts = payouts.slice(pageStart).slice(0, payoutsPerPage);
 
   if (!payouts.length) {
     return null;

--- a/src/pages/Payouts/types.ts
+++ b/src/pages/Payouts/types.ts
@@ -6,7 +6,6 @@ import type { AnySubscan } from 'types';
 export interface PayoutListProps {
   allowMoreCols?: boolean;
   pagination?: boolean;
-  disableThrottle?: boolean;
   title?: string | null;
   payoutsList?: AnySubscan;
   payouts?: AnySubscan;

--- a/src/pages/Pools/Home/Favorites/index.tsx
+++ b/src/pages/Pools/Home/Favorites/index.tsx
@@ -8,7 +8,7 @@ import { useApi } from 'contexts/Api';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { CardWrapper } from 'library/Card/Wrappers';
-import { PoolList } from 'library/PoolList/Default';
+import { PoolList } from 'library/PoolList';
 import { ListStatusHeader } from 'library/List';
 import { PoolListProvider } from 'library/PoolList/context';
 import type { BondedPool } from 'contexts/Pools/BondedPools/types';

--- a/src/pages/Pools/Home/Status/FindingPoolPercent.tsx
+++ b/src/pages/Pools/Home/Status/FindingPoolPercent.tsx
@@ -1,0 +1,30 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import BigNumber from 'bignumber.js';
+import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
+
+export const FindingPoolsPercent = () => {
+  const { getPoolPerformanceTask } = usePoolPerformance();
+
+  // Get the pool performance task to determine if performance data is ready.
+  const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join');
+
+  if (poolJoinPerformanceTask.status === 'synced') {
+    return null;
+  }
+
+  // Calculate syncing status.
+  const { startEra, currentEra, endEra } = poolJoinPerformanceTask;
+  const totalEras = startEra.minus(endEra);
+  const erasPassed = startEra.minus(currentEra);
+  const percentPassed = erasPassed.isEqualTo(0)
+    ? new BigNumber(0)
+    : erasPassed.dividedBy(totalEras).multipliedBy(100);
+
+  return (
+    <span className="counter">
+      {percentPassed.decimalPlaces(0).toFormat()}%
+    </span>
+  );
+};

--- a/src/pages/Pools/Home/Status/FindingPoolPercent.tsx
+++ b/src/pages/Pools/Home/Status/FindingPoolPercent.tsx
@@ -10,7 +10,7 @@ export const FindingPoolsPercent = () => {
   // Get the pool performance task to determine if performance data is ready.
   const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join');
 
-  if (poolJoinPerformanceTask.status === 'synced') {
+  if (poolJoinPerformanceTask.status !== 'syncing') {
     return null;
   }
 

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -21,8 +21,10 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const { getPerformanceFetchedKey } = usePoolPerformance();
   const { disableJoin, disableCreate } = useStatusButtons();
 
-  const joinButtonDisabled =
-    disableJoin() || getPerformanceFetchedKey('pool_list').status !== 'synced';
+  const poolJoinPerformanceSynced =
+    getPerformanceFetchedKey('pool_join').status === 'synced';
+
+  const joinButtonDisabled = disableJoin() || !poolJoinPerformanceSynced;
 
   const createButtonDisabled = disableCreate();
 
@@ -48,8 +50,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     }
                     disabled={joinButtonDisabled}
                   >
-                    {getPerformanceFetchedKey('pool_list').status !==
-                    'synced' ? (
+                    {poolJoinPerformanceSynced ? (
                       t('syncingPoolData', { ns: 'library' })
                     ) : (
                       <>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -50,7 +50,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     }
                     disabled={joinButtonDisabled}
                   >
-                    {poolJoinPerformanceSynced ? (
+                    {!poolJoinPerformanceSynced ? (
                       t('syncingPoolData', { ns: 'library' })
                     ) : (
                       <>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -17,14 +17,17 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const { setOnPoolSetup } = useSetup();
   const { openCanvas } = useOverlay().canvas;
   const { getPoolPerformanceTask } = usePoolPerformance();
-  const { disableJoin, disableCreate } = useStatusButtons();
+  const { getJoinDisabled, getCreateDisabled } = useStatusButtons();
 
-  const poolJoinPerformanceSynced =
-    getPoolPerformanceTask('pool_join').status === 'synced';
+  // Get the pool performance task to determine if performance data is ready.
+  const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join');
 
-  const joinButtonDisabled = disableJoin() || !poolJoinPerformanceSynced;
+  // Disable opening the canvas if data is not ready.
+  const joinButtonDisabled =
+    getJoinDisabled() || poolJoinPerformanceTask.status !== 'synced';
 
-  const createButtonDisabled = disableCreate();
+  // Alias for create button disabled state.
+  const createDisabled = getCreateDisabled();
 
   return (
     <CallToActionWrapper>
@@ -48,7 +51,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     }
                     disabled={joinButtonDisabled}
                   >
-                    {!poolJoinPerformanceSynced ? (
+                    {poolJoinPerformanceTask.status !== 'synced' ? (
                       t('syncingPoolData', { ns: 'library' })
                     ) : (
                       <>
@@ -63,11 +66,11 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
             <section>
               <div className="buttons">
                 <div
-                  className={`button secondary standalone${createButtonDisabled ? ` disabled` : ``}`}
+                  className={`button secondary standalone${createDisabled ? ` disabled` : ``}`}
                 >
                   <button
                     onClick={() => setOnPoolSetup(true)}
-                    disabled={createButtonDisabled}
+                    disabled={createDisabled}
                   >
                     {t('pools.createPool', { ns: 'pages' })}
                     <FontAwesomeIcon

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -22,7 +22,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const { disableJoin, disableCreate } = useStatusButtons();
 
   const joinButtonDisabled =
-    disableJoin() || getPerformanceFetchedKey('pool_list') !== 'synced';
+    disableJoin() || getPerformanceFetchedKey('pool_list').status !== 'synced';
 
   const createButtonDisabled = disableCreate();
 
@@ -48,7 +48,8 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     }
                     disabled={joinButtonDisabled}
                   >
-                    {getPerformanceFetchedKey('pool_list') !== 'synced' ? (
+                    {getPerformanceFetchedKey('pool_list').status !==
+                    'synced' ? (
                       t('syncingPoolData', { ns: 'library' })
                     ) : (
                       <>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CallToActionWrapper } from '../../../../library/CallToAction';
 import { faChevronRight, faUserGroup } from '@fortawesome/free-solid-svg-icons';
 import { useSetup } from 'contexts/Setup';
-import { usePoolsTabs } from '../context';
 import { useStatusButtons } from './useStatusButtons';
 import { useTranslation } from 'react-i18next';
 import { useOverlay } from 'kits/Overlay/Provider';
@@ -16,7 +15,6 @@ import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation();
   const { setOnPoolSetup } = useSetup();
-  const { setActiveTab } = usePoolsTabs();
   const { openCanvas } = useOverlay().canvas;
   const { getPerformanceFetchedKey } = usePoolPerformance();
   const { disableJoin, disableCreate } = useStatusButtons();
@@ -38,7 +36,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
             <section>
               <div className="buttons">
                 <div
-                  className={`button primary${joinButtonDisabled ? ` disabled` : ``}`}
+                  className={`button primary standalone${joinButtonDisabled ? ` disabled` : ``}`}
                 >
                   <button
                     onClick={() =>
@@ -58,16 +56,6 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                         <FontAwesomeIcon icon={faUserGroup} />
                       </>
                     )}
-                  </button>
-                </div>
-
-                <div className="button secondary">
-                  <button onClick={() => setActiveTab(1)}>
-                    {t('pools.browsePools', { ns: 'pages' })}
-                    <FontAwesomeIcon
-                      icon={faChevronRight}
-                      transform={'shrink-4'}
-                    />
                   </button>
                 </div>
               </div>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -11,6 +11,7 @@ import { useOverlay } from 'kits/Overlay/Provider';
 import type { NewMemberProps } from './types';
 import { CallToActionLoader } from 'library/Loader/CallToAction';
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
+import { FindingPoolsPercent } from './FindingPoolPercent';
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation();
@@ -36,10 +37,10 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
           <CallToActionLoader />
         ) : (
           <>
-            <section>
+            <section className="fixedWidth">
               <div className="buttons">
                 <div
-                  className={`button primary standalone${joinButtonDisabled ? ` disabled` : ``}`}
+                  className={`button primary standalone${getJoinDisabled() ? ` disabled` : ``}`}
                 >
                   <button
                     onClick={() =>
@@ -52,13 +53,19 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     disabled={joinButtonDisabled}
                   >
                     {poolJoinPerformanceTask.status !== 'synced' ? (
-                      t('syncingPoolData', { ns: 'library' })
+                      <>{t('syncingPoolData', { ns: 'library' })}</>
                     ) : (
                       <>
                         {t('pools.joinPool', { ns: 'pages' })}
                         <FontAwesomeIcon icon={faUserGroup} />
                       </>
                     )}
+
+                    {poolJoinPerformanceTask.status !== 'synced' && (
+                      <div className="loader"></div>
+                    )}
+
+                    <FindingPoolsPercent />
                   </button>
                 </div>
               </div>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -18,11 +18,11 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const { setOnPoolSetup } = useSetup();
   const { setActiveTab } = usePoolsTabs();
   const { openCanvas } = useOverlay().canvas;
-  const { poolRewardPointsFetched } = usePoolPerformance();
+  const { getPerformanceFetchedKey } = usePoolPerformance();
   const { disableJoin, disableCreate } = useStatusButtons();
 
   const joinButtonDisabled =
-    disableJoin() || poolRewardPointsFetched !== 'synced';
+    disableJoin() || getPerformanceFetchedKey('pool_list') !== 'synced';
 
   const createButtonDisabled = disableCreate();
 
@@ -48,7 +48,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     }
                     disabled={joinButtonDisabled}
                   >
-                    {poolRewardPointsFetched !== 'synced' ? (
+                    {getPerformanceFetchedKey('pool_list') !== 'synced' ? (
                       t('syncingPoolData', { ns: 'library' })
                     ) : (
                       <>

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -82,7 +82,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
 
                     {poolJoinPerformanceTask.status === 'synced' && (
                       <>
-                        Ready to Join Pool
+                        {t('readyToJoinPool', { ns: 'library' })}
                         <FontAwesomeIcon icon={faUserPlus} />
                       </>
                     )}

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -16,11 +16,11 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation();
   const { setOnPoolSetup } = useSetup();
   const { openCanvas } = useOverlay().canvas;
-  const { getPerformanceFetchedKey } = usePoolPerformance();
+  const { getPoolPerformanceTask } = usePoolPerformance();
   const { disableJoin, disableCreate } = useStatusButtons();
 
   const poolJoinPerformanceSynced =
-    getPerformanceFetchedKey('pool_join').status === 'synced';
+    getPoolPerformanceTask('pool_join').status === 'synced';
 
   const joinButtonDisabled = disableJoin() || !poolJoinPerformanceSynced;
 

--- a/src/pages/Pools/Home/Status/useStatusButtons.tsx
+++ b/src/pages/Pools/Home/Status/useStatusButtons.tsx
@@ -26,7 +26,7 @@ export const useStatusButtons = () => {
   const membership = getPoolMembership(activeAccount);
   const { active } = getTransferOptions(activeAccount).pool;
 
-  const disableCreate = () => {
+  const getCreateDisabled = () => {
     if (!isReady || isReadOnlyAccount(activeAccount) || !activeAccount) {
       return true;
     }
@@ -41,7 +41,7 @@ export const useStatusButtons = () => {
 
   let label;
 
-  const disableJoin = () =>
+  const getJoinDisabled = () =>
     !isReady ||
     isReadOnlyAccount(activeAccount) ||
     !activeAccount ||
@@ -56,5 +56,5 @@ export const useStatusButtons = () => {
   } else {
     label = `${t('pools.leavingPool')} ${membership.poolId}`;
   }
-  return { label, disableJoin, disableCreate };
+  return { label, getJoinDisabled, getCreateDisabled };
 };

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -23,7 +23,6 @@ import { MinCreateBondStat } from './Stats/MinCreateBond';
 import { MinJoinBondStat } from './Stats/MinJoinBond';
 import { Status } from './Status';
 import { PoolsTabsProvider, usePoolsTabs } from './context';
-import { useApi } from 'contexts/Api';
 import { useActivePools } from 'hooks/useActivePools';
 import { useBalances } from 'contexts/Balances';
 import { PageTitle } from 'kits/Structure/PageTitle';
@@ -35,15 +34,14 @@ import { useSyncing } from 'hooks/useSyncing';
 
 export const HomeInner = () => {
   const { t } = useTranslation('pages');
-  const { poolMembersipSyncing } = useSyncing();
   const { favorites } = useFavoritePools();
   const { openModal } = useOverlay().modal;
   const { bondedPools } = useBondedPools();
   const { getPoolMembership } = useBalances();
+  const { poolMembersipSyncing } = useSyncing();
   const { activeAccount } = useActiveAccounts();
   const { activeTab, setActiveTab } = usePoolsTabs();
   const { getPoolRoles, activePool } = useActivePool();
-  const { counterForBondedPools } = useApi().poolsConfig;
   const membership = getPoolMembership(activeAccount);
 
   const { activePools } = useActivePools({
@@ -68,7 +66,6 @@ export const HomeInner = () => {
       title: t('pools.allPools'),
       active: activeTab === 1,
       onClick: () => setActiveTab(1),
-      badge: String(counterForBondedPools.toString()),
     },
     {
       title: t('pools.favorites'),

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -31,9 +31,11 @@ import { PageRow } from 'kits/Structure/PageRow';
 import { RowSection } from 'kits/Structure/RowSection';
 import { WithdrawPrompt } from 'library/WithdrawPrompt';
 import { useSyncing } from 'hooks/useSyncing';
+import { useNetwork } from 'contexts/Network';
 
 export const HomeInner = () => {
   const { t } = useTranslation('pages');
+  const { network } = useNetwork();
   const { favorites } = useFavoritePools();
   const { openModal } = useOverlay().modal;
   const { bondedPools } = useBondedPools();
@@ -77,12 +79,10 @@ export const HomeInner = () => {
 
   const ROW_HEIGHT = 220;
 
-  // Back to tab 0 if not in a pool & on members tab.
+  // Go back to tab 0 on network change.
   useEffect(() => {
-    if (!activePool) {
-      setActiveTab(0);
-    }
-  }, [activePool]);
+    setActiveTab(0);
+  }, [network]);
 
   return (
     <>
@@ -144,10 +144,6 @@ export const HomeInner = () => {
             <PoolListProvider>
               <PoolList
                 pools={bondedPools}
-                defaultFilters={{
-                  includes: ['active'],
-                  excludes: ['locked', 'destroying'],
-                }}
                 allowMoreCols
                 allowSearch
                 pagination

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useActivePool } from 'contexts/Pools/ActivePool';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { CardWrapper } from 'library/Card/Wrappers';
-import { PoolList } from 'library/PoolList/Default';
+import { PoolList } from 'library/PoolList';
 import { StatBoxList } from 'library/StatBoxList';
 import { useFavoritePools } from 'contexts/Pools/FavoritePools';
 import { useOverlay } from 'kits/Overlay/Provider';

--- a/src/theme/accents/polkadot-relay.css
+++ b/src/theme/accents/polkadot-relay.css
@@ -6,7 +6,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   --accent-color-primary-dark: rgb(211 48 121);
 
   --accent-color-secondary-light: #552bbf;
-  --accent-color-secondary-dark: #6d39ee;
+  --accent-color-secondary-dark: #aa90ec;
 
   --accent-color-tertiary-light: #dedae8;
   --accent-color-tertiary-dark: #32264c;

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-await-in-loop */
 
 import BigNumber from 'bignumber.js';
-import type { PoolRewardPointsBatchKey } from 'contexts/Pools/PoolPerformance/types';
+import type { PoolRewardPointsKey } from 'contexts/Pools/PoolPerformance/types';
 import type { Exposure } from 'contexts/Staking/types';
 import type { ErasRewardPoints } from 'contexts/Validators/types';
 import type { AnyJson } from 'types';
@@ -33,7 +33,7 @@ const processErasStakersForNominationPoolRewards = async ({
   erasRewardPoints,
   exposures,
 }: {
-  key: PoolRewardPointsBatchKey;
+  key: PoolRewardPointsKey;
   addresses: string[];
   era: string;
   erasRewardPoints: ErasRewardPoints;

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -27,20 +27,20 @@ ctx.addEventListener('message', async (event: AnyJson) => {
 // Process `erasStakersClipped` and generate nomination pool reward data.
 const processErasStakersForNominationPoolRewards = async ({
   key,
-  bondedPools,
+  addresses,
   era,
   erasRewardPoints,
   exposures,
 }: {
   key: PoolRewardPointsBatchKey;
-  bondedPools: string[];
+  addresses: string[];
   era: string;
   erasRewardPoints: ErasRewardPoints;
   exposures: Exposure[];
 }) => {
   const poolRewardData: Record<string, Record<string, string>> = {};
 
-  for (const address of bondedPools) {
+  for (const address of addresses) {
     let validator = null;
     for (const exposure of exposures) {
       const { others } = exposure.val;

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable no-await-in-loop */
 
+import type { PoolRewardPointsBatchKey } from 'contexts/Pools/PoolPerformance/types';
 import type { Exposure } from 'contexts/Staking/types';
 import type { ErasRewardPoints } from 'contexts/Validators/types';
 import type { AnyApi, AnyJson } from 'types';
@@ -25,11 +26,13 @@ ctx.addEventListener('message', async (event: AnyJson) => {
 
 // Process `erasStakersClipped` and generate nomination pool reward data.
 const processErasStakersForNominationPoolRewards = async ({
+  key,
   bondedPools,
   era,
   erasRewardPoints,
   exposures,
 }: {
+  key: PoolRewardPointsBatchKey;
   bondedPools: string[];
   era: string;
   erasRewardPoints: ErasRewardPoints;
@@ -60,6 +63,7 @@ const processErasStakersForNominationPoolRewards = async ({
   }
 
   return {
+    key,
     poolRewardData,
   };
 };

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -5,7 +5,7 @@
 import type { PoolRewardPointsBatchKey } from 'contexts/Pools/PoolPerformance/types';
 import type { Exposure } from 'contexts/Staking/types';
 import type { ErasRewardPoints } from 'contexts/Validators/types';
-import type { AnyApi, AnyJson } from 'types';
+import type { AnyJson } from 'types';
 
 // eslint-disable-next-line no-restricted-globals, @typescript-eslint/no-explicit-any
 export const ctx: Worker = self as any;
@@ -14,7 +14,7 @@ export const ctx: Worker = self as any;
 ctx.addEventListener('message', async (event: AnyJson) => {
   const { data } = event;
   const { task } = data;
-  let message: AnyJson = {};
+  let message = {};
   switch (task) {
     case 'processNominationPoolsRewardData':
       message = await processErasStakersForNominationPoolRewards(data);
@@ -44,7 +44,7 @@ const processErasStakersForNominationPoolRewards = async ({
     let validator = null;
     for (const exposure of exposures) {
       const { others } = exposure.val;
-      const inOthers = others.find((o: AnyApi) => o.who === address);
+      const inOthers = others.find(({ who }) => who === address);
 
       if (inOthers) {
         validator = exposure.keys[1];

--- a/src/workers/poolPerformance.ts
+++ b/src/workers/poolPerformance.ts
@@ -64,6 +64,7 @@ const processErasStakersForNominationPoolRewards = async ({
 
   return {
     key,
+    addresses,
     poolRewardData,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,13 +2136,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/crypto-js@npm:^4":
-  version: 4.2.2
-  resolution: "@types/crypto-js@npm:4.2.2"
-  checksum: 10c0/760a2078f36f2a3a1089ef367b0d13229876adcf4bcd6e8824d00d9e9bfad8118dc7e6a3cc66322b083535e12be3a29044ccdc9603bfb12519ff61551a3322c6
-  languageName: node
-  linkType: hard
-
 "@types/eslint@npm:^8.4.5":
   version: 8.56.6
   resolution: "@types/eslint@npm:8.56.6"
@@ -3464,13 +3457,6 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
-  languageName: node
-  linkType: hard
-
-"crypto-js@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "crypto-js@npm:4.2.0"
-  checksum: 10c0/8fbdf9d56f47aea0794ab87b0eb9833baf80b01a7c5c1b0edc7faf25f662fb69ab18dc2199e2afcac54670ff0cd9607a9045a3f7a80336cccd18d77a55b9fdf0
   languageName: node
   linkType: hard
 
@@ -6520,7 +6506,6 @@ __metadata:
     "@polkawatch/ddp-client": "npm:^2.0.11"
     "@substrate/connect": "npm:0.7.35"
     "@types/chroma-js": "npm:^2.4.4"
-    "@types/crypto-js": "npm:^4"
     "@types/lodash.debounce": "npm:^4.0.9"
     "@types/lodash.throttle": "npm:^4.1.9"
     "@types/react": "npm:^18.2.73"
@@ -6544,7 +6529,6 @@ __metadata:
     buffer: "npm:^6.0.3"
     chart.js: "npm:^4.4.2"
     chroma-js: "npm:^2.4.2"
-    crypto-js: "npm:^4.2.0"
     date-fns: "npm:^3.3.1"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,6 +2136,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/crypto-js@npm:^4":
+  version: 4.2.2
+  resolution: "@types/crypto-js@npm:4.2.2"
+  checksum: 10c0/760a2078f36f2a3a1089ef367b0d13229876adcf4bcd6e8824d00d9e9bfad8118dc7e6a3cc66322b083535e12be3a29044ccdc9603bfb12519ff61551a3322c6
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^8.4.5":
   version: 8.56.6
   resolution: "@types/eslint@npm:8.56.6"
@@ -3457,6 +3464,13 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "crypto-js@npm:4.2.0"
+  checksum: 10c0/8fbdf9d56f47aea0794ab87b0eb9833baf80b01a7c5c1b0edc7faf25f662fb69ab18dc2199e2afcac54670ff0cd9607a9045a3f7a80336cccd18d77a55b9fdf0
   languageName: node
   linkType: hard
 
@@ -6506,6 +6520,7 @@ __metadata:
     "@polkawatch/ddp-client": "npm:^2.0.11"
     "@substrate/connect": "npm:0.7.35"
     "@types/chroma-js": "npm:^2.4.4"
+    "@types/crypto-js": "npm:^4"
     "@types/lodash.debounce": "npm:^4.0.9"
     "@types/lodash.throttle": "npm:^4.1.9"
     "@types/react": "npm:^18.2.73"
@@ -6529,6 +6544,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     chart.js: "npm:^4.4.2"
     chroma-js: "npm:^2.4.2"
+    crypto-js: "npm:^4.2.0"
     date-fns: "npm:^3.3.1"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"


### PR DESCRIPTION
This PR improves the fetching of pool performance data, and optimises pool joining UX. Prior to this PR, the app fetched performance data for every bonded pool. This was extremely useful to have as performance data was lacking ecosystem wide, but it came at a severe cost of consuming resources and slowing the app down on initialisation.

This PR now allows pool performance data to be fetched in small batches - a batch is fetched per page when the All Pools tab is visited, as well as a small batch when users click Join Pool. There are numerous other improvements in this PR that are documented below.

#### Breakdown of Changes

- Allows pool performance data to be fetched in batches, rather than fetching for all pools on app initialisation, dramatically improving performance on app load.
 A new `JoinPoolsProvider` has been introduced, that stores a small subset of active bonded pools that are used as a "pool" of pools to join for new stakers. This is prepared on app initialisation, but no performance data is fetched until users explicitly want to join a pool.
- Defaults have been assigned to the filter context so the pool list does not have to re-render again after mounting to apply those filters.
- Introduces a "Finding Pools to Join" state to the Join Pool button, with animated loader and percentage completed. This state is present when pool performance data is being fetched prior to the JoinPool canvas being accessible.
- The pool list active tab has been persisted to the `BondedPools` context, so it is remembered on subsequent pool list visits.
- PoolList optimisations to prevent re-renders.
- Pool performance chart in JoinPool canvas is now a line graph, more accurately representing their performance trend.
- Adds a pulse animation to the Join Pool button when the JoinPool canvas is ready.
- The `PoolPerformance` context has been revamped to host "tasks" metadata for each pool performance batch being processed. Refs have been used within the context to ensure the correct state is being used for updates. Improved type interfaces have been introduced making the structures easier to understand.
- The `poolPerformance` worker now accumulates era points where pools have backed multiple validators. 
- JoinPool canvas: Ensures the same pool is not chosen again when "Choose Another Pool" is selected.
- JoinPool canvas: Now only a subset of active pools are available to join, rather than every eligible pool. This subset is randomly selected, although the pool has to be active, and those displayed need daily rewards for the last 10 eras (the entire duration of performance data range).
- Various re-render fixes in JoinPool canvas.
- Removes "render batch iterations" for list items, as this was no longer a useful feature.
- `listItemsPerPage` default has now been removed in favour of a range of perPage consts for each list type.
- To speed up syncing, `MaxEraRewardPointsEras` has been decreased from 14 to 10.
- Theming improvements.
- Addresses #2056