### PR TITLE
feat(refactor): staking context tidy up

### DIFF
--- a/packages/app/src/StakingApi/index.tsx
+++ b/packages/app/src/StakingApi/index.tsx
@@ -13,15 +13,15 @@ export const StakingApi = (props: Props) => {
   const { setFastUnstakeStatus } = useFastUnstake()
 
   useEffect(() => {
-    if (!isBonding()) {
+    if (!isBonding) {
       setFastUnstakeStatus(null)
     }
-  }, [isBonding()])
+  }, [isBonding])
 
   return (
     <>
       <UnclaimedRewardsApi {...props} />
-      {isBonding() && <FastUnstakeApi {...props} />}
+      {isBonding && <FastUnstakeApi {...props} />}
     </>
   )
 }

--- a/packages/app/src/contexts/Pools/ActivePool/index.tsx
+++ b/packages/app/src/contexts/Pools/ActivePool/index.tsx
@@ -49,7 +49,7 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
     : null
 
   // Returns whether the active pool is being bonded to
-  const isBonding = () => !!activePool
+  const isBonding = !!activePool
 
   // Returns whether the active account is the nominator in the active pool
   const isNominator = () => {
@@ -76,7 +76,7 @@ export const ActivePoolProvider = ({ children }: { children: ReactNode }) => {
   }
 
   // Returns whether the active account is in a pool.
-  const inPool = () => !!(poolMembership?.address === activeAddress)
+  const inPool = !!(poolMembership?.address === activeAddress)
 
   // Returns whether the active account is the depositor of the active pool
   const isDepositor = () => {

--- a/packages/app/src/contexts/Pools/ActivePool/types.ts
+++ b/packages/app/src/contexts/Pools/ActivePool/types.ts
@@ -4,8 +4,8 @@
 import type { ActivePool, Nominations, PoolRoles, PoolUnlocking } from 'types'
 
 export interface ActivePoolContextState {
-  inPool: () => boolean
-  isBonding: () => boolean
+  inPool: boolean
+  isBonding: boolean
   isNominator: () => boolean
   isOwner: () => boolean
   isMember: () => boolean

--- a/packages/app/src/contexts/Staking/index.tsx
+++ b/packages/app/src/contexts/Staking/index.tsx
@@ -157,19 +157,13 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
   }
 
   // Helper function to determine whether the active account is bonding, or is yet to start
-  const isBonding = () =>
-    (getStakingLedger(activeAddress).ledger?.active || 0n) > 0n
-
-  // Helper function to determine whether the active account
-  const isUnlocking = () =>
-    (getStakingLedger(activeAddress).ledger?.unlocking || []).length
+  const isBonding = (getStakingLedger(activeAddress).ledger?.active || 0n) > 0n
 
   // Helper function to determine whether the active account is nominating, or is yet to start
-  const isNominating = () => getNominations(activeAddress).length > 0
+  const isNominating = getNominations(activeAddress).length > 0
 
-  // Helper function to determine whether the active account is nominating, or is yet to start
-  const inSetup = () =>
-    !activeAddress || (!isBonding() && !isNominating() && !isUnlocking())
+  // Helper function to determine whether the active account is a nominator
+  const isNominator = activeAddress !== null && isBonding && isNominating
 
   // Fetch eras stakers from storage
   const getPagedErasStakers = async (era: string) => {
@@ -244,7 +238,7 @@ export const StakingProvider = ({ children }: { children: ReactNode }) => {
         getNominationsStatusFromTargets,
         isBonding,
         isNominating,
-        inSetup,
+        isNominator,
         eraStakers,
         getPagedErasStakers,
       }}

--- a/packages/app/src/contexts/Staking/types.ts
+++ b/packages/app/src/contexts/Staking/types.ts
@@ -47,9 +47,9 @@ export interface StakingContextInterface {
     w: MaybeAddress,
     t: string[]
   ) => Record<string, NominationStatus>
-  isBonding: () => boolean
-  isNominating: () => boolean
-  inSetup: () => boolean
+  isBonding: boolean
+  isNominating: boolean
+  isNominator: boolean
   eraStakers: EraStakers
   getPagedErasStakers: (e: string) => Promise<Exposure[]>
 }

--- a/packages/app/src/hooks/useNominationStatus/index.tsx
+++ b/packages/app/src/hooks/useNominationStatus/index.tsx
@@ -15,7 +15,8 @@ export const useNominationStatus = () => {
   const { getNominations } = useBalances()
   const { syncing } = useSyncing(['era-stakers'])
   const { activePoolNominations } = useActivePool()
-  const { inSetup, eraStakers, getNominationsStatusFromTargets } = useStaking()
+  const { isNominator, eraStakers, getNominationsStatusFromTargets } =
+    useStaking()
 
   // Utility to get an account's nominees alongside their status.
   const getNominationSetStatus = (who: MaybeAddress, type: BondFor) => {
@@ -67,7 +68,7 @@ export const useNominationStatus = () => {
 
     // Determine the localised message to display based on the nomination status.
     let str
-    if (inSetup() || syncing) {
+    if (!isNominator || syncing) {
       str = t('notNominating', { ns: 'pages' })
     } else if (!nominees.length) {
       str = t('noNominationsSet', { ns: 'pages' })

--- a/packages/app/src/hooks/useUnstaking/index.tsx
+++ b/packages/app/src/hooks/useUnstaking/index.tsx
@@ -11,7 +11,7 @@ import { useNominationStatus } from '../useNominationStatus'
 
 export const useUnstaking = () => {
   const { t } = useTranslation('app')
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { activeAddress } = useActiveAccounts()
   const { getTransferOptions } = useTransferOptions()
   const { getNominationStatus } = useNominationStatus()
@@ -45,7 +45,7 @@ export const useUnstaking = () => {
 
   return {
     getFastUnstakeText,
-    isUnstaking: !inSetup() && !nominees.active.length && active === 0n,
+    isUnstaking: isNominator && !nominees.active.length && active === 0n,
     isFastUnstaking: !!registered,
   }
 }

--- a/packages/app/src/library/Nominations/index.tsx
+++ b/packages/app/src/library/Nominations/index.tsx
@@ -35,11 +35,11 @@ export const Nominations = ({
     isNominator: isPoolNominator,
   } = useActivePool()
   const { openHelp } = useHelp()
-  const { inSetup } = useStaking()
   const {
     modal: { openModal },
     canvas: { openCanvas },
   } = useOverlay()
+  const { isNominator } = useStaking()
   const { syncing } = useSyncing(['era-stakers'])
   const { getNominations } = useBalances()
   const { isFastUnstaking } = useUnstaking()
@@ -75,7 +75,7 @@ export const Nominations = ({
 
   // Determine whether buttons are disabled.
   const btnsDisabled =
-    (!isPool && inSetup()) ||
+    (!isPool && !isNominator) ||
     (!isPool && syncing) ||
     isReadOnlyAccount(activeAddress) ||
     poolDestroying ||

--- a/packages/app/src/library/SideMenu/Main.tsx
+++ b/packages/app/src/library/SideMenu/Main.tsx
@@ -21,9 +21,9 @@ export const Main = () => {
   const { syncing } = useSyncing()
   const { pathname } = useLocation()
   const { inPool } = useActivePool()
+  const { isNominator } = useStaking()
   const { formatWithPrefs } = useValidators()
   const { activeAddress } = useActiveAccounts()
-  const { inSetup: inNominatorSetup } = useStaking()
   const { sideMenuMinimised, advancedMode } = useUi()
   const { getNominations, getStakingLedger } = useBalances()
   const { controllerUnmigrated } = getStakingLedger(activeAddress)
@@ -47,20 +47,20 @@ export const Main = () => {
         }
       }
       if (uri === `${import.meta.env.BASE_URL}nominate`) {
-        if (!inNominatorSetup()) {
+        if (isNominator) {
           pages[i].bullet = 'accent'
           return true
         }
         if (
           (!syncing && controllerUnmigrated) ||
-          (!inNominatorSetup() && fullCommissionNominees.length > 0)
+          (isNominator && fullCommissionNominees.length > 0)
         ) {
           pages[i].bullet = 'warning'
           return true
         }
       }
       if (uri === `${import.meta.env.BASE_URL}pools`) {
-        if (inPool()) {
+        if (inPool) {
           pages[i].bullet = 'accent'
           return true
         }

--- a/packages/app/src/library/StatusLabel/index.tsx
+++ b/packages/app/src/library/StatusLabel/index.tsx
@@ -23,12 +23,12 @@ export const StatusLabel = ({
   const { openHelp } = useHelp()
   const { syncing } = useSyncing()
   const { plugins } = usePlugins()
-  const { inSetup } = useStaking()
   const { inPool } = useActivePool()
+  const { isNominator } = useStaking()
 
   // syncing or not staking
   if (status === 'sync_or_setup') {
-    if (syncing || !inSetup() || inPool()) {
+    if (syncing || isNominator || inPool) {
       return null
     }
   }

--- a/packages/app/src/overlay/canvas/Pool/Overview/index.tsx
+++ b/packages/app/src/overlay/canvas/Pool/Overview/index.tsx
@@ -14,14 +14,14 @@ import { Roles } from './Roles'
 import { Stats } from './Stats'
 
 export const Overview = (props: OverviewSectionProps) => {
-  const { inSetup } = useStaking()
   const { inPool } = useActivePool()
+  const { isNominator } = useStaking()
   const { activeAddress } = useActiveAccounts()
   const {
     bondedPool: { state },
   } = props
   const showJoinForm =
-    activeAddress !== null && state === 'Open' && !inPool() && inSetup()
+    activeAddress !== null && state === 'Open' && !inPool && !isNominator
 
   return (
     <Interface

--- a/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
+++ b/packages/app/src/pages/Nominate/Active/CommissionPrompt.tsx
@@ -20,7 +20,7 @@ import { useOverlay } from 'ui-overlay'
 
 export const CommissionPrompt = () => {
   const { t } = useTranslation('pages')
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { getNominations } = useBalances()
   const { openCanvas } = useOverlay().canvas
   const { getThemeValue } = useThemeValues()
@@ -33,7 +33,7 @@ export const CommissionPrompt = () => {
     (nominee) => nominee.prefs.commission === 100
   )
 
-  if (!fullCommissionNominees.length || inSetup() || syncing) {
+  if (!fullCommissionNominees.length || !isNominator || syncing) {
     return null
   }
 

--- a/packages/app/src/pages/Nominate/Active/ManageBond.tsx
+++ b/packages/app/src/pages/Nominate/Active/ManageBond.tsx
@@ -39,7 +39,7 @@ export const ManageBond = () => {
   const { network } = useNetwork()
   const { openHelp } = useHelp()
   const { syncing } = useSyncing()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { openModal } = useOverlay().modal
   const { getStakingLedger } = useBalances()
   const { isFastUnstaking } = useUnstaking()
@@ -88,7 +88,7 @@ export const ManageBond = () => {
     )
 
   const unstakeDisabled =
-    inSetup() || syncing || isReadOnlyAccount(activeAddress)
+    !isNominator || syncing || isReadOnlyAccount(activeAddress)
 
   const bondDisabled = unstakeDisabled || isFastUnstaking
 

--- a/packages/app/src/pages/Nominate/Active/Status/NewNominator.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NewNominator.tsx
@@ -29,7 +29,7 @@ export const NewNominator = ({ syncing }: NewNominatorProps) => {
   const { generateOptimalSetup, setNominatorSetup } = useNominatorSetups()
 
   const nominateButtonDisabled =
-    !isReady || !activeAddress || isReadOnlyAccount(activeAddress) || inPool()
+    !isReady || !activeAddress || isReadOnlyAccount(activeAddress) || inPool
 
   return (
     <CallToActionWrapper>

--- a/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/NominationStatus.tsx
@@ -20,7 +20,7 @@ export const NominationStatus = () => {
     <Stat
       label={t('status')}
       helpKey="Nomination Status"
-      stat={inPool() ? t('alreadyInPool') : nominationStatus.message}
+      stat={inPool ? t('alreadyInPool') : nominationStatus.message}
     />
   )
 }

--- a/packages/app/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/PayoutDestinationStatus.tsx
@@ -16,7 +16,7 @@ import { useOverlay } from 'ui-overlay'
 export const PayoutDestinationStatus = () => {
   const { t } = useTranslation('pages')
   const { syncing } = useSyncing()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { openModal } = useOverlay().modal
   const { getStakingLedger } = useBalances()
   const { isFastUnstaking } = useUnstaking()
@@ -28,7 +28,7 @@ export const PayoutDestinationStatus = () => {
 
   // Get payee status text to display.
   const getPayeeStatus = () => {
-    if (inSetup()) {
+    if (!isNominator) {
       return t('notAssigned')
     }
     const status = getPayeeItems(true).find(
@@ -42,7 +42,7 @@ export const PayoutDestinationStatus = () => {
   }
 
   // Get the payee destination icon to display, falling back to wallet icon.
-  const payeeIcon = inSetup()
+  const payeeIcon = !isNominator
     ? undefined
     : getPayeeItems(true).find(({ value }) => value === payee?.destination)
         ?.icon || faWallet
@@ -54,7 +54,7 @@ export const PayoutDestinationStatus = () => {
       icon={payeeIcon}
       stat={getPayeeStatus()}
       buttons={
-        !inSetup()
+        isNominator
           ? [
               {
                 title: t('update'),
@@ -62,7 +62,7 @@ export const PayoutDestinationStatus = () => {
                 small: true,
                 disabled:
                   syncing ||
-                  inSetup() ||
+                  !isNominator ||
                   isReadOnlyAccount(activeAddress) ||
                   isFastUnstaking,
                 onClick: () => openModal({ key: 'UpdatePayee', size: 'sm' }),

--- a/packages/app/src/pages/Nominate/Active/Status/index.tsx
+++ b/packages/app/src/pages/Nominate/Active/Status/index.tsx
@@ -15,7 +15,7 @@ import { UnclaimedPayoutsStatus } from './UnclaimedPayoutsStatus'
 
 export const Status = ({ height }: { height: number }) => {
   const { syncing } = useSyncing()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { pluginEnabled } = usePlugins()
   const { activeAddress } = useActiveAccounts()
   const { isReadOnlyAccount } = useImportedAccounts()
@@ -23,16 +23,16 @@ export const Status = ({ height }: { height: number }) => {
   return (
     <CardWrapper
       height={height}
-      className={!syncing && inSetup() ? 'prompt' : undefined}
+      className={!syncing && !isNominator ? 'prompt' : undefined}
     >
       <NominationStatus />
       <Separator />
       <UnclaimedPayoutsStatus
-        dimmed={inSetup() || !pluginEnabled('staking_api')}
+        dimmed={!isNominator || !pluginEnabled('staking_api')}
       />
 
       {!syncing ? (
-        !inSetup() ? (
+        isNominator ? (
           <>
             <Separator />
             <PayoutDestinationStatus />

--- a/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
+++ b/packages/app/src/pages/Nominate/Active/UnstakePrompts.tsx
@@ -19,8 +19,8 @@ import { useOverlay } from 'ui-overlay'
 export const UnstakePrompts = () => {
   const { t } = useTranslation('pages')
   const { syncing } = useSyncing()
-  const { inSetup } = useStaking()
   const { network } = useNetwork()
+  const { isNominator } = useStaking()
   const { openModal } = useOverlay().modal
   const { getThemeValue } = useThemeValues()
   const { activeAddress } = useActiveAccounts()
@@ -36,7 +36,7 @@ export const UnstakePrompts = () => {
     isUnstaking && active === 0n && totalUnlocking === 0n && totalUnlocked > 0n
 
   return (
-    !inSetup() &&
+    isNominator &&
     (isUnstaking || isFastUnstaking) &&
     !syncing && (
       <Page.Row>

--- a/packages/app/src/pages/Nominate/Active/index.tsx
+++ b/packages/app/src/pages/Nominate/Active/index.tsx
@@ -30,11 +30,11 @@ export const Active = () => {
   const { openHelp } = useHelp()
   const { syncing } = useSyncing()
   const { getNominations } = useBalances()
-  const { inSetup, isBonding } = useStaking()
   const { openCanvas } = useOverlay().canvas
   const { isFastUnstaking } = useUnstaking()
   const { formatWithPrefs } = useValidators()
   const { activeAddress } = useActiveAccounts()
+  const { isNominator, isBonding } = useStaking()
 
   const nominated = formatWithPrefs(getNominations(activeAddress))
   const ROW_HEIGHT = 220
@@ -60,10 +60,10 @@ export const Active = () => {
           <Status height={ROW_HEIGHT} />
         </Page.RowSection>
       </Page.Row>
-      {isBonding() && (
+      {isBonding && (
         <Page.Row>
           <CardWrapper>
-            {nominated?.length || inSetup() || syncing ? (
+            {nominated?.length || !isNominator || syncing ? (
               <Nominations bondFor="nominator" nominator={activeAddress} />
             ) : (
               <>
@@ -81,7 +81,7 @@ export const Active = () => {
                       iconLeft={faChevronCircleRight}
                       iconTransform="grow-1"
                       text={`${t('nominate', { ns: 'pages' })}`}
-                      disabled={inSetup() || syncing || isFastUnstaking}
+                      disabled={!isNominator || syncing || isFastUnstaking}
                       onClick={() =>
                         openCanvas({
                           key: 'ManageNominations',

--- a/packages/app/src/pages/Nominate/NominationGeo/NominationGeoList/index.tsx
+++ b/packages/app/src/pages/Nominate/NominationGeo/NominationGeoList/index.tsx
@@ -74,7 +74,7 @@ export const NominationGeoList = ({ title, data }: NomninationGeoListProps) => {
             !(
               activeAddress &&
               ['polkadot', 'kusama'].includes(network) &&
-              isNominating()
+              isNominating
             )
           }
         />

--- a/packages/app/src/pages/Nominate/NominationGeo/index.tsx
+++ b/packages/app/src/pages/Nominate/NominationGeo/index.tsx
@@ -61,11 +61,11 @@ export const NominationGeo = () => {
 
   // Status label config.
   const showDisabledLabel = !enabled
-  const showNotNominatingLabel = enabled && !isNominating()
-  const showNotAvailableLabel = enabled && !analyticsAvailable && isNominating()
+  const showNotNominatingLabel = enabled && !isNominating
+  const showNotAvailableLabel = enabled && !analyticsAvailable && isNominating
 
   // Whether to interact with Polkawatch API.
-  const callPolkawatchApi = networkSupported && enabled && isNominating()
+  const callPolkawatchApi = networkSupported && enabled && isNominating
 
   useEffect(() => {
     if (callPolkawatchApi) {
@@ -84,7 +84,7 @@ export const NominationGeo = () => {
       setNetworkMeta({} as ChainMetadata)
       setAnalyticsAvailable(false)
     }
-  }, [activeAddress, network, enabled, isNominating()])
+  }, [activeAddress, network, enabled, isNominating])
 
   // NOTE: The list of dependencies assume that changing network
   // triggers a change of account also (i.e. different network prefix).
@@ -108,7 +108,7 @@ export const NominationGeo = () => {
       setNominationDetail({} as NominatorDetail)
       setAnalyticsAvailable(false)
     }
-  }, [activeAddress, network, enabled, isNominating()])
+  }, [activeAddress, network, enabled, isNominating])
 
   return (
     <>

--- a/packages/app/src/pages/Overview/AccountBalance/BalanceLinks.tsx
+++ b/packages/app/src/pages/Overview/AccountBalance/BalanceLinks.tsx
@@ -51,7 +51,7 @@ export const BalanceLinks = () => {
             !(
               activeAddress &&
               ['polkadot', 'kusama'].includes(network) &&
-              isNominating()
+              isNominating
             )
           }
         />

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -29,16 +29,16 @@ import { InactiveGraph } from './InactiveGraph'
 export const Payouts = () => {
   const { i18n, t } = useTranslation('pages')
   const { network } = useNetwork()
-  const { inSetup } = useStaking()
   const { syncing } = useSyncing()
   const { containerRefs } = useUi()
   const { inPool } = useActivePool()
   const { currency } = useCurrency()
+  const { isNominator } = useStaking()
   const { pluginEnabled } = usePlugins()
 
   const { units } = getStakingChainData(network)
   const Token = getChainIcons(network).token
-  const staking = !inSetup() || inPool
+  const staking = isNominator || inPool
   const notStaking = !syncing && !staking
 
   const [lastReward, setLastReward] = useState<RewardResult>()
@@ -109,8 +109,8 @@ export const Payouts = () => {
         >
           {staking && pluginEnabled('staking_api') ? (
             <ActiveGraph
-              nominating={!inSetup()}
-              inPool={inPool()}
+              nominating={isNominator}
+              inPool={inPool}
               lineMarginTop="3rem"
               setLastReward={setLastReward}
             />

--- a/packages/app/src/pages/Overview/QuickActions/index.tsx
+++ b/packages/app/src/pages/Overview/QuickActions/index.tsx
@@ -16,12 +16,12 @@ import type { QuickActionGroup } from './types'
 
 export const QuickActions = ({ height }: { height: number }) => {
   const { t } = useTranslation('pages')
-  const { inSetup } = useStaking()
   const { inPool } = useActivePool()
+  const { isNominator } = useStaking()
   const { accountSynced } = useSyncing()
   const { activeAddress } = useActiveAccounts()
 
-  const isStaking = inPool() || !inSetup()
+  const isStaking = inPool || isNominator
   const syncing = !accountSynced(activeAddress)
 
   let actionGroup: QuickActionGroup = 'staking'
@@ -45,7 +45,7 @@ export const QuickActions = ({ height }: { height: number }) => {
           {actionGroup === 'disconnected' && <Disconnected />}
           {actionGroup === 'notStaking' && <NotStaking />}
           {actionGroup === 'staking' && (
-            <Staking bondFor={inPool() ? 'pool' : 'nominator'} />
+            <Staking bondFor={inPool ? 'pool' : 'nominator'} />
           )}
         </>
       )}

--- a/packages/app/src/pages/Overview/StakeStatus/Tips/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/Tips/index.tsx
@@ -99,7 +99,7 @@ export const Tips = () => {
   const segments: AnyJson = []
   if (!activeAddress) {
     segments.push(1)
-  } else if (!isNominating() && !inPool()) {
+  } else if (!isNominating && !inPool) {
     if (freeBalance - feeReserve > minNominatorBond) {
       segments.push(2)
     } else {
@@ -107,10 +107,10 @@ export const Tips = () => {
     }
     segments.push(4)
   } else {
-    if (isNominating()) {
+    if (isNominating) {
       segments.push(5)
     }
-    if (inPool()) {
+    if (inPool) {
       if (!isOwner()) {
         segments.push(6)
       } else {

--- a/packages/app/src/pages/Overview/StakeStatus/index.tsx
+++ b/packages/app/src/pages/Overview/StakeStatus/index.tsx
@@ -12,11 +12,11 @@ import { StatusWrapper } from './Wrappers'
 
 export const StakeStatus = ({ height }: { height: number }) => {
   const { inPool } = useActivePool()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
 
-  const notStaking = !inPool() && inSetup()
-  const showNominate = notStaking || !inSetup()
-  const showMembership = notStaking || inPool()
+  const notStaking = !inPool && !isNominator
+  const showNominate = notStaking || isNominator
+  const showMembership = notStaking || inPool
 
   return (
     <CardWrapper style={{ padding: 0 }} height={height}>

--- a/packages/app/src/pages/Pools/ClosurePrompts.tsx
+++ b/packages/app/src/pages/Pools/ClosurePrompts.tsx
@@ -81,7 +81,7 @@ export const ClosurePrompts = () => {
                     ? t('unlocked')
                     : String(totalUnlockChunks ?? 0)
                 }
-                disabled={syncing || !isBonding()}
+                disabled={syncing || !isBonding}
                 onClick={() =>
                   openModal({
                     key: 'UnlockChunks',

--- a/packages/app/src/pages/Pools/ManageBond.tsx
+++ b/packages/app/src/pages/Pools/ManageBond.tsx
@@ -43,7 +43,7 @@ export const ManageBond = () => {
 
   const bondDisabled =
     syncing ||
-    !isBonding() ||
+    !isBonding ||
     !isMember() ||
     isReadOnlyAccount(activeAddress) ||
     state === 'Destroying'

--- a/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
+++ b/packages/app/src/pages/Pools/Status/MembershipStatus.tsx
@@ -22,7 +22,7 @@ export const MembershipStatus = ({
 }: MembershipStatusProps) => {
   const { t } = useTranslation('pages')
   const { isReady } = useApi()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { label } = useStatusButtons()
   const { openModal } = useOverlay().modal
   const { poolsMetaData } = useBondedPools()
@@ -83,7 +83,7 @@ export const MembershipStatus = ({
     <Stat
       label={t('poolMembership')}
       helpKey="Pool Membership"
-      stat={!inSetup() ? t('alreadyNominating') : t('notInPool')}
+      stat={isNominator ? t('alreadyNominating') : t('notInPool')}
       buttonType={buttonType}
     />
   )

--- a/packages/app/src/pages/Pools/Status/NewMember.tsx
+++ b/packages/app/src/pages/Pools/Status/NewMember.tsx
@@ -14,16 +14,16 @@ import { useStatusButtons } from './useStatusButtons'
 
 export const NewMember = ({ syncing }: NewMemberProps) => {
   const { t } = useTranslation()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { setActiveTab } = usePoolsTabs()
   const { openCanvas } = useOverlay().canvas
   const { getJoinDisabled, getCreateDisabled } = useStatusButtons()
 
   // Alias for create button disabled state
-  const createDisabled = getCreateDisabled() || !inSetup()
+  const createDisabled = getCreateDisabled() || isNominator
 
   // Disable opening the canvas if data is not ready.
-  const joinButtonDisabled = getJoinDisabled() || !inSetup()
+  const joinButtonDisabled = getJoinDisabled() || isNominator
 
   return (
     <CallToActionWrapper>

--- a/packages/app/src/pages/Pools/Status/index.tsx
+++ b/packages/app/src/pages/Pools/Status/index.tsx
@@ -24,19 +24,19 @@ export const Status = ({ height }: StatusProps) => {
   return (
     <CardWrapper
       height={height}
-      className={!syncing && !activePool && !inPool() ? 'prompt' : undefined}
+      className={!syncing && !activePool && !inPool ? 'prompt' : undefined}
     >
       <MembershipStatus />
       <Separator />
-      <RewardsStatus dimmed={inPool() === null} />
+      <RewardsStatus dimmed={inPool === null} />
       {!syncing ? (
-        activePool && inPool() ? (
+        activePool && inPool ? (
           <>
             <Separator />
             <PoolStatus />
           </>
         ) : (
-          !inPool() &&
+          !inPool &&
           !isReadOnlyAccount(activeAddress) && <NewMember syncing={syncing} />
         )
       ) : (

--- a/packages/app/src/pages/Rewards/Overview/RecentPayouts/index.tsx
+++ b/packages/app/src/pages/Rewards/Overview/RecentPayouts/index.tsx
@@ -29,10 +29,10 @@ export const RecentPayouts = ({
   loading,
 }: PayoutHistoryProps) => {
   const { i18n, t } = useTranslation('pages')
-  const { inSetup } = useStaking()
   const { syncing } = useSyncing()
   const { containerRefs } = useUi()
   const { inPool } = useActivePool()
+  const { isNominator } = useStaking()
   const { pluginEnabled } = usePlugins()
 
   const payoutsFromDate = getPayoutsFromDate(
@@ -43,8 +43,7 @@ export const RecentPayouts = ({
     payoutsList,
     locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat
   )
-  const nominating = !inSetup()
-  const staking = nominating || inPool
+  const staking = isNominator || inPool
   const notStaking = !syncing && !staking
 
   const ref = useRef<HTMLDivElement>(null)
@@ -104,8 +103,8 @@ export const RecentPayouts = ({
         >
           {staking && pluginEnabled('staking_api') ? (
             <ActiveGraph
-              nominating={nominating}
-              inPool={inPool()}
+              nominating={isNominator}
+              inPool={inPool}
               payoutGraphData={payoutGraphData}
               loading={loading}
             />

--- a/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
+++ b/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
@@ -23,7 +23,7 @@ export const RewardTrend = () => {
   const { t } = useTranslation('pages')
   const { network } = useNetwork()
   const { activeEra } = useApi()
-  const { inSetup } = useStaking()
+  const { isNominator } = useStaking()
   const { erasPerDay } = useErasPerDay()
   const { getStakingLedger } = useBalances()
   const { activeAddress } = useActiveAccounts()
@@ -49,7 +49,7 @@ export const RewardTrend = () => {
 
   useEffect(() => {
     setRewardTrend(null)
-    if (!inSetup() || poolMembership) {
+    if (isNominator || poolMembership) {
       getRewardTrend()
     }
   }, [
@@ -57,7 +57,7 @@ export const RewardTrend = () => {
     network,
     activeEra.index.toString(),
     poolMembership,
-    inSetup(),
+    isNominator,
   ])
 
   // Format the reward trend data


### PR DESCRIPTION
Simplifies some staking API and naming, notably `inSetup()` is now just an `isNominator` boolean.