### PR TITLE
feat(refactor): Ensure pool title with missing metadata

### DIFF
--- a/packages/app/src/canvas/Pool/Header.tsx
+++ b/packages/app/src/canvas/Pool/Header.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Polkicon } from '@w3ux/react-polkicon'
+import { ellipsisFn } from '@w3ux/utils'
 import { PerbillMultiplier } from 'consts'
 import { onTabVisitEvent } from 'event-tracking'
 import { PageTabs } from 'library/PageTabs'
@@ -17,7 +18,7 @@ export const Header = ({
 	setActiveTab,
 }: HeaderProps) => {
 	const { t } = useTranslation()
-	const poolCommission = bondedPool?.commission?.current?.[0]
+	const poolCommission = bondedPool.commission?.current?.[0]
 
 	// Pool state to tag class
 	const getTagClass = (state: PoolState) => {
@@ -31,19 +32,22 @@ export const Header = ({
 		}
 	}
 
+	// Render title as metadata, or fallback to clipped stash address
+	const title = metadata || ellipsisFn(bondedPool.addresses.stash)
+
 	return (
 		<AccountTitle>
 			<div>
 				<div>
 					<Polkicon
-						address={bondedPool?.addresses.stash || ''}
+						address={bondedPool.addresses.stash || ''}
 						background="transparent"
 						fontSize="4rem"
 					/>
 				</div>
 				<div>
 					<div className="title">
-						<h1>{metadata}</h1>
+						<h1>{title}</h1>
 					</div>
 					<HeadTags>
 						<h3>

--- a/packages/app/src/canvas/Pool/types.ts
+++ b/packages/app/src/canvas/Pool/types.ts
@@ -7,7 +7,7 @@ import type { BondedPool, RoleIdentities } from 'types'
 export interface HeaderProps {
 	activeTab: number
 	bondedPool: BondedPool
-	metadata: string
+	metadata: string | undefined
 	autoSelected: boolean
 	setActiveTab: (tab: number) => void
 }


### PR DESCRIPTION
This PR refactors the pool header component to gracefully handle cases where pool metadata is missing by displaying a fallback title using the pool's stash address.

**Changes:**
- Updated the `HeaderProps` interface to allow `metadata` to be `undefined`
- Added fallback logic to display an ellipsified stash address when metadata is not available
- Removed unnecessary optional chaining on `bondedPool` (guaranteed to be defined at render time)
