### PR TITLE
fix: correct Ledger hardware handling bugs

### DIFF
--- a/packages/app/src/contexts/LedgerHardware/index.tsx
+++ b/packages/app/src/contexts/LedgerHardware/index.tsx
@@ -198,7 +198,7 @@ export const LedgerHardwareProvider = ({
 				setStatusFeedback({
 					message: t('openAppOnLedger'),
 					helpKey: 'Open App On Ledger',
-					code: 'TransactionRejected',
+					code: 'AppNotOpen',
 				})
 				break
 			// Occurs when submitted extrinsic(s) are not supported
@@ -213,7 +213,7 @@ export const LedgerHardwareProvider = ({
 				setStatusFeedback({
 					message: t('transactionRejectedPending'),
 					helpKey: 'Ledger Rejected Transaction',
-					code: 'AppNotOpen',
+					code: 'TransactionRejected',
 				})
 				break
 			// Handle all other errors

--- a/packages/app/src/contexts/LedgerHardware/static/ledger.ts
+++ b/packages/app/src/contexts/LedgerHardware/static/ledger.ts
@@ -64,14 +64,6 @@ export class Ledger {
 			},
 		)
 
-		// Debug logging for Ledger device address retrieval
-		console.log('[Ledger Debug] Address retrieval:', {
-			device: this.transport?.device?.productName || 'Unknown',
-			path: bip42Path,
-			accountIndex: index,
-			ss58Prefix,
-			result,
-		})
 		await this.ensureClosed()
 		return result
 	}


### PR DESCRIPTION
The patch component was incorrectly assigned result?.major instead of result?.patch, corrupting the semantic version string used to determine whether the Ledger app is a legacy version.