### PR TITLE
feat(fix): Fix reward trend API

### DIFF
--- a/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
+++ b/packages/app/src/pages/Rewards/Stats/RewardTrend.tsx
@@ -39,10 +39,11 @@ export const RewardTrend = () => {
 	// Fetch the reward trend on account, network changes. Ensure the active era is greater than 0
 	const getRewardTrend = async () => {
 		if (activeAddress && activeEra.index > 0) {
-			const { rewardTrend } = membership
+			const result = membership
 				? await fetchPoolRewardTrend(network, activeAddress, duration)
 				: await fetchNominatorRewardTrend(network, activeAddress, eras)
-			setRewardTrend(rewardTrend)
+
+			setRewardTrend(result)
 		}
 	}
 

--- a/packages/plugin-staking-api/src/queries/nominatorRewardTrend.ts
+++ b/packages/plugin-staking-api/src/queries/nominatorRewardTrend.ts
@@ -3,7 +3,7 @@
 
 import { gql } from '@apollo/client'
 import { client } from '../Client'
-import type { RewardTrendData } from '../types'
+import type { NominatorRewardTrendData, RewardTrend } from '../types'
 
 const QUERY = gql`
   query NominatorRewardTrend($network: String!, $who: String!, $eras: Int!) {
@@ -18,14 +18,12 @@ const QUERY = gql`
   }
 `
 
-const DEFAULT: RewardTrendData = {
-	rewardTrend: {
-		reward: '0',
-		previous: '0',
-		change: {
-			percent: '0',
-			value: '0',
-		},
+const DEFAULT: RewardTrend = {
+	reward: '0',
+	previous: '0',
+	change: {
+		percent: '0',
+		value: '0',
 	},
 }
 
@@ -33,13 +31,13 @@ export const fetchNominatorRewardTrend = async (
 	network: string,
 	who: string,
 	eras: number,
-): Promise<RewardTrendData> => {
+): Promise<RewardTrend> => {
 	try {
-		const result = await client.query<RewardTrendData>({
+		const result = await client.query<NominatorRewardTrendData>({
 			query: QUERY,
 			variables: { network, who, eras },
 		})
-		return result?.data || DEFAULT
+		return result?.data?.nominatorRewardTrend || DEFAULT
 	} catch {
 		return DEFAULT
 	}

--- a/packages/plugin-staking-api/src/queries/poolRewardTrend.ts
+++ b/packages/plugin-staking-api/src/queries/poolRewardTrend.ts
@@ -3,7 +3,7 @@
 
 import { gql } from '@apollo/client'
 import { client } from '../Client'
-import type { RewardTrendData } from '../types'
+import type { PoolRewardTrendData, RewardTrend } from '../types'
 
 const QUERY = gql`
   query PoolRewardTrend($network: String!, $who: String!, $duration: Int!) {
@@ -18,14 +18,12 @@ const QUERY = gql`
   }
 `
 
-const DEFAULT: RewardTrendData = {
-	rewardTrend: {
-		reward: '0',
-		previous: '0',
-		change: {
-			percent: '0',
-			value: '0',
-		},
+const DEFAULT: RewardTrend = {
+	reward: '0',
+	previous: '0',
+	change: {
+		percent: '0',
+		value: '0',
 	},
 }
 
@@ -33,13 +31,13 @@ export const fetchPoolRewardTrend = async (
 	network: string,
 	who: string,
 	duration: number,
-): Promise<RewardTrendData> => {
+): Promise<RewardTrend> => {
 	try {
-		const result = await client.query<RewardTrendData>({
+		const result = await client.query<PoolRewardTrendData>({
 			query: QUERY,
 			variables: { network, who, duration },
 		})
-		return result?.data || DEFAULT
+		return result?.data?.poolRewardTrend || DEFAULT
 	} catch {
 		return DEFAULT
 	}

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -76,8 +76,12 @@ export interface EraTotalNominatorsData {
 	}
 }
 
-export interface RewardTrendData {
-	rewardTrend: RewardTrend
+export interface NominatorRewardTrendData {
+	nominatorRewardTrend: RewardTrend
+}
+
+export interface PoolRewardTrendData {
+	poolRewardTrend: RewardTrend
 }
 
 export interface RewardTrend {


### PR DESCRIPTION
Updates the staking reward trend fetching/types so the client returns the correct GraphQL field payload for pool vs nominator reward trend queries, and updates the app UI to consume the corrected return shape.

**Changes:**
- Split reward trend query response types into `NominatorRewardTrendData` and `PoolRewardTrendData`.
- Update both reward trend query helpers to return the inner `RewardTrend` object (with correct GraphQL response key).
- Update Rewards UI to use the new return value directly rather than destructuring `{ rewardTrend }`.
