### PR TITLE
feat: Track provider change events between RPC and Light Client

### DIFF
--- a/packages/app/src/modals/Networks/index.tsx
+++ b/packages/app/src/modals/Networks/index.tsx
@@ -9,6 +9,7 @@ import { useApi } from 'contexts/Api'
 import { useNetwork } from 'contexts/Network'
 import { usePrompt } from 'contexts/Prompt'
 import { useUi } from 'contexts/UI'
+import { onNodeProviderTypeChangedEvent } from 'event-tracking'
 import { setAutoRpc, setProviderType } from 'global-bus'
 import { Title } from 'library/Modal/Title'
 import { useEffect } from 'react'
@@ -90,6 +91,7 @@ export const Networks = () => {
 								onClick={() => {
 									setProviderType('sc')
 									switchNetwork(networkKey as NetworkId)
+									onNodeProviderTypeChangedEvent(networkKey, 'light_client')
 									closeModal()
 								}}
 							>
@@ -105,6 +107,7 @@ export const Networks = () => {
 								onClick={() => {
 									setProviderType('ws')
 									switchNetwork(networkKey as NetworkId)
+									onNodeProviderTypeChangedEvent(networkKey, 'rpc')
 									closeModal()
 								}}
 							>

--- a/packages/event-tracking/src/index.ts
+++ b/packages/event-tracking/src/index.ts
@@ -67,3 +67,11 @@ export const onTransactionSubmittedEvent = (
 ) => {
 	onSaEvent(`${network.toLowerCase()}_tx_submitted_${txLabel}`)
 }
+
+// Node provider type changed
+export const onNodeProviderTypeChangedEvent = (
+	network: string,
+	method: string,
+) => {
+	onSaEvent(`${network.toLowerCase()}_node_provider_type_changed_${method}`)
+}


### PR DESCRIPTION
Tracks when node provider (RPC / light client) is switched.