### PR TITLE
fix: Use balanceTxFees instead of transferableBalance for transaction validation

### DIFF
--- a/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
+++ b/packages/app/src/hooks/useSubmitExtrinsic/index.tsx
@@ -64,7 +64,7 @@ export const useSubmitExtrinsic = ({
 	const { activeAccount, activeProxy } = useActiveAccounts()
 	const { getAccount, requiresManualSign } = useImportedAccounts()
 	const {
-		balances: { transferableBalance },
+		balances: { balanceTxFees },
 	} = useAccountBalances(from)
 	const { unit, units } = getStakingChainData(network)
 
@@ -348,7 +348,7 @@ export const useSubmitExtrinsic = ({
 		}
 
 		const txFee = getTxSubmission(uid)?.fee || 0n
-		const hasInsufficientFunds = transferableBalance < txFee
+		const hasInsufficientFunds = balanceTxFees < txFee
 
 		let title = t('cancelled')
 		let subtitle = t('transactionCancelled')

--- a/packages/app/src/library/SubmitTx/index.tsx
+++ b/packages/app/src/library/SubmitTx/index.tsx
@@ -44,9 +44,9 @@ export const SubmitTx = ({
 	const submitted = txSubmission?.submitted || false
 
 	const {
-		balances: { transferableBalance },
+		balances: { balanceTxFees },
 	} = useAccountBalances(from)
-	const notEnoughFunds = transferableBalance - fee < 0n && fee > 0n
+	const notEnoughFunds = balanceTxFees - fee < 0n && fee > 0n
 
 	// Default to active account, using activeAccount to get the correct account
 	let signingOpts = {


### PR DESCRIPTION
Users were blocked from signing transactions even with sufficient balance. For example, a user with 0.02 KSM was unable to sign a transaction with 0.00009 KSM fee because the validation incorrectly used transferableBalance (which subtracts the 0.05 KSM fee reserve) instead of balanceTxFees.

This fix ensures transaction validation only checks if the account has enough balance to pay the current transaction fee plus existential deposit, not the configurable fee reserve meant for future transactions.