### PR TITLE
feat(ux): Add pool commission change rate warning

### DIFF
--- a/packages/app/src/hooks/useWarnings/index.tsx
+++ b/packages/app/src/hooks/useWarnings/index.tsx
@@ -1,7 +1,11 @@
 // Copyright 2025 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faCircleUp, faTrashCan } from '@fortawesome/free-regular-svg-icons'
+import {
+	faCalendarXmark,
+	faCircleUp,
+	faTrashCan,
+} from '@fortawesome/free-regular-svg-icons'
 import { useActiveAccounts } from 'contexts/ActiveAccounts'
 import { poolWarnings$ } from 'global-bus'
 import type { WarningMessage } from 'pages/Overview/Summaries/types'
@@ -38,6 +42,13 @@ export const useWarnings = () => {
 						description: t('warnings.highCommissionDescription'),
 						format: 'warning',
 					})
+				} else if (warning.type === 'noChangeRate') {
+					messages.push({
+						value: t('warnings.noChangeRateTitle'),
+						faIcon: faCalendarXmark,
+						description: t('warnings.noChangeRateDescription'),
+						format: 'warning',
+					})
 				}
 			})
 
@@ -48,17 +59,11 @@ export const useWarnings = () => {
 	}, [activeAddress])
 
 	const getMostSevereWarningFormat = () => {
-		let format: 'danger' | 'warning' = 'warning'
-
-		warningMessages.forEach((message) => {
-			if (message.format === 'danger') {
-				format = 'danger'
-				return
-			} else if (message.format === 'warning') {
-				format = 'warning'
-			}
-		})
-		return format
+		// Danger is more severe than warning, so return danger if any danger messages exist
+		const hasDanger = warningMessages.some(
+			(message) => message.format === 'danger',
+		)
+		return hasDanger ? 'danger' : 'warning'
 	}
 
 	return { warningMessages, getMostSevereWarningFormat }

--- a/packages/global-bus/src/poolWarnings/index.ts
+++ b/packages/global-bus/src/poolWarnings/index.ts
@@ -10,7 +10,7 @@ import { _poolWarnings } from './private'
 export interface PoolWarning {
 	poolId: number
 	address: string
-	type: 'destroying' | 'highCommission'
+	type: 'destroying' | 'highCommission' | 'noChangeRate'
 }
 
 export interface PoolWarningsState {
@@ -67,6 +67,9 @@ export const fetchAndSetPoolWarnings = async (
 			...result.highCommissionPools
 				.filter((m) => m.address === address)
 				.map((m) => ({ ...m, type: 'highCommission' as const })),
+			...result.noChangeRatePools
+				.filter((m) => m.address === address)
+				.map((m) => ({ ...m, type: 'noChangeRate' as const })),
 		]
 	})
 

--- a/packages/locales/src/resources/en/app.json
+++ b/packages/locales/src/resources/en/app.json
@@ -380,7 +380,9 @@
 			"destroyingDescription": "Your pool is being destroyed and you cannot earn pool rewards.",
 			"destroyingTitle": "Pool is Destroying",
 			"highCommissionDescription": "Your pool's commission is high. Consider joining a different pool to increase rewards.",
-			"highCommissionTitle": "High Commission"
+			"highCommissionTitle": "High Commission",
+			"noChangeRateDescription": "Your pool has no commission change rate set. It can increase its commission to any value at any time.",
+			"noChangeRateTitle": "No Commission Change Rate"
 		},
 		"webExtensions": "Web Extensions",
 		"whenActivelyNominating": "when actively nominating.",

--- a/packages/locales/src/resources/es/app.json
+++ b/packages/locales/src/resources/es/app.json
@@ -380,7 +380,9 @@
 			"destroyingDescription": "Tu pool está siendo destruido y no puedes ganar recompensas del pool.",
 			"destroyingTitle": "Pool está siendo destruido",
 			"highCommissionDescription": "La comisión de tu pool es alta. Considera unirte a un pool diferente para aumentar las recompensas.",
-			"highCommissionTitle": "Comisión Alta"
+			"highCommissionTitle": "Comisión Alta",
+			"noChangeRateDescription": "Su fondo no tiene una tasa de cambio de comisión establecida. Puede aumentar su comisión a cualquier valor en cualquier momento.",
+			"noChangeRateTitle": "Tasa de cambio sin comisión"
 		},
 		"webExtensions": "Extensión de Navegador",
 		"whenActivelyNominating": "cuando nominas activamente.",

--- a/packages/locales/src/resources/zh/app.json
+++ b/packages/locales/src/resources/zh/app.json
@@ -376,6 +376,8 @@
 		"destroyingDescription": "您的奖池将被销毁，您将无法获得奖池奖励。",
 		"destroyingtitle": "奖池正在销毁",
 		"highCommissionDescription": "您的奖池佣金较高。考虑加入其他奖池以增加奖励。",
-		"highCommissionTitle": "高佣金"
+		"highCommissionTitle": "高佣金",
+		"noChangeRateDescription": "您的奖池未设置佣金变动率。它可以随时将佣金提高到任何值。",
+		"noChangeRateTitle": "无佣金变更率"
 	}
 }

--- a/packages/plugin-staking-api/src/queries/poolWarnings.ts
+++ b/packages/plugin-staking-api/src/queries/poolWarnings.ts
@@ -19,12 +19,19 @@ const QUERY = gql`
 				address
 			}
 		}
+		noChangeRatePoolMembers(network: $network, addresses: $addresses) {
+			members {
+				poolId
+				address
+			}
+		}
 	}
 `
 
 const DEFAULT: PoolWarningsResult = {
 	destroyingPools: [],
 	highCommissionPools: [],
+	noChangeRatePools: [],
 }
 
 export const fetchPoolWarnings = async (
@@ -45,6 +52,7 @@ export const fetchPoolWarnings = async (
 			destroyingPools: result?.data?.destroyingPoolMembers?.members || [],
 			highCommissionPools:
 				result?.data?.highCommissionPoolMembers?.members || [],
+			noChangeRatePools: result?.data?.noChangeRatePoolMembers?.members || [],
 		}
 	} catch {
 		return DEFAULT

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -267,6 +267,9 @@ export interface PoolWarningsData {
 	highCommissionPoolMembers: {
 		members: HighCommissionPoolMember[]
 	}
+	noChangeRatePoolMembers: {
+		members: NoChangeRatePoolMember[]
+	}
 }
 
 export interface DestroyingPoolMember {
@@ -279,7 +282,13 @@ export interface HighCommissionPoolMember {
 	address: string
 }
 
+export interface NoChangeRatePoolMember {
+	poolId: number
+	address: string
+}
+
 export interface PoolWarningsResult {
 	destroyingPools: DestroyingPoolMember[]
 	highCommissionPools: HighCommissionPoolMember[]
+	noChangeRatePools: NoChangeRatePoolMember[]
 }


### PR DESCRIPTION
This PR adds support for warning pool members when their pool has no commission change rate set with their commission, allowing the pool to increase commission to any value at any time.

**Changes:**
- Added `NoChangeRatePoolMember` type and integrated it into pool warnings data structures
- Extended GraphQL query to fetch no-change-rate pool members
- Added translations for no commission change rate warnings in English, Spanish, and Chinese
- Updated warning display logic to show the new warning type with a calendar-xmark icon
- Refactored `getMostSevereWarningFormat` function for better readability