### PR TITLE
feat: Enable paged rewards on Kusama, disable `missing_identity`

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -20,10 +20,10 @@ import BigNumber from 'bignumber.js';
 // DEPRECATION: Paged Rewards
 //
 // Temporary until paged rewards migration has completed on all networks.
-export const NetworksWithPagedRewards: NetworkName[] = ['westend'];
+export const NetworksWithPagedRewards: NetworkName[] = ['westend', 'kusama'];
 export const PagedRewardsStartEra: Record<NetworkName, BigNumber | null> = {
   polkadot: null,
-  kusama: null,
+  kusama: new BigNumber(6514),
   westend: new BigNumber(7167),
 };
 

--- a/src/library/GenerateNominations/useFetchMethods.tsx
+++ b/src/library/GenerateNominations/useFetchMethods.tsx
@@ -68,7 +68,10 @@ export const useFetchMehods = () => {
     // filter validators to find active candidates
     filtered = applyFilter(
       ['active'],
-      ['all_commission', 'blocked_nominations', 'missing_identity'],
+      [
+        'all_commission',
+        'blocked_nominations' /* 'missing_identity', NOTE: disabled until People chain supported */,
+      ],
       filtered
     );
 
@@ -101,7 +104,7 @@ export const useFetchMehods = () => {
       [
         'all_commission',
         'blocked_nominations',
-        'missing_identity',
+        /* 'missing_identity', NOTE: disabled until People chain supported */
         'in_session',
       ],
       waiting
@@ -110,7 +113,10 @@ export const useFetchMehods = () => {
     // filter validators to find active candidates
     active = applyFilter(
       ['active'],
-      ['all_commission', 'blocked_nominations', 'missing_identity'],
+      [
+        'all_commission',
+        'blocked_nominations' /* 'missing_identity', NOTE: disabled until People chain supported */,
+      ],
       active
     );
 
@@ -141,7 +147,8 @@ export const useFetchMehods = () => {
         [
           'all_commission',
           'blocked_nominations',
-          'missing_identity',
+          /* 'missing_identity', NOTE: disabled until People chain supported */
+
           'not_parachain_validator',
         ],
         all
@@ -152,7 +159,10 @@ export const useFetchMehods = () => {
     const active =
       applyFilter(
         ['active'],
-        ['all_commission', 'blocked_nominations', 'missing_identity'],
+        [
+          'all_commission',
+          'blocked_nominations' /* 'missing_identity', NOTE: disabled until People chain supported */,
+        ],
         all
       ).filter(
         (n: Validator) => !nominations.find((o) => o.address === n.address)
@@ -166,7 +176,10 @@ export const useFetchMehods = () => {
     const random =
       applyFilter(
         null,
-        ['all_commission', 'blocked_nominations', 'missing_identity'],
+        [
+          'all_commission',
+          'blocked_nominations' /* 'missing_identity', NOTE: disabled until People chain supported */,
+        ],
         all
       ).filter(
         (n: Validator) => !nominations.find((o) => o.address === n.address)

--- a/src/library/ValidatorList/FilterValidators.tsx
+++ b/src/library/ValidatorList/FilterValidators.tsx
@@ -14,6 +14,13 @@ export const FilterValidators = () => {
   const { getFilters, toggleFilter } = useFilters();
   const { excludesToLabels, includesToLabels } = useValidatorFilters();
 
+  // Filtering missing_identity until People chain is supported.
+  const filteredExcludesToLabels = Object.fromEntries(
+    Object.entries(excludesToLabels).filter(
+      ([key]) => key !== 'missing_identity'
+    )
+  );
+
   const includes = getFilters('include', 'validators');
   const excludes = getFilters('exclude', 'validators');
 
@@ -40,7 +47,7 @@ export const FilterValidators = () => {
         ))}
 
         <h4>{t('exclude')}:</h4>
-        {Object.entries(excludesToLabels).map(([f, l], i) => (
+        {Object.entries(filteredExcludesToLabels).map(([f, l], i) => (
           <FilterListButton
             $active={excludes?.includes(f) ?? false}
             key={`validator_exclude_${i}`}

--- a/src/pages/Validators/AllValidators.tsx
+++ b/src/pages/Validators/AllValidators.tsx
@@ -49,7 +49,7 @@ export const AllValidators = () => {
                     excludes: [
                       'all_commission',
                       'blocked_nominations',
-                      'missing_identity',
+                      /* 'missing_identity', NOTE: disabled until People chain supported */
                     ],
                   }}
                   defaultOrder="rank"


### PR DESCRIPTION
This PR enables paged rewards on Kusama, and disables the "missing identity" filter as the People chain is now hosting identities on both Westend and Kusama.

Missing Identities will be re-introduced once the People system chain is supported. 