### PR TITLE
fix(Invite): strip duplicate https:// prefix and improve icon contrast

### DIFF
--- a/packages/app/src/modals/Invite/index.tsx
+++ b/packages/app/src/modals/Invite/index.tsx
@@ -32,7 +32,7 @@ export const Invite = () => {
 	let faIcon = faEnvelopeOpenText
 
 	if (membership) {
-		toCopy = `https://${ProductionURL}/#/overview?n=${network}&i=pool&id=${poolId}`
+		toCopy = `${ProductionURL}/#/overview?n=${network}&i=pool&id=${poolId}`
 		title = t('copyPoolInviteLink', { ns: 'app' })
 		subtitle = toCopy
 	} else if (nominated.length > 0) {
@@ -47,7 +47,10 @@ export const Invite = () => {
 			<Title />
 			<Padding verticalOnly>
 				<Support>
-					<FontAwesomeIcon icon={faIcon} />
+					<FontAwesomeIcon
+						icon={faIcon}
+						style={{ color: 'var(--gray-1000)' }}
+					/>
 					{canCopy ? (
 						<>
 							<ButtonCopy


### PR DESCRIPTION
Two small fixes in the pool invite modal (`Settings → Share`):

1. **Double `https://` bug** `Copy Pool Invite Link` produced `https://https://staking.polkadot.cloud/#/overview?n=polkadot&i=pool&id=15`. `ProductionURL` in `packages/consts` already includes the full scheme, so the template shouldn't prepend `https://` again.
2. **Dark-mode icon contrast** the FontAwesome envelope icon had no explicit color and rendered near-invisible against the dark modal background. Added `color: var(--gray-1000)` so it adapts with the theme.

Both changes isolated to `packages/app/src/modals/Invite/index.tsx`.
