### PR TITLE
perf: stable context values in Proxies, NominatorSetups, EraStakers

### DIFF
--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -10,7 +10,7 @@ import { usePlugins } from 'contexts/Plugins'
 import { removeSyncing, setSyncing } from 'global-bus'
 import { fetchEraTotalNominators } from 'plugin-staking-api'
 import type { ReactNode } from 'react'
-import { useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import type {
 	ErasStakersOverviewEntries,
 	MaybeAddress,
@@ -258,42 +258,48 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 	}
 
 	// Gets the nomination statuses of the provided nominator and targets
-	const getNominationsStatusFromEraStakers = (
-		who: MaybeAddress,
-		targets: string[],
-	) => {
-		const statuses: Record<string, NominationStatus> = {}
-		if (!targets.length) {
+	const getNominationsStatusFromEraStakers = useCallback(
+		(who: MaybeAddress, targets: string[]) => {
+			const statuses: Record<string, NominationStatus> = {}
+			if (!targets.length) {
+				return statuses
+			}
+			for (const target of targets) {
+				const staker = eraStakers.stakers.find(
+					({ address }) => address === target,
+				)
+				if (staker === undefined) {
+					statuses[target] = 'waiting'
+					continue
+				}
+				if (!(staker.others ?? []).find((o) => o.who === who)) {
+					statuses[target] = 'inactive'
+					continue
+				}
+				statuses[target] = 'active'
+			}
 			return statuses
-		}
-		for (const target of targets) {
-			const staker = eraStakers.stakers.find(
-				({ address }) => address === target,
-			)
-			if (staker === undefined) {
-				statuses[target] = 'waiting'
-				continue
-			}
-			if (!(staker.others ?? []).find((o) => o.who === who)) {
-				statuses[target] = 'inactive'
-				continue
-			}
-			statuses[target] = 'active'
-		}
-		return statuses
-	}
+		},
+		[eraStakers.stakers],
+	)
 
 	// Checks whether an address is an active nominator
-	const isNominatorActive = (who: MaybeAddress) => {
-		return eraStakers.stakers.some((staker) =>
-			staker.others.find((other) => other.who === who),
-		)
-	}
+	const isNominatorActive = useCallback(
+		(who: MaybeAddress) => {
+			return eraStakers.stakers.some((staker) =>
+				staker.others.find((other) => other.who === who),
+			)
+		},
+		[eraStakers.stakers],
+	)
 
 	// Checks whether an address is an active validator
-	const getActiveValidator = (who: MaybeAddress) => {
-		return eraStakers.stakers.find((s) => s.address === who)
-	}
+	const getActiveValidator = useCallback(
+		(who: MaybeAddress) => {
+			return eraStakers.stakers.find((s) => s.address === who)
+		},
+		[eraStakers.stakers],
+	)
 
 	useEffectIgnoreInitial(() => {
 		if (getApiStatus(network) === 'connecting') {
@@ -330,18 +336,29 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 		prevEraReward.era,
 	])
 
+	const contextValue = useMemo(
+		() => ({
+			eraStakers,
+			activeValidators,
+			activeNominatorsCount,
+			getNominationsStatusFromEraStakers,
+			isNominatorActive,
+			getActiveValidator,
+			prevEraReward,
+		}),
+		[
+			eraStakers,
+			activeValidators,
+			activeNominatorsCount,
+			getNominationsStatusFromEraStakers,
+			isNominatorActive,
+			getActiveValidator,
+			prevEraReward,
+		],
+	)
+
 	return (
-		<EraStakersContext.Provider
-			value={{
-				eraStakers,
-				activeValidators,
-				activeNominatorsCount,
-				getNominationsStatusFromEraStakers,
-				isNominatorActive,
-				getActiveValidator,
-				prevEraReward,
-			}}
-		>
+		<EraStakersContext.Provider value={contextValue}>
 			{children}
 		</EraStakersContext.Provider>
 	)

--- a/packages/app/src/contexts/NominatorSetups/index.tsx
+++ b/packages/app/src/contexts/NominatorSetups/index.tsx
@@ -11,7 +11,7 @@ import { useNetwork } from 'contexts/Network'
 import { useAccountBalances } from 'hooks/useAccountBalances'
 import { useFetchMethods } from 'hooks/useFetchMethods'
 import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { MaybeAddress } from 'types'
 import { defaultNominatorProgress } from './defaults'
 import { getLocalNominatorSetups, setLocalNominatorSetups } from './local'
@@ -48,98 +48,116 @@ export const NominatorSetupsProvider = ({
 	)
 
 	// Update nominator setups state
-	const setNominatorSetups = (setups: NominatorSetups) => {
+	const setNominatorSetups = useCallback((setups: NominatorSetups) => {
 		setLocalNominatorSetups(setups)
 		setNominatorSetupsState(setups)
-	}
+	}, [])
+
+	// Utility to update the progress item of a nominator setup
+	const updateSetups = useCallback(
+		(
+			all: NominatorSetups,
+			progress: NominatorProgress,
+			account: string,
+			maybeSection: number | undefined,
+		) => {
+			const current = Object.assign(all[account] || {})
+			const section = maybeSection ?? current.section ?? 1
+
+			all[account] = {
+				...current,
+				progress,
+				section,
+			}
+			return all
+		},
+		[],
+	)
 
 	// Gets the setup progress for a connected account. Falls back to default setup if progress does
 	// not yet exist
-	const getNominatorSetup = (address: MaybeAddress): NominatorSetup => {
-		const setup = Object.fromEntries(
-			Object.entries(nominatorSetups).filter(([k]) => k === address),
-		)
-		return (
-			setup[address || ''] || {
-				progress: defaultNominatorProgress,
-				section: 1,
-			}
-		)
-	}
-
-	const setNominatorSetup = (progress: NominatorProgress, section?: number) => {
-		if (activeAddress) {
-			const updatedSetups = updateSetups(
-				{ ...nominatorSetups },
-				progress,
-				activeAddress,
-				section,
+	const getNominatorSetup = useCallback(
+		(address: MaybeAddress): NominatorSetup => {
+			const setup = Object.fromEntries(
+				Object.entries(nominatorSetups).filter(([k]) => k === address),
 			)
-			setNominatorSetups(updatedSetups)
-		}
-	}
+			return (
+				setup[address || ''] || {
+					progress: defaultNominatorProgress,
+					section: 1,
+				}
+			)
+		},
+		[nominatorSetups],
+	)
+
+	const setNominatorSetup = useCallback(
+		(progress: NominatorProgress, section?: number) => {
+			if (activeAddress) {
+				const updatedSetups = updateSetups(
+					{ ...nominatorSetups },
+					progress,
+					activeAddress,
+					section,
+				)
+				setNominatorSetups(updatedSetups)
+			}
+		},
+		[activeAddress, nominatorSetups, updateSetups, setNominatorSetups],
+	)
 
 	// Remove setup progress for an account
-	const removeNominatorSetup = (address: MaybeAddress) => {
-		const updatedSetups = Object.fromEntries(
-			Object.entries(nominatorSetups).filter(([k]) => k !== address),
-		)
-		setNominatorSetups(updatedSetups)
-	}
-
-	// Sets a nominator setup section for an address
-	const setNominatorSetupSection = (section: number) => {
-		if (activeAddress) {
-			const newSetups = { ...nominatorSetups }
-			const updatedSetups = updateSetups(
-				newSetups,
-				newSetups[activeAddress]?.progress || defaultNominatorProgress,
-				activeAddress,
-				section,
+	const removeNominatorSetup = useCallback(
+		(address: MaybeAddress) => {
+			const updatedSetups = Object.fromEntries(
+				Object.entries(nominatorSetups).filter(([k]) => k !== address),
 			)
 			setNominatorSetups(updatedSetups)
-		}
-	}
+		},
+		[nominatorSetups, setNominatorSetups],
+	)
 
-	// Utility to update the progress item of a nominator setup
-	const updateSetups = (
-		all: NominatorSetups,
-		progress: NominatorProgress,
-		account: string,
-		maybeSection: number | undefined,
-	) => {
-		const current = Object.assign(all[account] || {})
-		const section = maybeSection ?? current.section ?? 1
-
-		all[account] = {
-			...current,
-			progress,
-			section,
-		}
-		return all
-	}
+	// Sets a nominator setup section for an address
+	const setNominatorSetupSection = useCallback(
+		(section: number) => {
+			if (activeAddress) {
+				const newSetups = { ...nominatorSetups }
+				const updatedSetups = updateSetups(
+					newSetups,
+					newSetups[activeAddress]?.progress || defaultNominatorProgress,
+					activeAddress,
+					section,
+				)
+				setNominatorSetups(updatedSetups)
+			}
+		},
+		[activeAddress, nominatorSetups, updateSetups, setNominatorSetups],
+	)
 
 	// Gets the stake setup progress as a percentage for an address
-	const getNominatorSetupPercent = (address: MaybeAddress) => {
-		if (!address) {
-			return 0
-		}
-		const { progress } = getNominatorSetup(address)
-		const bond = new BigNumber(progress?.bond || '0')
+	const getNominatorSetupPercent = useCallback(
+		(address: MaybeAddress) => {
+			if (!address) {
+				return 0
+			}
+			const { progress } = getNominatorSetup(address)
+			const bond = new BigNumber(progress?.bond || '0')
 
-		const p = 33
-		let percentage = 0
-		if (bond.isGreaterThan(0)) {
-			percentage += p
-		}
-		if (progress.nominations.length) {
-			percentage += p
-		}
-		if (progress.payee.destination !== null) {
-			percentage += p
-		}
-		return percentage
-	}
+			const p = 33
+			let percentage = 0
+			if (bond.isGreaterThan(0)) {
+				percentage += p
+			}
+			if (progress.nominations.length) {
+				percentage += p
+			}
+			if (progress.payee.destination !== null) {
+				percentage += p
+			}
+			return percentage
+		},
+		[getNominatorSetup],
+	)
 
 	// Update setup state when active address, network or imported accounts change
 	useEffectIgnoreInitial(() => {
@@ -148,7 +166,7 @@ export const NominatorSetupsProvider = ({
 		}
 	}, [activeAddress, network, stringifiedAccountsKey])
 
-	const generateOptimalSetup = (): NominatorProgress => {
+	const generateOptimalSetup = useCallback((): NominatorProgress => {
 		const setup = {
 			payee: {
 				destination: 'Staked' as PayeeOption,
@@ -158,19 +176,29 @@ export const NominatorSetupsProvider = ({
 			bond: planckToUnit(totalPossibleBond, units),
 		}
 		return setup
-	}
+	}, [fetch, totalPossibleBond, units])
+
+	const contextValue = useMemo(
+		() => ({
+			getNominatorSetup,
+			setNominatorSetup,
+			removeNominatorSetup,
+			getNominatorSetupPercent,
+			setNominatorSetupSection,
+			generateOptimalSetup,
+		}),
+		[
+			getNominatorSetup,
+			setNominatorSetup,
+			removeNominatorSetup,
+			getNominatorSetupPercent,
+			setNominatorSetupSection,
+			generateOptimalSetup,
+		],
+	)
 
 	return (
-		<NominatorSetupContext.Provider
-			value={{
-				getNominatorSetup,
-				setNominatorSetup,
-				removeNominatorSetup,
-				getNominatorSetupPercent,
-				setNominatorSetupSection,
-				generateOptimalSetup,
-			}}
-		>
+		<NominatorSetupContext.Provider value={contextValue}>
 			{children}
 		</NominatorSetupContext.Provider>
 	)

--- a/packages/app/src/contexts/Proxies/index.tsx
+++ b/packages/app/src/contexts/Proxies/index.tsx
@@ -15,7 +15,7 @@ import {
 	setActiveProxy,
 } from 'global-bus'
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { MaybeAddress, Proxies } from 'types'
 import type {
 	Delegates,
@@ -38,7 +38,7 @@ export const ProxiesProvider = ({ children }: { children: ReactNode }) => {
 	const [proxies, setProxies] = useState<Record<string, Proxies>>({})
 
 	// Reformats proxies into a list of delegates
-	const formatProxiesToDelegates = () => {
+	const formatProxiesToDelegates = useCallback(() => {
 		// Reformat proxies into a list of delegates
 		const newDelegates: Delegates = {}
 		for (const [delegator, record] of Object.entries(proxies)) {
@@ -60,72 +60,76 @@ export const ProxiesProvider = ({ children }: { children: ReactNode }) => {
 			}
 		}
 		return newDelegates
-	}
+	}, [proxies])
 
 	// Gets the delegates of the given account
-	const getDelegates = (address: MaybeAddress): Proxy | undefined => {
-		const results = Object.entries(proxies).find(
-			([delegator]) => delegator === address,
-		)
-		if (!results) {
-			return undefined
-		}
-		const config = results[1]
+	const getDelegates = useCallback(
+		(address: MaybeAddress): Proxy | undefined => {
+			const results = Object.entries(proxies).find(
+				([delegator]) => delegator === address,
+			)
+			if (!results) {
+				return undefined
+			}
+			const config = results[1]
 
-		return {
-			address,
-			delegator: address,
-			delegates: Object.values(config.proxies).map(
-				({ delegate, proxyType }) => ({
-					delegate,
-					proxyType,
-				}),
-			),
-			reserved: new BigNumber(config.deposit),
-		}
-	}
+			return {
+				address,
+				delegator: address,
+				delegates: Object.values(config.proxies).map(
+					({ delegate, proxyType }) => ({
+						delegate,
+						proxyType,
+					}),
+				),
+				reserved: new BigNumber(config.deposit),
+			}
+		},
+		[proxies],
+	)
 
 	// Gets delegators and proxy types for the given delegate address
 	// Queries the chain to check if the given delegator & delegate pair is valid proxy. Used when a
 	// proxy account is being manually declared
-	const handleDeclareDelegate = async (
-		delegator: string,
-	): Promise<ProxyDelegate[]> => {
-		const results = await serviceApi.query.proxies(delegator)
+	const handleDeclareDelegate = useCallback(
+		async (delegator: string): Promise<ProxyDelegate[]> => {
+			const results = await serviceApi.query.proxies(delegator)
 
-		let addDelegatorAsExternal = false
-		for (const delegate of results) {
-			if (accounts.find(({ address }) => address === delegate)) {
-				addDelegatorAsExternal = true
+			let addDelegatorAsExternal = false
+			for (const delegate of results) {
+				if (accounts.find(({ address }) => address === delegate)) {
+					addDelegatorAsExternal = true
+				}
 			}
-		}
-		if (addDelegatorAsExternal) {
-			addExternalAccount(delegator, 'system')
-		}
-		return []
-	}
+			if (addDelegatorAsExternal) {
+				addExternalAccount(delegator, 'system')
+			}
+			return []
+		},
+		[accounts, addExternalAccount, serviceApi],
+	)
 
 	// Gets the delegate and proxy type of an account, if any
-	const getProxyDelegate = (
-		delegator: MaybeAddress,
-		delegate: MaybeAddress,
-	): ProxyDelegate | null => {
-		const results = Object.entries(proxies).find(([key]) => key === delegator)
-		if (!results) {
-			return null
-		}
-		const config = results[1]
-		const maybeDelegate = Object.values(config.proxies).find(
-			(d) => d.delegate === delegate,
-		)
-		if (!maybeDelegate) {
-			return null
-		}
-		return {
-			delegate: maybeDelegate.delegate,
-			proxyType: maybeDelegate.proxyType,
-		}
-	}
+	const getProxyDelegate = useCallback(
+		(delegator: MaybeAddress, delegate: MaybeAddress): ProxyDelegate | null => {
+			const results = Object.entries(proxies).find(([key]) => key === delegator)
+			if (!results) {
+				return null
+			}
+			const config = results[1]
+			const maybeDelegate = Object.values(config.proxies).find(
+				(d) => d.delegate === delegate,
+			)
+			if (!maybeDelegate) {
+				return null
+			}
+			return {
+				delegate: maybeDelegate.delegate,
+				proxyType: maybeDelegate.proxyType,
+			}
+		},
+		[proxies],
+	)
 
 	// If active proxy has not yet been set, check local storage `activeProxy` & set it as active
 	// proxy if it is the delegate of `activeAccount`
@@ -167,15 +171,23 @@ export const ProxiesProvider = ({ children }: { children: ReactNode }) => {
 		}
 	}, [])
 
+	const contextValue = useMemo(
+		() => ({
+			handleDeclareDelegate,
+			getDelegates,
+			getProxyDelegate,
+			formatProxiesToDelegates,
+		}),
+		[
+			handleDeclareDelegate,
+			getDelegates,
+			getProxyDelegate,
+			formatProxiesToDelegates,
+		],
+	)
+
 	return (
-		<ProxiesContext.Provider
-			value={{
-				handleDeclareDelegate,
-				getDelegates,
-				getProxyDelegate,
-				formatProxiesToDelegates,
-			}}
-		>
+		<ProxiesContext.Provider value={contextValue}>
 			{children}
 		</ProxiesContext.Provider>
 	)


### PR DESCRIPTION
## Summary

Applies the `useCallback`/`useMemo` stabilisation pattern (established in earlier batches) to three remaining high-traffic context providers that were previously creating new function references every render.

## Providers updated

| Provider | Consumers | Change |
|---|---|---|
| `ProxiesProvider` | 6 | All 4 handler functions wrapped with `useCallback`; context value memoised |
| `NominatorSetupsProvider` | 10 | All 7 handler/utility functions wrapped with `useCallback`; context value memoised |
| `EraStakersProvider` | 12 | 3 read-only query functions wrapped with `useCallback([eraStakers.stakers])`; context value memoised |

**Total consumers benefiting: 28**

## Why it matters

Each time these providers re-render (e.g. on subscription updates, era changes, active-address changes), every consumer that calls `useContext` would also re-render — even if the data they care about hasn't changed — because the context value object was a new reference every render.

With stable function references and a memoised context value, consumers only re-render when the data they actually depend on changes.

## What was not changed

- Async fetch functions in `EraStakersProvider` (`fetchEraStakers`, `fetchActiveEraStakers`, `getPagedErasStakers`, etc.) were intentionally left un-wrapped: they close over many transient values and are only called from `useEffect` hooks, not from the context value, so stabilising them would require heavier dep-array work with minimal benefit.
- `LedgerHardwareProvider` is left for a separate batch: its callback cascade has complex `useTranslation` deps that warrant isolated review.

## Validation

- `tsc --noEmit`: no errors in changed files (pre-existing unbuilt-package errors in `ledger-connect`/`vault-connect` unaffected)
- `biome check --write`: 1 formatting fix auto-applied; all 3 files clean

## Related

Part of the optimisation backlog tracked in #3340.