### PR TITLE
fix: enable Ledger device confirmation and add debug logging for Nano X address issue

### DIFF
--- a/packages/app/src/contexts/LedgerHardware/static/ledger.ts
+++ b/packages/app/src/contexts/LedgerHardware/static/ledger.ts
@@ -58,11 +58,23 @@ export class Ledger {
 
 		const result = await withTimeout(
 			3000,
-			app.getAddress(bip42Path, ss58Prefix, false),
+			app.getAddress(bip42Path, ss58Prefix, true),
 			{
 				onTimeout: () => this.transport?.close(),
 			},
 		)
+
+		// Debug logging for Ledger device address retrieval
+		console.log('[Ledger Debug] Address retrieval:', {
+			device: this.transport?.device?.productName || 'Unknown',
+			path: bip42Path,
+			accountIndex: index,
+			ss58Prefix,
+			pubKey: (result as AnyJson)?.pubKey,
+			address: (result as AnyJson)?.address,
+			returnCode: (result as AnyJson)?.return_code,
+		})
+
 		await this.ensureClosed()
 		return result
 	}


### PR DESCRIPTION
**Issue: Ledger Nano X displays correct address on device but returns different address to the dashboard, while Ledger Flex works correctly. This appears to be an SS58 encoding mismatch in Nano X firmware.**

**Changes:**
- Enable device confirmation (showAddrInDevice: true) in getAddress() call
  * Forces user to verify address on device before import
  * Ensures consistency between displayed and returned address
  * Adds manual verification step to catch encoding mismatches

- Add debug console logging to capture:
  * Device model (Nano X, Flex, etc.)
  * Derivation path and account index
  * SS58 prefix (network identifier)
  * Raw public key and encoded address
  * Return code for error diagnosis