### PR TITLE
feat: Remove unused imports on save

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,11 @@
 				"noStaticOnlyClass": "off"
 			},
 			"correctness": {
+				"noUnusedImports": {
+					"level": "warn",
+					"fix": "safe",
+					"options": {}
+				},
 				"useExhaustiveDependencies": "off",
 				"useJsxKeyInIterable": "off"
 			},


### PR DESCRIPTION
This PR enables automatic removal of unused imports when saving files by configuring the Biome linter to detect and fix unused imports.