### PR TITLE
feat(refactor): Remove pre-paged rewards code

### DIFF
--- a/src/modals/ClaimPayouts/Forms.tsx
+++ b/src/modals/ClaimPayouts/Forms.tsx
@@ -32,7 +32,7 @@ export const Forms = forwardRef(
     ref: ForwardedRef<HTMLDivElement>
   ) => {
     const { t } = useTranslation('modals');
-    const { api, isPagedRewardsActive } = useApi();
+    const { api } = useApi();
     const {
       networkData: { units, unit },
     } = useNetwork();
@@ -68,16 +68,9 @@ export const Forms = forwardRef(
         if (!paginatedValidators) {
           return [];
         }
-
-        return paginatedValidators.forEach(([page, v]) => {
-          if (isPagedRewardsActive(new BigNumber(era))) {
-            return calls.push(api.tx.staking.payoutStakersByPage(v, era, page));
-          }
-          // DEPRECATION: Paged Rewards
-          //
-          // Fall back to deprecated `payoutStakers` if not on paged reward era.
-          return calls.push(api.tx.staking.payoutStakers(v, era));
-        });
+        return paginatedValidators.forEach(([page, v]) =>
+          calls.push(api.tx.staking.payoutStakersByPage(v, era, page))
+        );
       });
       return calls;
     };

--- a/src/model/Api/index.ts
+++ b/src/model/Api/index.ts
@@ -15,7 +15,7 @@ import type {
 } from 'contexts/Api/types';
 import { SyncController } from 'controllers/SyncController';
 import type { AnyApi, NetworkName } from 'types';
-import { NetworkList, NetworksWithPagedRewards } from 'config/networks';
+import { NetworkList } from 'config/networks';
 import { makeCancelable, rmCommas, stringToBigNumber } from '@w3ux/utils';
 import { WellKnownChain } from '@substrate/connect';
 import type { BlockNumber } from '@polkadot/types/interfaces';
@@ -245,19 +245,8 @@ export class Api {
       this.api.consts.staking.historyDepth,
       this.api.consts.fastUnstake.deposit,
       this.api.consts.nominationPools.palletId,
+      this.api.consts.staking.maxExposurePageSize,
     ];
-
-    // DEPRECATION: Paged Rewards
-    //
-    // Fetch `maxExposurePageSize` instead of `maxNominatorRewardedPerValidator` for networks that
-    // have paged rewards.
-    if (NetworksWithPagedRewards.includes(this.network)) {
-      allPromises.push(this.api.consts.staking.maxExposurePageSize);
-    } else {
-      allPromises.push(
-        this.api.consts.staking.maxNominatorRewardedPerValidator
-      );
-    }
 
     const consts = await Promise.all(allPromises);
 


### PR DESCRIPTION
Removes pre-paged rewards code that is no longer needed to calculate Payouts. `maxExposurePageSize` is also now being fetched for all networks, so the check for `maxNominatorRewardedPerValidator` is no longer needed.