### PR TITLE
fix: deduct funds reserved plank value for funds free

### DIFF
--- a/src/pages/Overview/BalanceChart.tsx
+++ b/src/pages/Overview/BalanceChart.tsx
@@ -113,12 +113,7 @@ export const BalanceChart = () => {
   let fundsReserved = planckToUnit(fundsReservedPlank, units);
 
   const fundsFree = planckToUnit(
-    BigNumber.max(
-      allTransferOptions.freeBalance
-        .minus(fundsReservedPlank)
-        .minus(fundsLockedPlank),
-      0
-    ),
+    BigNumber.max(allTransferOptions.freeBalance.minus(fundsLockedPlank), 0),
     units
   );
 

--- a/src/pages/Overview/BalanceChart.tsx
+++ b/src/pages/Overview/BalanceChart.tsx
@@ -107,13 +107,15 @@ export const BalanceChart = () => {
 
   // Available balance data.
   const fundsLockedPlank = BigNumber.max(frozen.minus(lockStakingAmount), 0);
+  const fundsReservedPlank = edReserved.plus(feeReserve);
+
   const fundsLocked = planckToUnit(fundsLockedPlank, units);
-  let fundsReserved = planckToUnit(edReserved.plus(feeReserve), units);
+  let fundsReserved = planckToUnit(fundsReservedPlank, units);
 
   const fundsFree = planckToUnit(
     BigNumber.max(
       allTransferOptions.freeBalance
-        .minus(fundsReserved)
+        .minus(fundsReservedPlank)
         .minus(fundsLockedPlank),
       0
     ),


### PR DESCRIPTION
Fixes an issue where the `fundsReserved` was not being deducted in plank format.

Addresses #2072