### PR TITLE
chore: optimise era points high calculation

### DIFF
--- a/packages/app/src/library/List/EraPointsGraph/HistoricalEraPoints.tsx
+++ b/packages/app/src/library/List/EraPointsGraph/HistoricalEraPoints.tsx
@@ -23,8 +23,10 @@ export const HistoricalEraPoints = ({
 	const { validatorsFetched } = useValidators()
 	const { setTooltipTextAndOpen } = useTooltip()
 
-	const eraPointData: bigint[] = eraPoints.map(({ points }) => BigInt(points))
-	const high = eraPointData.sort((a, b) => Number(b - a))[0]
+	const high = eraPoints.reduce<bigint>((acc, { points }) => {
+		const value = BigInt(points)
+		return value > acc ? value : acc
+	}, 0n)
 
 	const normalisedPoints = normaliseEraPoints(
 		Object.fromEntries(


### PR DESCRIPTION
### Summary
Optimises historical era points processing by replacing a full array sort with a single-pass max calculation.

### What changed
- Replaced `eraPointData.sort(...)[0]` in `HistoricalEraPoints` with a `reduce` that computes the max value in one pass.
- Removed the temporary `eraPointData` array used only for sorting.

### Why
The previous approach sorted all point values to obtain only the highest one, doing extra work (`O(n log n)`) and mutating the temporary array. This change computes the same result in `O(n)` with less overhead and clearer intent.

### Scope
This is a small, behaviour-preserving optimisation limited to one component and one calculation path.

### Validation
- `corepack pnpm --filter app exec biome check src/library/List/EraPointsGraph/HistoricalEraPoints.tsx` ✅
- `corepack pnpm --filter app exec tsc --noEmit --skipLibCheck` ✅

### Risks / notes
Low risk. The logic still derives the same `high` value and keeps the existing fallback path (`high || 1`) for empty datasets.
