### PR TITLE
feat(refactor): Lazy load advanced mode pages

### DIFF
--- a/packages/app/src/library/PagePreloader/index.tsx
+++ b/packages/app/src/library/PagePreloader/index.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { CardWrapper } from 'library/Card/Wrappers'
+import { Loader, Page, Stat } from 'ui-core/base'
+
+export const PagePreloader = ({
+	showStats = true,
+}: {
+	showStats?: boolean
+}) => (
+	<>
+		{showStats && (
+			<Stat.Row>
+				<Stat.Loading />
+				<Stat.Loading />
+				<Stat.Loading />
+			</Stat.Row>
+		)}
+		<Page.Row>
+			<CardWrapper height={80}>
+				<Loader
+					style={{
+						height: '100%',
+						width: '100%',
+						maxHeight: '75px',
+					}}
+				/>
+			</CardWrapper>
+		</Page.Row>
+	</>
+)

--- a/packages/app/src/pages/Operators/index.tsx
+++ b/packages/app/src/pages/Operators/index.tsx
@@ -6,13 +6,18 @@ import {
 	validatorListSupported,
 } from '@w3ux/validator-assets'
 import { useNetwork } from 'contexts/Network'
+import { PagePreloader } from 'library/PagePreloader'
+import { lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { PageProps } from 'types'
 import { Page } from 'ui-core/base'
 import { OperatorsSectionsProvider, useOperatorsSections } from './context'
-import { Entity } from './Entity'
-import { List } from './List'
 import { Wrapper } from './Wrappers'
+
+const List = lazy(() => import('./List').then((m) => ({ default: m.List })))
+const Entity = lazy(() =>
+	import('./Entity').then((m) => ({ default: m.Entity })),
+)
 
 export const OperatorsInner = ({ page }: PageProps) => {
 	const { t } = useTranslation('app')
@@ -28,12 +33,14 @@ export const OperatorsInner = ({ page }: PageProps) => {
 	return (
 		<Wrapper>
 			<Page.Title title={t(key)} />
-			{activeSection === 0 && (
-				<List network={network as ValidatorSupportedNetwork} />
-			)}
-			{activeSection === 1 && (
-				<Entity network={network as ValidatorSupportedNetwork} />
-			)}
+			<Suspense fallback={<PagePreloader />}>
+				{activeSection === 0 && (
+					<List network={network as ValidatorSupportedNetwork} />
+				)}
+				{activeSection === 1 && (
+					<Entity network={network as ValidatorSupportedNetwork} />
+				)}
+			</Suspense>
 		</Wrapper>
 	)
 }

--- a/packages/app/src/pages/Operators/index.tsx
+++ b/packages/app/src/pages/Operators/index.tsx
@@ -33,7 +33,7 @@ export const OperatorsInner = ({ page }: PageProps) => {
 	return (
 		<Wrapper>
 			<Page.Title title={t(key)} />
-			<Suspense fallback={<PagePreloader />}>
+			<Suspense fallback={<PagePreloader showStats={false} />}>
 				{activeSection === 0 && (
 					<List network={network as ValidatorSupportedNetwork} />
 				)}

--- a/packages/app/src/pages/PoolsList/Overview.tsx
+++ b/packages/app/src/pages/PoolsList/Overview.tsx
@@ -1,0 +1,27 @@
+// Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { ListProvider } from 'contexts/List'
+import { useBondedPools } from 'contexts/Pools/BondedPools'
+import { CardWrapper } from 'library/Card/Wrappers'
+import { PoolList } from 'library/PoolList'
+import { Page } from 'ui-core/base'
+
+export const PoolsOverview = () => {
+	const { bondedPools } = useBondedPools()
+
+	return (
+		<Page.Row>
+			<CardWrapper>
+				<ListProvider>
+					<PoolList
+						pools={bondedPools}
+						itemsPerPage={50}
+						allowMoreCols
+						allowSearch
+					/>
+				</ListProvider>
+			</CardWrapper>
+		</Page.Row>
+	)
+}

--- a/packages/app/src/pages/PoolsList/index.tsx
+++ b/packages/app/src/pages/PoolsList/index.tsx
@@ -1,25 +1,27 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { ListProvider } from 'contexts/List'
 import { useNetwork } from 'contexts/Network'
-import { useBondedPools } from 'contexts/Pools/BondedPools'
 import { useFavoritePools } from 'contexts/Pools/FavoritePools'
 import { onTabVisitEvent } from 'event-tracking'
-import { CardWrapper } from 'library/Card/Wrappers'
+import { PagePreloader } from 'library/PagePreloader'
 import { PageTabs } from 'library/PageTabs'
-import { PoolList } from 'library/PoolList'
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Page } from 'ui-core/base'
 import { PoolsTabsProvider, usePoolsTabs } from './context'
-import { PoolFavorites } from './Favorites'
+
+const PoolsOverview = lazy(() =>
+	import('./Overview').then((m) => ({ default: m.PoolsOverview })),
+)
+const PoolFavorites = lazy(() =>
+	import('./Favorites').then((m) => ({ default: m.PoolFavorites })),
+)
 
 const PoolsListInner = () => {
 	const { t } = useTranslation('pages')
 	const { network } = useNetwork()
 	const { favorites } = useFavoritePools()
-	const { bondedPools } = useBondedPools()
 	const { activeTab, setActiveTab } = usePoolsTabs()
 
 	// Go back to tab 0 on network change
@@ -52,21 +54,10 @@ const PoolsListInner = () => {
 					]}
 				/>
 			</Page.Title>
-			{activeTab === 0 && (
-				<Page.Row>
-					<CardWrapper>
-						<ListProvider>
-							<PoolList
-								pools={bondedPools}
-								itemsPerPage={50}
-								allowMoreCols
-								allowSearch
-							/>
-						</ListProvider>
-					</CardWrapper>
-				</Page.Row>
-			)}
-			{activeTab === 1 && <PoolFavorites />}
+			<Suspense fallback={<PagePreloader showStats={false} />}>
+				{activeTab === 0 && <PoolsOverview />}
+				{activeTab === 1 && <PoolFavorites />}
+			</Suspense>
 		</>
 	)
 }

--- a/packages/app/src/pages/Validators/index.tsx
+++ b/packages/app/src/pages/Validators/index.tsx
@@ -3,13 +3,19 @@
 
 import { useFavoriteValidators } from 'contexts/Validators/FavoriteValidators'
 import { onTabVisitEvent } from 'event-tracking'
+import { PagePreloader } from 'library/PagePreloader'
 import { PageTabs } from 'library/PageTabs'
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Page } from 'ui-core/base'
-import { AllValidators } from './AllValidators'
 import { useValidatorsTabs, ValidatorsTabsProvider } from './context'
-import { ValidatorFavorites } from './Favorites'
+
+const AllValidators = lazy(() =>
+	import('./AllValidators').then((m) => ({ default: m.AllValidators })),
+)
+const ValidatorFavorites = lazy(() =>
+	import('./Favorites').then((m) => ({ default: m.ValidatorFavorites })),
+)
 
 export const ValidatorsInner = () => {
 	const { t } = useTranslation('pages')
@@ -48,8 +54,10 @@ export const ValidatorsInner = () => {
 					]}
 				/>
 			</Page.Title>
-			{activeTab === 0 && <AllValidators />}
-			{activeTab === 1 && <ValidatorFavorites />}
+			<Suspense fallback={<PagePreloader />}>
+				{activeTab === 0 && <AllValidators />}
+				{activeTab === 1 && <ValidatorFavorites />}
+			</Suspense>
 		</>
 	)
 }

--- a/packages/app/src/pages/Validators/index.tsx
+++ b/packages/app/src/pages/Validators/index.tsx
@@ -54,7 +54,7 @@ export const ValidatorsInner = () => {
 					]}
 				/>
 			</Page.Title>
-			<Suspense fallback={<PagePreloader />}>
+			<Suspense fallback={<PagePreloader showStats={activeTab === 0} />}>
 				{activeTab === 0 && <AllValidators />}
 				{activeTab === 1 && <ValidatorFavorites />}
 			</Suspense>


### PR DESCRIPTION
This PR refactors advanced-mode tab content to load lazily, extending route-level code splitting with tab/section-level chunking for validators, pools list, and operators pages.

**Changes:**
- Converts validators, pools list, and operators tab/section bodies to `React.lazy()` components behind `Suspense`.
- Extracts pools overview content into its own lazy-loadable component.
- Adds a shared `PagePreloader` fallback component for page-level lazy loading.


Responds to: https://github.com/polkadot-cloud/polkadot-staking-dashboard/pull/3390