### PR TITLE
fix(manage-nominations): Revert changes behavior in Manage nominations

### DIFF
--- a/src/canvas/ManageNominations/index.tsx
+++ b/src/canvas/ManageNominations/index.tsx
@@ -54,7 +54,7 @@ export const ManageNominations = () => {
   // Default nominators, from canvas options.
   const [defaultNominations, setDefaultNominations] =
     useState<NominationSelectionWithResetCounter>({
-      nominations: options?.nominated || [],
+      nominations: [...(options?.nominated || [])],
       reset: 0,
     });
 
@@ -70,7 +70,7 @@ export const ManageNominations = () => {
 
   // Handler for reverting nomination updates.
   const handleRevertChanges = () => {
-    setNewNominations({ nominations: defaultNominations.nominations });
+    setNewNominations({ nominations: [...defaultNominations.nominations] });
     setDefaultNominations({
       nominations: defaultNominations.nominations,
       reset: defaultNominations.reset + 1,
@@ -194,7 +194,7 @@ export const ManageNominations = () => {
               set: handleSetupUpdate,
             },
           ]}
-          nominations={defaultNominations}
+          nominations={newNominations}
         />
       </CanvasFullScreenWrapper>
       <CanvasSubmitTxFooter>


### PR DESCRIPTION
"Revert Changes" is not working correctly in the Manage Nominations modal. The issue stems from both defaultNominations and newNominations pointing to the same memory. Consequently, when modifying newNominations, defaultNominations is also altered. As a result, clicking the "Revert Changes" button does not correctly revert the changes back.

https://github.com/paritytech/polkadot-staking-dashboard/blob/main/src/canvas/ManageNominations/index.tsx#L55-L64