### PR TITLE
feat: Open `JoinPool` canvas immediately,  preloader, prioritise low member pools.

### DIFF
--- a/src/canvas/JoinPool/Preloader.tsx
+++ b/src/canvas/JoinPool/Preloader.tsx
@@ -7,12 +7,15 @@ import { ButtonPrimaryInvert } from 'kits/Buttons/ButtonPrimaryInvert';
 import { useOverlay } from 'kits/Overlay/Provider';
 import { useTranslation } from 'react-i18next';
 import {
+  JoinFormWrapper,
   JoinPoolInterfaceWrapper,
   PreloaderWrapper,
   TitleWrapper,
 } from './Wrappers';
 import { PoolSync } from 'library/PoolSync';
 import { CallToActionLoader } from 'library/Loader/CallToAction';
+import { LoaderWrapper } from 'library/Loader/Wrappers';
+import { PageTitleTabs } from 'kits/Structure/PageTitleTabs';
 
 export const Preloader = () => {
   const { t } = useTranslation();
@@ -35,7 +38,7 @@ export const Preloader = () => {
           style={{ marginLeft: '1.1rem' }}
         />
       </div>
-      <TitleWrapper className="preload">
+      <TitleWrapper>
         <div className="inner">
           <div className="empty"></div>
           <div className="standalone">
@@ -50,13 +53,47 @@ export const Preloader = () => {
             </div>
           </div>
         </div>
+        <PageTitleTabs
+          sticky={false}
+          tabs={[
+            {
+              title: t('pools.overview', { ns: 'pages' }),
+              active: true,
+              onClick: () => {
+                /* Do nothing */
+              },
+              disabled: true,
+              asPreloader: true,
+            },
+            {
+              title: t('nominate.nominations', { ns: 'pages' }),
+              active: true,
+              onClick: () => {
+                /* Do nothing */
+              },
+              disabled: true,
+              asPreloader: true,
+            },
+          ]}
+          tabClassName="canvas"
+          inline={true}
+        />
       </TitleWrapper>
 
       <JoinPoolInterfaceWrapper>
         <div className="content">
-          <PreloaderWrapper>
-            <CallToActionLoader />
-          </PreloaderWrapper>
+          <div className="main">
+            <PreloaderWrapper>
+              <CallToActionLoader />
+            </PreloaderWrapper>
+          </div>
+          <div className="side">
+            <div>
+              <JoinFormWrapper className="preload">
+                <LoaderWrapper style={{ width: '100%', height: '30rem' }} />
+              </JoinFormWrapper>
+            </div>
+          </div>
         </div>
       </JoinPoolInterfaceWrapper>
     </>

--- a/src/canvas/JoinPool/Preloader.tsx
+++ b/src/canvas/JoinPool/Preloader.tsx
@@ -12,11 +12,9 @@ import {
   TitleWrapper,
 } from './Wrappers';
 import { PoolSync } from 'library/PoolSync';
-import { PageTitleTabs } from 'kits/Structure/PageTitleTabs';
-import type { PreloaderProps } from './types';
 import { CallToActionLoader } from 'library/Loader/CallToAction';
 
-export const Preloader = ({ activeTab, setActiveTab }: PreloaderProps) => {
+export const Preloader = () => {
   const { t } = useTranslation();
   const { closeCanvas } = useOverlay().canvas;
 
@@ -37,7 +35,7 @@ export const Preloader = ({ activeTab, setActiveTab }: PreloaderProps) => {
           style={{ marginLeft: '1.1rem' }}
         />
       </div>
-      <TitleWrapper>
+      <TitleWrapper className="preload">
         <div className="inner">
           <div className="empty"></div>
           <div className="standalone">
@@ -52,26 +50,8 @@ export const Preloader = ({ activeTab, setActiveTab }: PreloaderProps) => {
             </div>
           </div>
         </div>
-        <PageTitleTabs
-          sticky={false}
-          tabs={[
-            {
-              title: t('pools.overview', { ns: 'pages' }),
-              active: activeTab === 0,
-              onClick: () => setActiveTab(0),
-              disabled: true,
-            },
-            {
-              title: t('nominate.nominations', { ns: 'pages' }),
-              active: activeTab === 1,
-              onClick: () => setActiveTab(1),
-              disabled: true,
-            },
-          ]}
-          tabClassName="canvas"
-          inline={true}
-        />
       </TitleWrapper>
+
       <JoinPoolInterfaceWrapper>
         <div className="content">
           <PreloaderWrapper>

--- a/src/canvas/JoinPool/Preloader.tsx
+++ b/src/canvas/JoinPool/Preloader.tsx
@@ -1,0 +1,84 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faArrowsRotate, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { ButtonPrimary } from 'kits/Buttons/ButtonPrimary';
+import { ButtonPrimaryInvert } from 'kits/Buttons/ButtonPrimaryInvert';
+import { useOverlay } from 'kits/Overlay/Provider';
+import { useTranslation } from 'react-i18next';
+import {
+  JoinPoolInterfaceWrapper,
+  PreloaderWrapper,
+  TitleWrapper,
+} from './Wrappers';
+import { PoolSync } from 'library/PoolSync';
+import { PageTitleTabs } from 'kits/Structure/PageTitleTabs';
+import type { PreloaderProps } from './types';
+import { CallToActionLoader } from 'library/Loader/CallToAction';
+
+export const Preloader = ({ activeTab, setActiveTab }: PreloaderProps) => {
+  const { t } = useTranslation();
+  const { closeCanvas } = useOverlay().canvas;
+
+  return (
+    <>
+      <div className="head">
+        <ButtonPrimaryInvert
+          text={t('chooseAnotherPool', { ns: 'library' })}
+          iconLeft={faArrowsRotate}
+          disabled
+          lg
+        />
+        <ButtonPrimary
+          text={t('cancel', { ns: 'library' })}
+          lg
+          onClick={() => closeCanvas()}
+          iconLeft={faTimes}
+          style={{ marginLeft: '1.1rem' }}
+        />
+      </div>
+      <TitleWrapper>
+        <div className="inner">
+          <div className="empty"></div>
+          <div className="standalone">
+            <div className="title">
+              <h1>{t('syncingPoolData', { ns: 'library' })}...</h1>
+            </div>
+            <div className="labels">
+              <h3>
+                Analyzing pool performance and finding optimal pools.
+                <PoolSync label="Completed" />
+              </h3>
+            </div>
+          </div>
+        </div>
+        <PageTitleTabs
+          sticky={false}
+          tabs={[
+            {
+              title: t('pools.overview', { ns: 'pages' }),
+              active: activeTab === 0,
+              onClick: () => setActiveTab(0),
+              disabled: true,
+            },
+            {
+              title: t('nominate.nominations', { ns: 'pages' }),
+              active: activeTab === 1,
+              onClick: () => setActiveTab(1),
+              disabled: true,
+            },
+          ]}
+          tabClassName="canvas"
+          inline={true}
+        />
+      </TitleWrapper>
+      <JoinPoolInterfaceWrapper>
+        <div className="content">
+          <PreloaderWrapper>
+            <CallToActionLoader />
+          </PreloaderWrapper>
+        </div>
+      </JoinPoolInterfaceWrapper>
+    </>
+  );
+};

--- a/src/canvas/JoinPool/Preloader.tsx
+++ b/src/canvas/JoinPool/Preloader.tsx
@@ -47,7 +47,7 @@ export const Preloader = ({ activeTab, setActiveTab }: PreloaderProps) => {
             <div className="labels">
               <h3>
                 Analyzing pool performance and finding optimal pools.
-                <PoolSync label="Completed" />
+                <PoolSync label={t('complete', { ns: 'library' })} />
               </h3>
             </div>
           </div>

--- a/src/canvas/JoinPool/Wrappers.ts
+++ b/src/canvas/JoinPool/Wrappers.ts
@@ -69,10 +69,6 @@ export const TitleWrapper = styled.div`
   margin: 2rem 0 1.55rem 0;
   padding-bottom: 0.1rem;
 
-  &.preload {
-    padding-bottom: 1rem;
-  }
-
   > .inner {
     display: flex;
     align-items: center;
@@ -164,6 +160,11 @@ export const JoinFormWrapper = styled.div`
 
   @media (max-width: 1000px) {
     margin-top: 1rem;
+  }
+
+  &.preload {
+    padding: 0;
+    opacity: 0.5;
   }
 
   h4 {

--- a/src/canvas/JoinPool/Wrappers.ts
+++ b/src/canvas/JoinPool/Wrappers.ts
@@ -69,6 +69,10 @@ export const TitleWrapper = styled.div`
   margin: 2rem 0 1.55rem 0;
   padding-bottom: 0.1rem;
 
+  &.preload {
+    padding-bottom: 1rem;
+  }
+
   > .inner {
     display: flex;
     align-items: center;

--- a/src/canvas/JoinPool/Wrappers.ts
+++ b/src/canvas/JoinPool/Wrappers.ts
@@ -53,6 +53,14 @@ export const JoinPoolInterfaceWrapper = styled.div`
   }
 `;
 
+export const PreloaderWrapper = styled.div`
+  background-color: var(--background-floating-card);
+  width: 100%;
+  height: 3.75rem;
+  border-radius: 2rem;
+  opacity: 0.4;
+`;
+
 export const TitleWrapper = styled.div`
   border-bottom: 1px solid var(--border-secondary-color);
   flex: 1;
@@ -73,11 +81,19 @@ export const TitleWrapper = styled.div`
 
       &:nth-child(1) {
         max-width: 4rem;
+
+        &.empty {
+          max-width: 0px;
+        }
       }
 
       &:nth-child(2) {
         padding-left: 1rem;
         flex-direction: column;
+
+        &.standalone {
+          padding-left: 0;
+        }
 
         > .title {
           position: relative;

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -83,7 +83,7 @@ export const JoinPool = () => {
     [selectedPoolId]
   );
 
-  // If syncing completes within the canvas, assign a selected pool
+  // If syncing completes within the canvas, assign a selected pool.
   useEffect(() => {
     if (performanceDataReady && selectedPoolId === 0) {
       setSelectedPoolId(

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -96,7 +96,7 @@ export const JoinPool = () => {
   return (
     <CanvasFullScreenWrapper>
       {poolJoinPerformanceTask.status !== 'synced' || !bondedPool ? (
-        <Preloader activeTab={activeTab} setActiveTab={setActiveTab} />
+        <Preloader />
       ) : (
         <>
           <Header

--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -13,16 +13,22 @@ import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 import { MaxEraRewardPointsEras } from 'consts';
 import { useStaking } from 'contexts/Staking';
 import { useJoinPools } from 'contexts/Pools/JoinPools';
+import { Preloader } from './Preloader';
 
 export const JoinPool = () => {
   const {
-    closeCanvas,
     config: { options },
   } = useOverlay().canvas;
   const { eraStakers } = useStaking();
   const { poolsForJoin } = useJoinPools();
-  const { getPoolRewardPoints } = usePoolPerformance();
   const { poolsMetaData, bondedPools } = useBondedPools();
+  const { getPoolRewardPoints, getPoolPerformanceTask } = usePoolPerformance();
+
+  // Get the pool performance task to determine if performance data is ready.
+  const poolJoinPerformanceTask = getPoolPerformanceTask('pool_join');
+  const performanceDataReady = poolJoinPerformanceTask.status === 'synced';
+
+  // Get performance data: Assumed to be fetched now.
   const poolRewardPoints = getPoolRewardPoints('pool_join');
 
   // The active canvas tab.
@@ -53,14 +59,14 @@ export const JoinPool = () => {
             staker.others.find(({ who }) => who !== pool.addresses.stash)
           )
         ),
-    [poolsForJoin, poolRewardPoints]
+    [poolsForJoin, poolRewardPoints, performanceDataReady]
   );
 
   const initialSelectedPoolId = useMemo(
     () =>
       options?.poolId ||
       filteredBondedPools[(filteredBondedPools.length * Math.random()) << 0]
-        .id ||
+        ?.id ||
       0,
     []
   );
@@ -77,41 +83,45 @@ export const JoinPool = () => {
     [selectedPoolId]
   );
 
-  // Close canvas if no pool id is selected.
+  // If syncing completes within the canvas, assign a selected pool
   useEffect(() => {
-    if (selectedPoolId === 0) {
-      closeCanvas();
+    if (performanceDataReady && selectedPoolId === 0) {
+      setSelectedPoolId(
+        filteredBondedPools[(filteredBondedPools.length * Math.random()) << 0]
+          ?.id || 0
+      );
     }
-  }, [selectedPoolId]);
-
-  // Ensure bonded pool exists before rendering. Canvas should close if this is the case.
-  if (!bondedPool) {
-    return null;
-  }
+  }, [performanceDataReady]);
 
   return (
     <CanvasFullScreenWrapper>
-      <Header
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        setSelectedPoolId={setSelectedPoolId}
-        bondedPool={bondedPool}
-        metadata={poolsMetaData[selectedPoolId]}
-        autoSelected={options?.poolId === undefined}
-        filteredBondedPools={filteredBondedPools}
-      />
+      {poolJoinPerformanceTask.status !== 'synced' || !bondedPool ? (
+        <Preloader activeTab={activeTab} setActiveTab={setActiveTab} />
+      ) : (
+        <>
+          <Header
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            setSelectedPoolId={setSelectedPoolId}
+            bondedPool={bondedPool}
+            metadata={poolsMetaData[selectedPoolId]}
+            autoSelected={options?.poolId === undefined}
+            filteredBondedPools={filteredBondedPools}
+          />
 
-      <JoinPoolInterfaceWrapper>
-        <div className="content">
-          {activeTab === 0 && <Overview bondedPool={bondedPool} />}
-          {activeTab === 1 && (
-            <Nominations
-              poolId={bondedPool.id}
-              stash={bondedPool.addresses.stash}
-            />
-          )}
-        </div>
-      </JoinPoolInterfaceWrapper>
+          <JoinPoolInterfaceWrapper>
+            <div className="content">
+              {activeTab === 0 && <Overview bondedPool={bondedPool} />}
+              {activeTab === 1 && (
+                <Nominations
+                  poolId={bondedPool.id}
+                  stash={bondedPool.addresses.stash}
+                />
+              )}
+            </div>
+          </JoinPoolInterfaceWrapper>
+        </>
+      )}
     </CanvasFullScreenWrapper>
   );
 };

--- a/src/canvas/JoinPool/types.ts
+++ b/src/canvas/JoinPool/types.ts
@@ -14,6 +14,11 @@ export interface JoinPoolHeaderProps {
   setSelectedPoolId: Dispatch<SetStateAction<number>>;
 }
 
+export interface PreloaderProps {
+  activeTab: number;
+  setActiveTab: (tab: number) => void;
+}
+
 export interface NominationsProps {
   stash: string;
   poolId: number;

--- a/src/canvas/JoinPool/types.ts
+++ b/src/canvas/JoinPool/types.ts
@@ -14,11 +14,6 @@ export interface JoinPoolHeaderProps {
   setSelectedPoolId: Dispatch<SetStateAction<number>>;
 }
 
-export interface PreloaderProps {
-  activeTab: number;
-  setActiveTab: (tab: number) => void;
-}
-
 export interface NominationsProps {
   stash: string;
   poolId: number;

--- a/src/kits/Buttons/ButtonTab.tsx
+++ b/src/kits/Buttons/ButtonTab.tsx
@@ -14,6 +14,8 @@ export type ButtonTabProps = ComponentBaseWithClassName &
     title: string;
     // a badge value can represent the main content of the tab page
     badge?: string | number;
+    // whether this tab is acting as a preloader.
+    asPreloader?: boolean;
   };
 
 /**
@@ -31,17 +33,20 @@ export const ButtonTab = ({
   onMouseOver,
   onMouseMove,
   onMouseOut,
+  asPreloader,
 }: ButtonTabProps) => (
   <button
     className={`btn-tab${appendOrEmpty(active, 'active')}${
       className ? ` ${className}` : ''
-    }`}
+    }${asPreloader ? ` preload` : ``}`}
     style={style}
     type="button"
     disabled={disabled}
     {...onMouseHandlers({ onClick, onMouseOver, onMouseMove, onMouseOut })}
   >
-    {title}
-    {badge ? <span className="badge">{badge}</span> : null}
+    <span className={`${asPreloader ? `preload` : ``}`}>
+      {title}
+      {badge ? <span className="badge">{badge}</span> : null}
+    </span>
   </button>
 );

--- a/src/kits/Buttons/index.scss
+++ b/src/kits/Buttons/index.scss
@@ -397,7 +397,6 @@
 .btn-tab {
   @include btn-core;
   @include btn-layout;
-  @include btn-disabled;
 
   color: var(--text-color-primary);
   transition:
@@ -448,6 +447,15 @@
       color: var(--text-color-primary);
       background: var(--button-tab-canvas-background);
     }
+  }
+
+  &:disabled {
+    opacity: 0.4;
+
+    &:hover {
+      opacity: 0.6;
+    }
+    cursor: default;
   }
 }
 

--- a/src/kits/Buttons/index.scss
+++ b/src/kits/Buttons/index.scss
@@ -417,29 +417,6 @@
     opacity: 0.9;
   }
 
-  > .badge {
-    border: 1px solid var(--border-primary-color);
-    color: var(--text-color-tertiary);
-    font-size: var(--button-font-size-small);
-    margin-left: var(--button-spacing-large);
-    display: flex;
-    padding: 0.3rem 0.6rem;
-    align-items: center;
-    justify-content: center;
-    border-radius: 0.4rem;
-    overflow: hidden;
-    width: fit-content;
-    max-width: 3rem;
-  }
-
-  &.active {
-    background: var(--button-tab-background);
-
-    > .badge {
-      border: 1px solid var(--border-secondary-color);
-    }
-  }
-
   &.canvas {
     color: var(--text-color-tertiary);
 
@@ -450,12 +427,50 @@
   }
 
   &:disabled {
-    opacity: 0.4;
-
-    &:hover {
-      opacity: 0.6;
-    }
     cursor: default;
+  }
+
+  > span {
+    display: flex;
+    align-items: center;
+
+    &.preload {
+      opacity: 0;
+    }
+
+    > .badge {
+      border: 1px solid var(--border-primary-color);
+      color: var(--text-color-tertiary);
+      font-size: var(--button-font-size-small);
+      margin-left: var(--button-spacing-large);
+      display: flex;
+      padding: 0.3rem 0.6rem;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0.4rem;
+      overflow: hidden;
+      width: fit-content;
+      max-width: 3rem;
+    }
+  }
+
+  &.active {
+    background: var(--button-tab-background);
+
+    > span > .badge {
+      border: 1px solid var(--border-secondary-color);
+    }
+  }
+
+  &.preload {
+    background: var(--shimmer-foreground);
+  }
+
+  &.canvas {
+    &.preload {
+      background: var(--shimmer-foreground);
+      opacity: 1;
+    }
   }
 }
 

--- a/src/kits/Structure/PageTitleTabs/index.tsx
+++ b/src/kits/Structure/PageTitleTabs/index.tsx
@@ -23,7 +23,10 @@ export const PageTitleTabs = ({
     <div className="scroll">
       <div className="inner">
         {tabs.map(
-          ({ active, onClick, title, badge }: PageTitleTabProps, i: number) => (
+          (
+            { active, onClick, title, badge, disabled }: PageTitleTabProps,
+            i: number
+          ) => (
             <ButtonTab
               className={tabClassName}
               active={!!active}
@@ -31,6 +34,7 @@ export const PageTitleTabs = ({
               onClick={() => onClick()}
               title={title}
               badge={badge}
+              disabled={disabled === undefined ? false : disabled}
             />
           )
         )}

--- a/src/kits/Structure/PageTitleTabs/index.tsx
+++ b/src/kits/Structure/PageTitleTabs/index.tsx
@@ -24,7 +24,14 @@ export const PageTitleTabs = ({
       <div className="inner">
         {tabs.map(
           (
-            { active, onClick, title, badge, disabled }: PageTitleTabProps,
+            {
+              active,
+              onClick,
+              title,
+              badge,
+              disabled,
+              asPreloader,
+            }: PageTitleTabProps,
             i: number
           ) => (
             <ButtonTab
@@ -35,6 +42,7 @@ export const PageTitleTabs = ({
               title={title}
               badge={badge}
               disabled={disabled === undefined ? false : disabled}
+              asPreloader={asPreloader == undefined ? false : asPreloader}
             />
           )
         )}

--- a/src/kits/Structure/PageTitleTabs/types.ts
+++ b/src/kits/Structure/PageTitleTabs/types.ts
@@ -21,4 +21,6 @@ export interface PageTitleTabProps {
   badge?: string | number;
   // whether the tab button is disabled.
   disabled?: boolean;
+  // whether the tab is acting as a preloader.
+  asPreloader?: boolean;
 }

--- a/src/kits/Structure/PageTitleTabs/types.ts
+++ b/src/kits/Structure/PageTitleTabs/types.ts
@@ -19,4 +19,6 @@ export interface PageTitleTabProps {
   onClick: () => void;
   // a badge that can have a glance at before visting the tab page.
   badge?: string | number;
+  // whether the tab button is disabled.
+  disabled?: boolean;
 }

--- a/src/library/CallToAction/index.tsx
+++ b/src/library/CallToAction/index.tsx
@@ -189,59 +189,6 @@ export const CallToActionWrapper = styled.div`
               margin-left: 0.75rem;
             }
 
-            .loader {
-              height: 0.8rem;
-              margin-left: 1.6rem;
-              aspect-ratio: 5;
-              --_g: no-repeat radial-gradient(farthest-side, white 94%, #0000);
-              background: var(--_g), var(--_g), var(--_g), var(--_g);
-              background-size: 20% 100%;
-              animation:
-                l40-1 0.75s infinite alternate,
-                l40-2 1.5s infinite alternate;
-            }
-            @keyframes l40-1 {
-              0%,
-              10% {
-                background-position:
-                  0 0,
-                  0 0,
-                  0 0,
-                  0 0;
-              }
-              33% {
-                background-position:
-                  0 0,
-                  calc(100% / 3) 0,
-                  calc(100% / 3) 0,
-                  calc(100% / 3) 0;
-              }
-              66% {
-                background-position:
-                  0 0,
-                  calc(100% / 3) 0,
-                  calc(2 * 100% / 3) 0,
-                  calc(2 * 100% / 3) 0;
-              }
-              90%,
-              100% {
-                background-position:
-                  0 0,
-                  calc(100% / 3) 0,
-                  calc(2 * 100% / 3) 0,
-                  100% 0;
-              }
-            }
-            @keyframes l40-2 {
-              0%,
-              49.99% {
-                transform: scale(1);
-              }
-              50%,
-              100% {
-                transform: scale(-1);
-              }
-            }
             &:disabled {
               cursor: default;
             }

--- a/src/library/Loader/Wrappers.ts
+++ b/src/library/Loader/Wrappers.ts
@@ -13,7 +13,7 @@ export const LoaderWrapper = styled.div`
     var(--shimmer-foreground) 100%
   );
   background-repeat: no-repeat;
-  background-size: 600px 104px;
+  background-size: 600px 100%;
   animation-duration: 1.5s;
   animation-fill-mode: forwards;
   animation-iteration-count: infinite;

--- a/src/library/PoolSync/Loader.ts
+++ b/src/library/PoolSync/Loader.ts
@@ -1,0 +1,59 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import styled from 'styled-components';
+
+export const StyledLoader = styled.div`
+  height: 0.8rem;
+  margin-left: 1.6rem;
+  aspect-ratio: 5;
+  --_g: no-repeat radial-gradient(farthest-side, white 94%, #0000);
+  background: var(--_g), var(--_g), var(--_g), var(--_g);
+  background-size: 20% 100%;
+  animation:
+    l40-1 0.75s infinite alternate,
+    l40-2 1.5s infinite alternate;
+
+  @keyframes l40-1 {
+    0%,
+    10% {
+      background-position:
+        0 0,
+        0 0,
+        0 0,
+        0 0;
+    }
+    33% {
+      background-position:
+        0 0,
+        calc(100% / 3) 0,
+        calc(100% / 3) 0,
+        calc(100% / 3) 0;
+    }
+    66% {
+      background-position:
+        0 0,
+        calc(100% / 3) 0,
+        calc(2 * 100% / 3) 0,
+        calc(2 * 100% / 3) 0;
+    }
+    90%,
+    100% {
+      background-position:
+        0 0,
+        calc(100% / 3) 0,
+        calc(2 * 100% / 3) 0,
+        100% 0;
+    }
+  }
+  @keyframes l40-2 {
+    0%,
+    49.99% {
+      transform: scale(1);
+    }
+    50%,
+    100% {
+      transform: scale(-1);
+    }
+  }
+`;

--- a/src/library/PoolSync/index.tsx
+++ b/src/library/PoolSync/index.tsx
@@ -4,7 +4,7 @@
 import BigNumber from 'bignumber.js';
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 
-export const FindingPoolsPercent = () => {
+export const PoolSync = ({ label }: { label?: string }) => {
   const { getPoolPerformanceTask } = usePoolPerformance();
 
   // Get the pool performance task to determine if performance data is ready.
@@ -24,7 +24,7 @@ export const FindingPoolsPercent = () => {
 
   return (
     <span className="counter">
-      {percentPassed.decimalPlaces(0).toFormat()}%
+      {percentPassed.decimalPlaces(0).toFormat()}%{label && ` ${label}`}
     </span>
   );
 };

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { CallToActionWrapper } from '../../../../library/CallToAction';
+import { CallToActionWrapper } from 'library/CallToAction';
 import {
   faChevronRight,
   faUserGroup,
@@ -15,7 +15,7 @@ import { useOverlay } from 'kits/Overlay/Provider';
 import type { NewMemberProps } from './types';
 import { CallToActionLoader } from 'library/Loader/CallToAction';
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
-import { PoolSync } from '../../../../library/PoolSync';
+import { PoolSync } from 'library/PoolSync';
 import { useJoinPools } from 'contexts/Pools/JoinPools';
 import { StyledLoader } from 'library/PoolSync/Loader';
 

--- a/src/pages/Pools/Home/Status/NewMember.tsx
+++ b/src/pages/Pools/Home/Status/NewMember.tsx
@@ -15,8 +15,9 @@ import { useOverlay } from 'kits/Overlay/Provider';
 import type { NewMemberProps } from './types';
 import { CallToActionLoader } from 'library/Loader/CallToAction';
 import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
-import { FindingPoolsPercent } from './FindingPoolPercent';
+import { PoolSync } from '../../../../library/PoolSync';
 import { useJoinPools } from 'contexts/Pools/JoinPools';
+import { StyledLoader } from 'library/PoolSync/Loader';
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation();
@@ -46,23 +47,20 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
             <section className="fixedWidth">
               <div className="buttons">
                 <div
-                  className={`button primary standalone${getJoinDisabled() ? ` disabled` : ``}${poolJoinPerformanceTask.status === 'synced' ? ` pulse` : ``}${poolJoinPerformanceTask.status === 'syncing' ? ` inactive` : ``}`}
+                  className={`button primary standalone${getJoinDisabled() ? ` disabled` : ``}${poolJoinPerformanceTask.status === 'synced' ? ` pulse` : ``}`}
                 >
                   <button
                     onClick={() => {
                       // Start sync process, otherwise, open canvas.
                       if (poolJoinPerformanceTask.status === 'unsynced') {
                         startJoinPoolFetch();
-                      } else if (poolJoinPerformanceTask.status === 'synced') {
-                        openCanvas({
-                          key: 'JoinPool',
-                          options: {},
-                          size: 'xl',
-                        });
-                      } else {
-                        // Syncing in progress, don't do anything.
-                        return;
                       }
+
+                      openCanvas({
+                        key: 'JoinPool',
+                        options: {},
+                        size: 'xl',
+                      });
                     }}
                     disabled={joinButtonDisabled}
                   >
@@ -76,7 +74,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                     {poolJoinPerformanceTask.status === 'syncing' && (
                       <>
                         {t('syncingPoolData', { ns: 'library' })}{' '}
-                        <div className="loader"></div>
+                        <StyledLoader />
                       </>
                     )}
 
@@ -87,7 +85,7 @@ export const NewMember = ({ syncing }: NewMemberProps) => {
                       </>
                     )}
 
-                    <FindingPoolsPercent />
+                    <PoolSync />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Improves pool joining UX by opening the JoinPool canvas immediately and displaying a preloading state within the canvas. This prevents the user having to click the "Join Pool" button twice, once to initiate the syncing process, and another time to open the canvas. 

The user is still free to close the JoinPool canvas while the performance data is being fetched - it will continue and be ready when the user opens it again.

#### Breakdown of changes

- [x] New preloading state in `JoinPool` canvas while performance data is being fetched, with ability to open `JoinPool` immediately.
- [x] Added ability to disable `ButtonTab`s, with custom disabled styling.
- [x] Moved join pool loader animation to a separate styled component.
- [x] Optimise join pool selection to promote decentralisation.
     - [x]  Fetch the lower third of pools ordered by `memberCounter`.
     - [x]  Ensure pools have at least 2x the minimum active stake in points value (converting to balance would be extra overhead and time to process, deemed not necessary).
- [x] Misc polish.