### PR TITLE
feat: Implement browser language detection using navigator.language

### DIFF
--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -18,9 +18,9 @@ export const DefaultLocale = 'en'
 
 // Available locales as key value pairs.
 export const locales: Record<string, LocaleEntry> = {
-  en: { dateFormat: enGB, label: 'English' },
-  cn: { dateFormat: zhCN, label: '中文' },
-  es: { dateFormat: es, label: 'Español' },
+  en: { dateFormat: enGB, label: 'English', tag: 'en' },
+  cn: { dateFormat: zhCN, label: '中文', tag: 'zh' },
+  es: { dateFormat: es, label: 'Español', tag: 'es' },
 }
 
 // Supported namespaces.

--- a/packages/locales/src/types.ts
+++ b/packages/locales/src/types.ts
@@ -24,4 +24,5 @@ export type LocaleJsonValue =
 export interface LocaleEntry {
   dateFormat: Locale
   label: string
+  tag: string
 }

--- a/packages/locales/src/util.ts
+++ b/packages/locales/src/util.ts
@@ -20,10 +20,19 @@ export const getInitialLanguage = () => {
     return urlLng
   }
 
-  // fall back to localStorage if present.
+  // fall back to localStorage if present
   const localLng = localStorage.getItem('lng')
   if (localLng && Object.keys(locales).find((key) => key === localLng)) {
     return localLng
+  }
+
+  // fall back to browser language
+  const supportedBrowser = Object.entries(locales).find(([, { tag }]) =>
+    navigator.language.startsWith(tag)
+  )?.[0]
+  if (supportedBrowser) {
+    localStorage.setItem('lng', supportedBrowser)
+    return supportedBrowser
   }
 
   localStorage.setItem('lng', DefaultLocale)


### PR DESCRIPTION
Implements automatic language detection to improve localization experience for the Staking Dashboard. Closes #2492.

Changes:
- Adds browser language detection using navigator.language
- Implements support for English, Chinese, and Spanish
- Provides graceful fallback to English for unsupported languages