### PR TITLE
feat(ux): Simplify pool list, fetch performance on More click

### DIFF
--- a/src/contexts/Pools/PoolPerformance/types.ts
+++ b/src/contexts/Pools/PoolPerformance/types.ts
@@ -24,8 +24,9 @@ export interface PoolPerformanceContextInterface {
 }
 
 // Fetching status for keys.
-export type PoolPerformanceTasks = Partial<
-  Record<PoolRewardPointsKey, PoolPerformanceTaskStatus>
+export type PoolPerformanceTasks = Record<
+  PoolRewardPointsKey,
+  PoolPerformanceTaskStatus
 >;
 
 // Performance fetching status.
@@ -42,10 +43,10 @@ export interface PoolPerformanceTaskStatus {
  */
 
 // Supported reward points batch keys.
-export type PoolRewardPointsKey = 'pool_join' | 'pool_page';
+export type PoolRewardPointsKey = string;
 
 // Pool reward batches, keyed by batch key.
-export type PoolRewardPointsMap = Partial<Record<string, PoolRewardPoints>>;
+export type PoolRewardPointsMap = Record<PoolRewardPointsKey, PoolRewardPoints>;
 
 // Pool reward points are keyed by era, then by pool address.
 

--- a/src/library/List/defaults.ts
+++ b/src/library/List/defaults.ts
@@ -17,7 +17,7 @@ export const defaultContext: ListContextInterface = {
 };
 
 // The amount of pools per page.
-export const poolsPerPage = 21;
+export const poolsPerPage = 30;
 
 // The amount of validators per page.
 export const validatorsPerPage = 30;

--- a/src/library/ListItem/Labels/More.tsx
+++ b/src/library/ListItem/Labels/More.tsx
@@ -5,30 +5,39 @@ import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { useOverlay } from 'kits/Overlay/Provider';
+import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
+import type { BondedPool } from 'contexts/Pools/BondedPools/types';
 
-export const JoinPool = ({
-  id,
+export const More = ({
+  pool,
   setActiveTab,
   disabled,
 }: {
-  id: number;
+  pool: BondedPool;
   setActiveTab: (t: number) => void;
   disabled: boolean;
 }) => {
   const { t } = useTranslation('tips');
   const { openCanvas } = useOverlay().canvas;
+  const { startPoolRewardPointsFetch } = usePoolPerformance();
+
+  const { id, addresses } = pool;
+
+  // Define a unique pool performance data key
+  const performanceKey = `pool_page_standalone_${id}`;
 
   return (
     <div className="label button-with-text">
       <button
         type="button"
         onClick={() => {
+          startPoolRewardPointsFetch(performanceKey, [addresses.stash]);
           openCanvas({
             key: 'JoinPool',
             options: {
               providedPool: {
                 id,
-                performanceBatchKey: 'pool_page',
+                performanceBatchKey: performanceKey,
               },
               onJoinCallback: () => setActiveTab(0),
             },

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -14,7 +14,7 @@ export const PoolBonded = ({ pool }: { pool: Pool }) => {
   const {
     networkData: {
       units,
-      brand: { inline },
+      brand: { token },
     },
   } = useNetwork();
   const { setTooltipTextAndOpen } = useTooltip();
@@ -22,7 +22,7 @@ export const PoolBonded = ({ pool }: { pool: Pool }) => {
   const tooltipText = t('bonded');
 
   const { points } = pool;
-  const TokenIcon = inline.svg;
+  const TokenIcon = token;
 
   // Format total bonded pool amount.
   const bonded = planckToUnit(new BigNumber(rmCommas(points)), units);
@@ -35,7 +35,10 @@ export const PoolBonded = ({ pool }: { pool: Pool }) => {
         onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
       />
 
-      <TokenIcon height="1rem" style={{ marginRight: '0.25rem' }} />
+      <TokenIcon
+        style={{ maxWidth: '1.25rem', height: '1.25rem' }}
+        className="token"
+      />
       {bonded.decimalPlaces(0).toFormat()}
     </div>
   );

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -1,24 +1,19 @@
 // Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { capitalizeFirstLetter, planckToUnit, rmCommas } from '@w3ux/utils';
-import BigNumber from 'bignumber.js';
+import { capitalizeFirstLetter } from '@w3ux/utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useBondedPools } from 'contexts/Pools/BondedPools';
 import { useStaking } from 'contexts/Staking';
-import { ValidatorStatusWrapper } from 'library/ListItem/Wrappers';
+import { PoolStatusWrapper } from 'library/ListItem/Wrappers';
 import type { Pool } from 'library/Pool/types';
-import { useNetwork } from 'contexts/Network';
 
 export const PoolBonded = ({ pool }: { pool: Pool }) => {
   const { t } = useTranslation('library');
-  const {
-    networkData: { units, unit },
-  } = useNetwork();
   const { getPoolNominationStatusCode, poolsNominations } = useBondedPools();
   const { eraStakers, getNominationsStatusFromTargets } = useStaking();
-  const { addresses, points } = pool;
+  const { addresses } = pool;
 
   // get pool targets from nominations meta batch
   const nominations = poolsNominations[pool.id];
@@ -54,25 +49,22 @@ export const PoolBonded = ({ pool }: { pool: Pool }) => {
     handleNominationsStatus();
   }, [pool, eraStakers.stakers.length, Object.keys(poolsNominations).length]);
 
-  // calculate total bonded pool amount
-  const poolBonded = planckToUnit(new BigNumber(rmCommas(points)), units);
-
   // determine nominations status and display
   const nominationStatus = getPoolNominationStatusCode(
     nominationsStatus || null
   );
 
   return (
-    <ValidatorStatusWrapper $status={nominationStatus} $noMargin>
-      <h5>
-        {nominationStatus === null || !eraStakers.stakers.length
-          ? `${t('syncing')}...`
-          : targets.length
-            ? capitalizeFirstLetter(t(`${nominationStatus}`) ?? '')
-            : t('notNominating')}
-        {' / '}
-        {t('bonded')}: {poolBonded.decimalPlaces(3).toFormat()} {unit}
-      </h5>
-    </ValidatorStatusWrapper>
+    <PoolStatusWrapper $status={nominationStatus}>
+      <h4>
+        <span>
+          {nominationStatus === null || !eraStakers.stakers.length
+            ? `${t('syncing')}...`
+            : targets.length
+              ? capitalizeFirstLetter(t(`${nominationStatus}`) ?? '')
+              : t('notNominating')}
+        </span>
+      </h4>
+    </PoolStatusWrapper>
   );
 };

--- a/src/library/ListItem/Labels/PoolBonded.tsx
+++ b/src/library/ListItem/Labels/PoolBonded.tsx
@@ -1,0 +1,42 @@
+// Copyright 2024 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { planckToUnit, rmCommas } from '@w3ux/utils';
+import BigNumber from 'bignumber.js';
+import { useNetwork } from 'contexts/Network';
+import type { Pool } from 'library/Pool/types';
+import { TooltipTrigger } from '../Wrappers';
+import { useTranslation } from 'react-i18next';
+import { useTooltip } from 'contexts/Tooltip';
+
+export const PoolBonded = ({ pool }: { pool: Pool }) => {
+  const { t } = useTranslation('library');
+  const {
+    networkData: {
+      units,
+      brand: { inline },
+    },
+  } = useNetwork();
+  const { setTooltipTextAndOpen } = useTooltip();
+
+  const tooltipText = t('bonded');
+
+  const { points } = pool;
+  const TokenIcon = inline.svg;
+
+  // Format total bonded pool amount.
+  const bonded = planckToUnit(new BigNumber(rmCommas(points)), units);
+
+  return (
+    <div className="label pool">
+      <TooltipTrigger
+        className="tooltip-trigger-element"
+        data-tooltip-text={tooltipText}
+        onMouseMove={() => setTooltipTextAndOpen(tooltipText)}
+      />
+
+      <TokenIcon height="1rem" style={{ marginRight: '0.25rem' }} />
+      {bonded.decimalPlaces(0).toFormat()}
+    </div>
+  );
+};

--- a/src/library/ListItem/Labels/PoolNominateStatus.tsx
+++ b/src/library/ListItem/Labels/PoolNominateStatus.tsx
@@ -9,7 +9,7 @@ import { useStaking } from 'contexts/Staking';
 import { PoolStatusWrapper } from 'library/ListItem/Wrappers';
 import type { Pool } from 'library/Pool/types';
 
-export const PoolBonded = ({ pool }: { pool: Pool }) => {
+export const PoolNominateStatus = ({ pool }: { pool: Pool }) => {
   const { t } = useTranslation('library');
   const { getPoolNominationStatusCode, poolsNominations } = useBondedPools();
   const { eraStakers, getNominationsStatusFromTargets } = useStaking();

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -13,7 +13,7 @@ export const Wrapper = styled.div`
     --height-bottom-row: 2.75rem;
   }
   &.pool-more {
-    --height-bottom-row: 7.5rem;
+    --height-bottom-row: 5.5rem;
   }
 
   --height-total: calc(var(--height-top-row) + var(--height-bottom-row));
@@ -66,6 +66,7 @@ export const Wrapper = styled.div`
         &.lg {
           display: flex;
           align-items: center;
+
           > div {
             &:first-child {
               flex-grow: 1;
@@ -138,7 +139,7 @@ export const Labels = styled.div`
     }
 
     &.button-with-text {
-      margin-right: 0;
+      margin: 0.25rem 0 0 0;
 
       button {
         color: var(--accent-color-secondary);
@@ -250,6 +251,43 @@ export const ValidatorStatusWrapper = styled.div<{
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+`;
+
+export const PoolStatusWrapper = styled.div<{
+  $status: string;
+}>`
+  h4,
+  h5 {
+    display: flex;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  h4 {
+    color: var(--text-color-tertiary);
+    font-size: 1rem;
+
+    padding-top: ${(props) =>
+      props.$status === 'active' ? '0.15rem' : '0.25rem'};
+
+    > span {
+      color: ${(props) =>
+        props.$status === 'active'
+          ? 'var(--status-success-color)'
+          : 'var(--text-color-tertiary)'};
+
+      border: 0.75px solid
+        ${(props) =>
+          props.$status === 'active'
+            ? 'var(--status-success-color)'
+            : 'transparent'};
+
+      padding: ${(props) => (props.$status === 'active' ? '0 0.5rem' : '0')};
+      border-radius: 0.3rem;
+      opacity: ${(props) => (props.$status === 'active' ? 1 : 0.6)};
+    }
   }
 `;
 

--- a/src/library/ListItem/Wrappers.ts
+++ b/src/library/ListItem/Wrappers.ts
@@ -13,7 +13,7 @@ export const Wrapper = styled.div`
     --height-bottom-row: 2.75rem;
   }
   &.pool-more {
-    --height-bottom-row: 5.5rem;
+    --height-bottom-row: 5.75rem;
   }
 
   --height-total: calc(var(--height-top-row) + var(--height-bottom-row));
@@ -63,6 +63,10 @@ export const Wrapper = styled.div`
       &.bottom {
         height: var(--height-bottom-row);
 
+        &.pools {
+          align-items: flex-start;
+        }
+
         &.lg {
           display: flex;
           align-items: center;
@@ -94,6 +98,10 @@ export const Labels = styled.div`
   flex-grow: 1;
   padding: 0 0 0 0.25rem;
   height: inherit;
+
+  &.yMargin {
+    margin-bottom: 0.9rem;
+  }
 
   button {
     background: var(--shimmer-foreground);
@@ -130,14 +138,11 @@ export const Labels = styled.div`
     align-items: center;
     justify-content: center;
     font-size: inherit;
+    margin: 0 0.4em;
 
-    @media (min-width: ${SmallFontSizeMaxWidth}px) {
-      margin: 0 0.35rem;
-      &.pool {
-        margin: 0 0.45rem;
-      }
+    > .token {
+      margin-right: 0.25rem;
     }
-
     &.button-with-text {
       margin: 0.25rem 0 0 0;
 

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -13,28 +13,15 @@ import { Members } from '../ListItem/Labels/Members';
 import { PoolId } from '../ListItem/Labels/PoolId';
 import type { PoolProps } from './types';
 import { useSyncing } from 'hooks/useSyncing';
-import { useNetwork } from 'contexts/Network';
-import { planckToUnit, rmCommas } from '@w3ux/utils';
-import BigNumber from 'bignumber.js';
+import { PoolBonded } from 'library/ListItem/Labels/PoolBonded';
 
 export const Pool = ({ pool }: PoolProps) => {
-  const { memberCounter, addresses, id, points } = pool;
+  const { memberCounter, addresses, id } = pool;
   const { setActiveTab } = usePoolsTabs();
   const { syncing } = useSyncing(['active-pools']);
   const { getCurrentCommission } = usePoolCommission();
-  const {
-    networkData: {
-      units,
-      brand: { inline },
-    },
-  } = useNetwork();
-
-  const TokenIcon = inline.svg;
 
   const currentCommission = getCurrentCommission(id);
-
-  // Calculate total bonded pool amount.
-  const bonded = planckToUnit(new BigNumber(rmCommas(points)), units);
 
   return (
     <Wrapper className="pool-more">
@@ -63,10 +50,7 @@ export const Pool = ({ pool }: PoolProps) => {
               )}
               <PoolId id={id} />
               <Members members={memberCounter} />
-              <div className="label pool">
-                <TokenIcon height="1rem" style={{ marginRight: '0.25rem' }} />{' '}
-                {bonded.decimalPlaces(0).toFormat()}
-              </div>
+              {<PoolBonded pool={pool} />}
             </Labels>
 
             <Labels>

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -12,16 +12,29 @@ import { JoinPool } from '../ListItem/Labels/JoinPool';
 import { Members } from '../ListItem/Labels/Members';
 import { PoolId } from '../ListItem/Labels/PoolId';
 import type { PoolProps } from './types';
-import { Rewards } from './Rewards';
 import { useSyncing } from 'hooks/useSyncing';
+import { useNetwork } from 'contexts/Network';
+import { planckToUnit, rmCommas } from '@w3ux/utils';
+import BigNumber from 'bignumber.js';
 
 export const Pool = ({ pool }: PoolProps) => {
-  const { memberCounter, addresses, id } = pool;
+  const { memberCounter, addresses, id, points } = pool;
   const { setActiveTab } = usePoolsTabs();
   const { syncing } = useSyncing(['active-pools']);
   const { getCurrentCommission } = usePoolCommission();
+  const {
+    networkData: {
+      units,
+      brand: { inline },
+    },
+  } = useNetwork();
+
+  const TokenIcon = inline.svg;
 
   const currentCommission = getCurrentCommission(id);
+
+  // Calculate total bonded pool amount.
+  const bonded = planckToUnit(new BigNumber(rmCommas(points)), units);
 
   return (
     <Wrapper className="pool-more">
@@ -35,9 +48,13 @@ export const Pool = ({ pool }: PoolProps) => {
           </div>
         </div>
         <Separator />
-        <div className="row bottom lg">
+        <div
+          className="row bottom lg"
+          style={{ alignItems: 'flex-start', paddingTop: '0.75rem' }}
+        >
           <div>
-            <Rewards address={addresses.stash} displayFor="default" />
+            <Labels style={{ marginBottom: '0.9rem' }}>&nbsp;</Labels>
+            <PoolBonded pool={pool} />
           </div>
           <div>
             <Labels style={{ marginBottom: '0.9rem' }}>
@@ -46,10 +63,13 @@ export const Pool = ({ pool }: PoolProps) => {
               )}
               <PoolId id={id} />
               <Members members={memberCounter} />
+              <div className="label pool">
+                <TokenIcon height="1rem" style={{ marginRight: '0.25rem' }} />{' '}
+                {bonded.decimalPlaces(0).toFormat()}
+              </div>
             </Labels>
-            <PoolBonded pool={pool} />
 
-            <Labels style={{ marginTop: '1rem' }}>
+            <Labels>
               <JoinPool
                 id={id}
                 setActiveTab={setActiveTab}

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -3,7 +3,7 @@
 
 import { usePoolCommission } from 'hooks/usePoolCommission';
 import { FavoritePool } from 'library/ListItem/Labels/FavoritePool';
-import { PoolBonded } from 'library/ListItem/Labels/PoolBonded';
+import { PoolNominateStatus } from 'library/ListItem/Labels/PoolNominateStatus';
 import { PoolCommission } from 'library/ListItem/Labels/PoolCommission';
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity';
 import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
@@ -54,7 +54,7 @@ export const Pool = ({ pool }: PoolProps) => {
         >
           <div>
             <Labels style={{ marginBottom: '0.9rem' }}>&nbsp;</Labels>
-            <PoolBonded pool={pool} />
+            <PoolNominateStatus pool={pool} />
           </div>
           <div>
             <Labels style={{ marginBottom: '0.9rem' }}>

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -8,7 +8,7 @@ import { PoolCommission } from 'library/ListItem/Labels/PoolCommission';
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity';
 import { Labels, Separator, Wrapper } from 'library/ListItem/Wrappers';
 import { usePoolsTabs } from 'pages/Pools/Home/context';
-import { JoinPool } from '../ListItem/Labels/JoinPool';
+import { More } from '../ListItem/Labels/More';
 import { Members } from '../ListItem/Labels/Members';
 import { PoolId } from '../ListItem/Labels/PoolId';
 import type { PoolProps } from './types';
@@ -54,8 +54,8 @@ export const Pool = ({ pool }: PoolProps) => {
             </Labels>
 
             <Labels>
-              <JoinPool
-                id={id}
+              <More
+                pool={pool}
                 setActiveTab={setActiveTab}
                 disabled={syncing}
               />

--- a/src/library/Pool/index.tsx
+++ b/src/library/Pool/index.tsx
@@ -35,22 +35,19 @@ export const Pool = ({ pool }: PoolProps) => {
           </div>
         </div>
         <Separator />
-        <div
-          className="row bottom lg"
-          style={{ alignItems: 'flex-start', paddingTop: '0.75rem' }}
-        >
+        <div className="row bottom lg pools">
           <div>
-            <Labels style={{ marginBottom: '0.9rem' }}>&nbsp;</Labels>
+            <Labels className="yMargin">&nbsp;</Labels>
             <PoolNominateStatus pool={pool} />
           </div>
           <div>
-            <Labels style={{ marginBottom: '0.9rem' }}>
+            <Labels className="yMargin">
               {currentCommission > 0 && (
                 <PoolCommission commission={`${currentCommission}%`} />
               )}
               <PoolId id={id} />
               <Members members={memberCounter} />
-              {<PoolBonded pool={pool} />}
+              <PoolBonded pool={pool} />
             </Labels>
 
             <Labels>

--- a/src/library/PoolList/index.tsx
+++ b/src/library/PoolList/index.tsx
@@ -28,10 +28,8 @@ import { usePoolList } from './context';
 import type { PoolListProps } from './types';
 import type { BondedPool } from 'contexts/Pools/BondedPools/types';
 import { useSyncing } from 'hooks/useSyncing';
-import { useValidators } from 'contexts/Validators/ValidatorEntries';
 import { useApi } from 'contexts/Api';
 import { useEffectIgnoreInitial } from '@w3ux/hooks';
-import { usePoolPerformance } from 'contexts/Pools/PoolPerformance';
 
 export const PoolList = ({
   allowMoreCols,
@@ -49,11 +47,9 @@ export const PoolList = ({
   const { activeEra } = useApi();
   const { syncing } = useSyncing();
   const { applyFilter } = usePoolFilters();
-  const { erasRewardPointsFetched } = useValidators();
   const { listFormat, setListFormat } = usePoolList();
-  const { startPoolRewardPointsFetch } = usePoolPerformance();
+  const { poolSearchFilter, poolsNominations } = useBondedPools();
   const { getFilters, getSearchTerm, setSearchTerm } = useFilters();
-  const { poolSearchFilter, poolsNominations, bondedPools } = useBondedPools();
 
   const includes = getFilters('include', 'pools');
   const excludes = getFilters('exclude', 'pools');
@@ -81,12 +77,12 @@ export const PoolList = ({
   // Whether this the initial render.
   const [synced, setSynced] = useState<boolean>(false);
 
-  // pagination
+  // Handle Pagination.
   const totalPages = Math.ceil(listPools.length / poolsPerPage);
   const pageEnd = page * poolsPerPage - 1;
   const pageStart = pageEnd - (poolsPerPage - 1);
 
-  // get paged subset of list items.
+  // Get paged subset of list items.
   const poolsToDisplay = listPools.slice(pageStart).slice(0, poolsPerPage);
 
   // Handle resetting of pool list when provided pools change.
@@ -96,7 +92,7 @@ export const PoolList = ({
     setSynced(true);
   };
 
-  // handle filter / order update
+  // Handle filter / order update
   const handlePoolsFilterUpdate = () => {
     const filteredPools = filterPoolList();
     setListPools(filteredPools);
@@ -118,17 +114,6 @@ export const PoolList = ({
     setListPools(filteredPools);
     setSearchTerm('pools', newValue);
   };
-
-  // Fetch pool performance data when list items or page changes. Requires `erasRewardPoints` and
-  // `bondedPools` to be fetched.
-  useEffect(() => {
-    if (erasRewardPointsFetched && bondedPools.length) {
-      startPoolRewardPointsFetch(
-        'pool_page',
-        poolsToDisplay.map(({ addresses }) => addresses.stash)
-      );
-    }
-  }, [JSON.stringify(listPools), page, erasRewardPointsFetched, bondedPools]);
 
   // Refetch list when pool list changes.
   useEffect(() => {


### PR DESCRIPTION
This PR moves away from displaying a pool's reward graph directly in the pool list, in favour of syncing and displaying it in the `JoinPool` canvas as and when the user visits it.

Fetching performance data is slow, and carries performance issues when users browse the pool pages, of filter it in any way. To maintain performance and ease of use of the pool list, performance is no longer fetched when the list upates.

UI has been simplified, and amount of pools per page is now at 30, from 21.