### PR TITLE
feat(refactor): Persist all imported accounts active pools.

### DIFF
--- a/src/canvas/JoinPool/index.tsx
+++ b/src/canvas/JoinPool/index.tsx
@@ -60,7 +60,7 @@ export const JoinPool = () => {
             rewardPoints.every((points) => Number(points) > 0) &&
             rewardPoints.length === MaxEraRewardPointsEras;
 
-          return pool.state === 'Open' && activeDaily;
+          return activeDaily;
         })
         // Ensure the pool is currently in the active set of backers.
         .filter((pool) =>

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -46,8 +46,7 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
       isCustomEvent(e) &&
       BalancesController.isValidNewAccountBalanceEvent(e)
     ) {
-      // Update whether all account balances have been synced. Uses greater than to account for
-      // possible errors on the API side.
+      // Update whether all account balances have been synced.
       checkBalancesSynced();
     }
   };

--- a/src/contexts/Balances/index.tsx
+++ b/src/contexts/Balances/index.tsx
@@ -54,23 +54,19 @@ export const BalancesProvider = ({ children }: { children: ReactNode }) => {
       // Update whether all account balances have been synced.
       checkBalancesSynced();
 
-      // If a pool membership exists, let `ActivePools` know of pool membership to re-sync pool
-      // details and nominations.
       const { address, ...newBalances } = e.detail;
       const { poolMembership } = newBalances;
 
+      // If a pool membership exists, let `ActivePools` know of pool membership to re-sync pool
+      // details and nominations.
       if (api && poolMembership) {
         const { poolId } = poolMembership;
-        const newPools = (
-          ActivePoolsController.pools?.[address]?.map(({ id, addresses }) => ({
-            id,
-            addresses,
-          })) || []
+        const newPools = ActivePoolsController.getformattedPoolItems(
+          address
         ).concat({
           id: String(poolId),
           addresses: { ...createPoolAccounts(Number(poolId)) },
         });
-
         ActivePoolsController.syncPools(api, address, newPools);
       }
     }

--- a/src/contexts/Pools/ActivePool/index.tsx
+++ b/src/contexts/Pools/ActivePool/index.tsx
@@ -91,12 +91,10 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     new BigNumber(0)
   );
 
-  const activePool = activePoolId
-    ? getActivePools(activeAccount, activePoolId)
-    : null;
+  const activePool = activePoolId ? getActivePools(activePoolId) : null;
 
   const activePoolNominations = activePoolId
-    ? getPoolNominations(activeAccount, activePoolId)
+    ? getPoolNominations(activePoolId)
     : null;
 
   // Sync active pool subscriptions.

--- a/src/contexts/Pools/ActivePool/index.tsx
+++ b/src/contexts/Pools/ActivePool/index.tsx
@@ -75,11 +75,11 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     {
       who: activeAccount,
       onCallback: async () => {
-        const accountPoolCount =
-          ActivePoolsController.getPools(activeAccount).length;
-
         // Sync: active pools synced once all account pools have been reported.
-        if (accountPoolIds.length <= accountPoolCount) {
+        if (
+          accountPoolIds.length <=
+          ActivePoolsController.getPools(activeAccount).length
+        ) {
           SyncController.dispatch('active-pools', 'complete');
         }
       },
@@ -91,11 +91,13 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     new BigNumber(0)
   );
 
-  const activePool =
-    (activePoolId && getActivePools(activeAccount, activePoolId)) || null;
+  const activePool = activePoolId
+    ? getActivePools(activeAccount, activePoolId)
+    : null;
 
-  const activePoolNominations =
-    (activePoolId && getPoolNominations(activeAccount, activePoolId)) || null;
+  const activePoolNominations = activePoolId
+    ? getPoolNominations(activeAccount, activePoolId)
+    : null;
 
   // Sync active pool subscriptions.
   const syncActivePoolSubscriptions = async () => {

--- a/src/contexts/Pools/JoinPools/index.tsx
+++ b/src/contexts/Pools/JoinPools/index.tsx
@@ -56,8 +56,8 @@ export const JoinPoolsProvider = ({ children }: { children: ReactNode }) => {
         ({ state }) => state === 'Open'
       );
 
-      // Filter pools that do not have at least double the minimum active stake in points. NOTE:
-      // assumes that points are a 1:1 ratio between balance and points.
+      // Filter pools that do not have at least double the minimum stake to earn rewards, in points.
+      // NOTE: assumes that points are a 1:1 ratio between balance and points.
       const rewardBondedPools = activeBondedPools.filter(({ points }) => {
         const pointsBn = new BigNumber(rmCommas(points));
         const threshold = minimumActiveStake.multipliedBy(2);

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -313,7 +313,7 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [apiStatus]);
 
-  // handle syncing with eraStakers
+  // handle syncing with eraStakers.
   useEffectIgnoreInitial(() => {
     if (isReady) {
       fetchActiveEraStakers();

--- a/src/controllers/ActivePoolsController/index.ts
+++ b/src/controllers/ActivePoolsController/index.ts
@@ -6,7 +6,13 @@ import { defaultPoolNominations } from 'contexts/Pools/ActivePool/defaults';
 import type { ActivePool, PoolRoles } from 'contexts/Pools/ActivePool/types';
 import { IdentitiesController } from 'controllers/IdentitiesController';
 import type { AnyApi, MaybeAddress } from 'types';
-import type { ActivePoolItem, DetailActivePool } from './types';
+import type {
+  AccountActivePools,
+  AccountPoolNominations,
+  AccountUnsubs,
+  ActivePoolItem,
+  DetailActivePool,
+} from './types';
 import { SyncController } from 'controllers/SyncController';
 import type { Nominations } from 'contexts/Balances/types';
 import type { ApiPromise } from '@polkadot/api';
@@ -21,13 +27,13 @@ export class ActivePoolsController {
 
   // Active pools that are being returned from subscriptions, keyed by account address, then pool
   // id.
-  static activePools: Record<string, Record<string, ActivePool | null>> = {};
+  static activePools: Record<string, AccountActivePools> = {};
 
   // Active pool nominations, keyed by account address, then pool id.
-  static poolNominations: Record<string, Record<string, Nominations>> = {};
+  static poolNominations: Record<string, AccountPoolNominations> = {};
 
   // Unsubscribe objects, keyed by account address, then pool id.
-  static #unsubs: Record<string, Record<string, VoidFn>> = {};
+  static #unsubs: Record<string, AccountUnsubs> = {};
 
   // ------------------------------------------------------
   // Pool membership syncing.
@@ -240,7 +246,7 @@ export class ActivePoolsController {
   };
 
   // Gets active pools for a provided address.
-  static getActivePools = (address: MaybeAddress) => {
+  static getActivePools = (address: MaybeAddress): AccountActivePools => {
     if (!address) {
       return {};
     }
@@ -248,7 +254,9 @@ export class ActivePoolsController {
   };
 
   // Gets active pool nominations for a provided address.
-  static getPoolNominations = (address: MaybeAddress) => {
+  static getPoolNominations = (
+    address: MaybeAddress
+  ): AccountPoolNominations => {
     if (!address) {
       return {};
     }

--- a/src/controllers/ActivePoolsController/index.ts
+++ b/src/controllers/ActivePoolsController/index.ts
@@ -228,7 +228,7 @@ export class ActivePoolsController {
   };
 
   // ------------------------------------------------------
-  // Class helpers.
+  // Getters.
   // ------------------------------------------------------
 
   // Gets pools for a provided address.
@@ -254,6 +254,18 @@ export class ActivePoolsController {
     }
     return this.poolNominations?.[address] || {};
   };
+
+  // Gets unique role addresses from a bonded pool's `roles` record.
+  static getUniqueRoleAddresses = (roles: PoolRoles): string[] => {
+    const roleAddresses: string[] = [
+      ...new Set(Object.values(roles).filter((role) => role !== undefined)),
+    ];
+    return roleAddresses;
+  };
+
+  // ------------------------------------------------------
+  // Setters.
+  // ------------------------------------------------------
 
   // Set an active pool for an address.
   static setActivePool = (
@@ -287,12 +299,21 @@ export class ActivePoolsController {
     this.#unsubs[address][poolId] = unsub;
   };
 
-  // Gets unique role addresses from a bonded pool's `roles` record.
-  static getUniqueRoleAddresses = (roles: PoolRoles): string[] => {
-    const roleAddresses: string[] = [
-      ...new Set(Object.values(roles).filter((role) => role !== undefined)),
-    ];
-    return roleAddresses;
+  // ------------------------------------------------------
+  // Class helpers.
+  // ------------------------------------------------------
+
+  // Format pools into active pool items (id and addresses only).
+  static getformattedPoolItems = (address: MaybeAddress): ActivePoolItem[] => {
+    if (!address) {
+      return [];
+    }
+    return (
+      this.pools?.[address]?.map(({ id, addresses }) => ({
+        id: id.toString(),
+        addresses,
+      })) || []
+    );
   };
 
   // Checks if event detailis a valid `new-active-pool` event.

--- a/src/controllers/ActivePoolsController/index.ts
+++ b/src/controllers/ActivePoolsController/index.ts
@@ -5,7 +5,7 @@ import type { VoidFn } from '@polkadot/api/types';
 import { defaultPoolNominations } from 'contexts/Pools/ActivePool/defaults';
 import type { ActivePool, PoolRoles } from 'contexts/Pools/ActivePool/types';
 import { IdentitiesController } from 'controllers/IdentitiesController';
-import type { AnyApi } from 'types';
+import type { AnyApi, MaybeAddress } from 'types';
 import type { ActivePoolItem, DetailActivePool } from './types';
 import { SyncController } from 'controllers/SyncController';
 import type { Nominations } from 'contexts/Balances/types';
@@ -16,17 +16,18 @@ export class ActivePoolsController {
   // Class members.
   // ------------------------------------------------------
 
-  // Pool ids that are being subscribed to.
-  static pools: ActivePoolItem[] = [];
+  // Pool ids that are being subscribed to. Keyed by address.
+  static pools: Record<string, ActivePoolItem[]> = {};
 
-  // Active pools that are being returned from subscriptions, keyed by pool id.
-  static activePools: Record<string, ActivePool | null> = {};
+  // Active pools that are being returned from subscriptions, keyed by account address, then pool
+  // id.
+  static activePools: Record<string, Record<string, ActivePool | null>> = {};
 
-  // Active pool nominations, keyed by pool id.
-  static poolNominations: Record<string, Nominations> = {};
+  // Active pool nominations, keyed by account address, then pool id.
+  static poolNominations: Record<string, Record<string, Nominations>> = {};
 
-  // Unsubscribe objects.
-  static #unsubs: Record<string, VoidFn> = {};
+  // Unsubscribe objects, keyed by account address, then pool id.
+  static #unsubs: Record<string, Record<string, VoidFn>> = {};
 
   // ------------------------------------------------------
   // Pool membership syncing.
@@ -35,23 +36,27 @@ export class ActivePoolsController {
   // Subscribes to pools and unsubscribes from removed pools.
   static syncPools = async (
     api: ApiPromise,
+    address: MaybeAddress,
     newPools: ActivePoolItem[]
   ): Promise<void> => {
-    // Sync: Checking active pools.
-    SyncController.dispatch('active-pools', 'syncing');
+    if (!address) {
+      return;
+    }
 
     // Handle pools that have been removed.
-    this.handleRemovedPools(newPools);
+    this.handleRemovedPools(address, newPools);
+
+    const currentPools = this.getPools(address);
 
     // Determine new pools that need to be subscribed to.
     const poolsAdded = newPools.filter(
-      (newPool) => !this.pools.find((pool) => pool.id === newPool.id)
+      (newPool) => !currentPools.find(({ id }) => id === newPool.id)
     );
 
     if (poolsAdded.length) {
       // Subscribe to and add new pool data.
       poolsAdded.forEach(async (pool) => {
-        this.pools.push(pool);
+        this.pools[address] = currentPools.concat(pool);
 
         const unsub = await api.queryMulti<AnyApi>(
           [
@@ -69,26 +74,31 @@ export class ActivePoolsController {
             // NOTE: async: fetches identity data for roles.
             await this.handleActivePoolCallback(
               api,
+              address,
               pool,
               bondedPool,
               rewardPool,
               accountData
             );
-            this.handleNominatorsCallback(pool, nominators);
+            this.handleNominatorsCallback(address, pool, nominators);
 
-            if (this.activePools[pool.id] && this.poolNominations[pool.id]) {
+            if (
+              this.activePools?.[address]?.[pool.id] &&
+              this.poolNominations?.[address]?.[pool.id]
+            ) {
               document.dispatchEvent(
                 new CustomEvent('new-active-pool', {
                   detail: {
-                    pool: this.activePools[pool.id],
-                    nominations: this.poolNominations[pool.id],
+                    address,
+                    pool: this.activePools[address][pool.id],
+                    nominations: this.poolNominations[address][pool.id],
                   },
                 })
               );
             }
           }
         );
-        this.#unsubs[pool.id] = unsub;
+        this.setUnsub(address, pool.id, unsub);
       });
     } else {
       // Status: Pools Synced Completed.
@@ -99,6 +109,7 @@ export class ActivePoolsController {
   // Handle active pool callback.
   static handleActivePoolCallback = async (
     api: ApiPromise,
+    address: string,
     pool: ActivePoolItem,
     bondedPoolResult: AnyApi,
     rewardPoolResult: AnyApi,
@@ -126,15 +137,16 @@ export class ActivePoolsController {
         rewardAccountBalance,
       };
 
-      this.activePools[pool.id] = newPool;
+      this.setActivePool(address, pool.id, newPool);
     } else {
       // Invalid pools were returned. To signal pool was synced, set active pool to `null`.
-      this.activePools[pool.id] = null;
+      this.setActivePool(address, pool.id, null);
     }
   };
 
   // Handle nominators callback.
   static handleNominatorsCallback = (
+    address: string,
     pool: ActivePoolItem,
     nominatorsResult: AnyApi
   ): void => {
@@ -148,28 +160,50 @@ export class ActivePoolsController {
             submittedIn: maybeNewNominations.submittedIn.toHuman(),
           };
 
-    this.poolNominations[pool.id] = newNominations;
+    this.setPoolNominations(address, pool.id, newNominations);
   };
 
   // Remove pools that no longer exist.
-  static handleRemovedPools = (newPools: ActivePoolItem[]): void => {
+  static handleRemovedPools = (
+    address: string,
+    newPools: ActivePoolItem[]
+  ): void => {
+    const currentPools = this.getPools(address);
+
     // Determine removed pools - current ones that no longer exist in `newPools`.
-    const poolsRemoved = this.pools.filter(
+    const poolsRemoved = currentPools.filter(
       (pool) => !newPools.find((newPool) => newPool.id === pool.id)
     );
 
     // Unsubscribe from removed pool subscriptions.
     poolsRemoved.forEach((pool) => {
-      if (this.#unsubs[pool.id]) {
-        this.#unsubs[pool.id]();
+      if (this.#unsubs?.[address]?.[pool.id]) {
+        this.#unsubs[address][pool.id]();
       }
-      delete this.#unsubs[pool.id];
-      delete this.activePools[pool.id];
-      delete this.poolNominations[pool.id];
+      delete this.activePools[address][pool.id];
+      delete this.poolNominations[address][pool.id];
     });
 
     // Remove removed pools from class.
-    this.pools = this.pools.filter((pool) => !poolsRemoved.includes(pool));
+    this.pools[address] = currentPools.filter(
+      (pool) => !poolsRemoved.includes(pool)
+    );
+
+    // Tidy up empty class state.
+    if (!this.pools[address].length) {
+      delete this.pools[address];
+    }
+
+    if (!this.activePools[address]) {
+      delete this.activePools[address];
+    }
+
+    if (!this.poolNominations[address]) {
+      delete this.poolNominations[address];
+    }
+    if (!this.#unsubs[address]) {
+      delete this.#unsubs[address];
+    }
   };
 
   // ------------------------------------------------------
@@ -178,14 +212,17 @@ export class ActivePoolsController {
 
   // Unsubscribe from all subscriptions and reset class members.
   static unsubscribe = (): void => {
-    Object.values(this.#unsubs).forEach((unsub) => {
-      unsub();
+    Object.values(this.#unsubs).forEach((accountUnsubs) => {
+      Object.values(accountUnsubs).forEach((unsub) => {
+        unsub();
+      });
     });
+
     this.#unsubs = {};
   };
 
   static resetState = (): void => {
-    this.pools = [];
+    this.pools = {};
     this.activePools = {};
     this.poolNominations = {};
   };
@@ -193,6 +230,62 @@ export class ActivePoolsController {
   // ------------------------------------------------------
   // Class helpers.
   // ------------------------------------------------------
+
+  // Gets pools for a provided address.
+  static getPools = (address: MaybeAddress): ActivePoolItem[] => {
+    if (!address) {
+      return [];
+    }
+    return this.pools?.[address] || [];
+  };
+
+  // Gets active pools for a provided address.
+  static getActivePools = (address: MaybeAddress) => {
+    if (!address) {
+      return {};
+    }
+    return this.activePools?.[address] || {};
+  };
+
+  // Gets active pool nominations for a provided address.
+  static getPoolNominations = (address: MaybeAddress) => {
+    if (!address) {
+      return {};
+    }
+    return this.poolNominations?.[address] || {};
+  };
+
+  // Set an active pool for an address.
+  static setActivePool = (
+    address: string,
+    poolId: string,
+    activePool: ActivePool | null
+  ): void => {
+    if (!this.activePools[address]) {
+      this.activePools[address] = {};
+    }
+    this.activePools[address][poolId] = activePool;
+  };
+
+  // Set pool nominations for an address.
+  static setPoolNominations = (
+    address: string,
+    poolId: string,
+    nominations: Nominations
+  ): void => {
+    if (!this.poolNominations[address]) {
+      this.poolNominations[address] = {};
+    }
+    this.poolNominations[address][poolId] = nominations;
+  };
+
+  // Set unsub for an address and pool id.
+  static setUnsub = (address: string, poolId: string, unsub: VoidFn): void => {
+    if (!this.#unsubs[address]) {
+      this.#unsubs[address] = {};
+    }
+    this.#unsubs[address][poolId] = unsub;
+  };
 
   // Gets unique role addresses from a bonded pool's `roles` record.
   static getUniqueRoleAddresses = (roles: PoolRoles): string[] => {
@@ -206,5 +299,8 @@ export class ActivePoolsController {
   static isValidNewActivePool = (
     event: CustomEvent
   ): event is CustomEvent<DetailActivePool> =>
-    event.detail && event.detail.pool && event.detail.nominations;
+    event.detail &&
+    event.detail.address &&
+    event.detail.pool &&
+    event.detail.nominations;
 }

--- a/src/controllers/ActivePoolsController/types.ts
+++ b/src/controllers/ActivePoolsController/types.ts
@@ -5,6 +5,7 @@ import type { Nominations } from 'contexts/Balances/types';
 import type { ActivePool } from 'contexts/Pools/ActivePool/types';
 
 export interface DetailActivePool {
+  address: string;
   pool: ActivePool;
   nominations: Nominations;
 }

--- a/src/controllers/ActivePoolsController/types.ts
+++ b/src/controllers/ActivePoolsController/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { VoidFn } from '@polkadot/api/types';
 import type { Nominations } from 'contexts/Balances/types';
 import type { ActivePool } from 'contexts/Pools/ActivePool/types';
 
@@ -17,3 +18,9 @@ export interface ActivePoolItem {
     reward: string;
   };
 }
+
+export type AccountActivePools = Record<string, ActivePool | null>;
+
+export type AccountPoolNominations = Record<string, Nominations>;
+
+export type AccountUnsubs = Record<string, VoidFn>;

--- a/src/hooks/useActivePools/index.tsx
+++ b/src/hooks/useActivePools/index.tsx
@@ -12,7 +12,6 @@ import type {
   ActivePoolsState,
 } from './types';
 import { useNetwork } from 'contexts/Network';
-import type { MaybeAddress } from 'types';
 
 export const useActivePools = ({ onCallback, who }: ActivePoolsProps) => {
   const { network } = useNetwork();
@@ -58,21 +57,12 @@ export const useActivePools = ({ onCallback, who }: ActivePoolsProps) => {
     }
   };
 
-  // Get active pools for an address.
-  const getActivePools = (address: MaybeAddress, poolId: string) => {
-    if (!address) {
-      return null;
-    }
-    return activePools?.[poolId] || null;
-  };
+  // Get an active pool.
+  const getActivePools = (poolId: string) => activePools?.[poolId] || null;
 
-  // Get active pool nominations for an address.
-  const getPoolNominations = (address: MaybeAddress, poolId: string) => {
-    if (!address) {
-      return null;
-    }
-    return poolNominations?.[poolId] || null;
-  };
+  // Get an active pool's nominations.
+  const getPoolNominations = (poolId: string) =>
+    poolNominations?.[poolId] || null;
 
   // Reset state on network change.
   useEffect(() => {

--- a/src/hooks/useActivePools/types.ts
+++ b/src/hooks/useActivePools/types.ts
@@ -4,9 +4,10 @@
 import type { Nominations } from 'contexts/Balances/types';
 import type { ActivePool } from 'contexts/Pools/ActivePool/types';
 import type { DetailActivePool } from 'controllers/ActivePoolsController/types';
+import type { MaybeAddress } from 'types';
 
 export interface ActivePoolsProps {
-  poolIds: string[] | '*';
+  who: MaybeAddress;
   onCallback?: (detail: DetailActivePool) => Promise<void>;
 }
 

--- a/src/library/Nominations/index.tsx
+++ b/src/library/Nominations/index.tsx
@@ -41,7 +41,7 @@ export const Nominations = ({
     modal: { openModal },
     canvas: { openCanvas },
   } = useOverlay();
-  const { syncing } = useSyncing();
+  const { syncing } = useSyncing(['balances', 'era-stakers']);
   const { getNominations } = useBalances();
   const { isFastUnstaking } = useUnstaking();
   const { formatWithPrefs } = useValidators();
@@ -77,7 +77,7 @@ export const Nominations = ({
   // Determine whether buttons are disabled.
   const btnsDisabled =
     (!isPool && inSetup()) ||
-    syncing ||
+    (!isPool && syncing) ||
     isReadOnlyAccount(activeAccount) ||
     poolDestroying ||
     isFastUnstaking;
@@ -131,7 +131,7 @@ export const Nominations = ({
           )}
         </div>
       </CardHeaderWrapper>
-      {syncing ? (
+      {!isPool && syncing ? (
         <ListStatusHeader>{`${t('nominate.syncing')}...`}</ListStatusHeader>
       ) : !nominator ? (
         <ListStatusHeader>{t('nominate.notNominating')}.</ListStatusHeader>

--- a/src/modals/AccountPoolRoles/index.tsx
+++ b/src/modals/AccountPoolRoles/index.tsx
@@ -43,7 +43,7 @@ export const AccountPoolRoles = () => {
           )}
           <h4>
             {t('activeRoles', {
-              count: activePools?.length || 0,
+              count: Object.keys(activePools)?.length || 0,
             })}
           </h4>
           <div className="items">

--- a/src/pages/Pools/Home/ManagePool/index.tsx
+++ b/src/pages/Pools/Home/ManagePool/index.tsx
@@ -9,18 +9,14 @@ import { useActivePool } from 'contexts/Pools/ActivePool';
 import { CardHeaderWrapper, CardWrapper } from 'library/Card/Wrappers';
 import { Nominations } from 'library/Nominations';
 import { useOverlay } from 'kits/Overlay/Provider';
-import { useActiveAccounts } from 'contexts/ActiveAccounts';
-import { useSyncing } from 'hooks/useSyncing';
 import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { ButtonHelp } from 'kits/Buttons/ButtonHelp';
 import { ButtonPrimary } from 'kits/Buttons/ButtonPrimary';
 
 export const ManagePool = () => {
   const { t } = useTranslation();
-  const { syncing } = useSyncing(['active-pools']);
   const { openCanvas } = useOverlay().canvas;
   const { formatWithPrefs } = useValidators();
-  const { activeAccount } = useActiveAccounts();
   const { isOwner, isNominator, activePoolNominations, activePool } =
     useActivePool();
 
@@ -38,9 +34,7 @@ export const ManagePool = () => {
   return (
     <PageRow>
       <CardWrapper>
-        {syncing ? (
-          <Nominations bondFor="pool" nominator={activeAccount} />
-        ) : canNominate && !isNominating && state !== 'Destroying' ? (
+        {canNominate && !isNominating && state !== 'Destroying' ? (
           <>
             <CardHeaderWrapper $withAction $withMargin>
               <h3>

--- a/src/pages/Pools/Home/index.tsx
+++ b/src/pages/Pools/Home/index.tsx
@@ -47,7 +47,7 @@ export const HomeInner = () => {
   const membership = getPoolMembership(activeAccount);
 
   const { activePools } = useActivePools({
-    poolIds: '*',
+    who: activeAccount,
   });
 
   // Calculate the number of _other_ pools the user has a role in.


### PR DESCRIPTION
Refector to persist all imported accounts active pools, to prevent re-syncing on account switching.