### PR TITLE
feat(refactor): Use generic Staking API functions

### DIFF
--- a/packages/plugin-staking-api/src/index.ts
+++ b/packages/plugin-staking-api/src/index.ts
@@ -4,7 +4,9 @@
 import { ApolloProvider } from '@apollo/client/react'
 
 export * from './Client'
+export * from './queries/activeValidatorRanks'
 export * from './queries/eraTotalNominators'
+export * from './queries/generic'
 export * from './queries/getStakerWithNominees'
 export * from './queries/identityCache'
 export * from './queries/nominatorRewardTrend'

--- a/packages/plugin-staking-api/src/queries/activeValidatorRanks.ts
+++ b/packages/plugin-staking-api/src/queries/activeValidatorRanks.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { ActiveValidatorRanksData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query ActiveValidatorRanks($network: String!) {
@@ -18,16 +18,5 @@ const DEFAULT: ActiveValidatorRanksData = {
 	activeValidatorRanks: [],
 }
 
-export const fetchActiveValidatorRanks = async (
-	network: string,
-): Promise<ActiveValidatorRanksData> => {
-	try {
-		const result = await client.query<ActiveValidatorRanksData>({
-			query: QUERY,
-			variables: { network },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchActiveValidatorRanks = (network: string) =>
+	fetchQuery<ActiveValidatorRanksData>(QUERY, { network }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
+++ b/packages/plugin-staking-api/src/queries/eraTotalNominators.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { EraTotalNominatorsData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query EraTotalNominators($network: String!, $era: Int!) {
@@ -19,17 +19,5 @@ const DEFAULT: EraTotalNominatorsData = {
 	},
 }
 
-export const fetchEraTotalNominators = async (
-	network: string,
-	era: number,
-): Promise<EraTotalNominatorsData> => {
-	try {
-		const result = await client.query<EraTotalNominatorsData>({
-			query: QUERY,
-			variables: { network, era },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchEraTotalNominators = (network: string, era: number) =>
+	fetchQuery<EraTotalNominatorsData>(QUERY, { network, era }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/generic.ts
+++ b/packages/plugin-staking-api/src/queries/generic.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { DocumentNode } from '@apollo/client'
+import { useQuery } from '@apollo/client/react'
+import { client } from '../Client'
+import type { QueryReturn } from '../types'
+
+type Variables = Record<string, unknown>
+
+/**
+ * Generic GraphQL query fetcher. Swallows errors and returns `defaultData` when the request fails
+ * or returns no data.
+ */
+export const fetchQuery = async <T>(
+	query: DocumentNode,
+	variables: Variables,
+	defaultData: T,
+): Promise<T> => {
+	try {
+		const result = await client.query<T>({ query, variables })
+		return result?.data || defaultData
+	} catch {
+		return defaultData
+	}
+}
+
+/**
+ * Generic React hook wrapper around Apollo's `useQuery`. Returns `defaultData` while loading or
+ * when data is unavailable.
+ */
+export const useApiQuery = <T>(
+	query: DocumentNode,
+	variables: Variables,
+	defaultData: T,
+	options?: { skip?: boolean },
+): QueryReturn<T> => {
+	const { loading, error, data, refetch } = useQuery<T>(query, {
+		variables,
+		...options,
+	})
+	return { loading, error, data: data || defaultData, refetch }
+}

--- a/packages/plugin-staking-api/src/queries/getStakerWithNominees.ts
+++ b/packages/plugin-staking-api/src/queries/getStakerWithNominees.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type {
 	ActiveStatusWithNominees,
 	GetActiveStakerWithNomineesData,
 } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query GetStakerWithNominees($network: String!, $era: Int!, $who: String!, $addresses: [String!]!) {
@@ -22,9 +22,9 @@ const QUERY = gql`
 }
 `
 
-const DEFAULT: ActiveStatusWithNominees = {
-	active: false,
-	statuses: [],
+const DEFAULT_DATA: GetActiveStakerWithNomineesData = {
+	isActiveStaker: { active: false },
+	getNomineesStatus: { statuses: [] },
 }
 
 export const fetchGetStakerWithNominees = async (
@@ -33,21 +33,13 @@ export const fetchGetStakerWithNominees = async (
 	who: string,
 	addresses: string[],
 ): Promise<ActiveStatusWithNominees> => {
-	try {
-		const result = await client.query<GetActiveStakerWithNomineesData>({
-			query: QUERY,
-			variables: { network, era, who, addresses },
-		})
-		return result?.data
-			? {
-					active: result.data.isActiveStaker.active,
-					statuses: result.data.getNomineesStatus.statuses,
-				}
-			: {
-					active: false,
-					statuses: [],
-				}
-	} catch {
-		return DEFAULT
+	const data = await fetchQuery<GetActiveStakerWithNomineesData>(
+		QUERY,
+		{ network, era, who, addresses },
+		DEFAULT_DATA,
+	)
+	return {
+		active: data.isActiveStaker.active,
+		statuses: data.getNomineesStatus.statuses,
 	}
 }

--- a/packages/plugin-staking-api/src/queries/identityCache.ts
+++ b/packages/plugin-staking-api/src/queries/identityCache.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { IdentityCacheData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query IdentityCache($network: String!, $addresses: [String!]!) {
@@ -17,6 +17,7 @@ const QUERY = gql`
 `
 
 const BATCH_SIZE = 500
+const EMPTY: IdentityCacheData = { identityCache: [] }
 
 export const fetchIdentityCache = async (
 	network: string,
@@ -28,24 +29,17 @@ export const fetchIdentityCache = async (
 		batches.push(addresses.slice(i, i + BATCH_SIZE))
 	}
 
-	try {
-		// Fetch all batches in parallel
-		const results = await Promise.all(
-			batches.map((batch) =>
-				client.query<IdentityCacheData>({
-					query: QUERY,
-					variables: { network, addresses: batch },
-				}),
+	const results = await Promise.all(
+		batches.map((batch) =>
+			fetchQuery<IdentityCacheData>(
+				QUERY,
+				{ network, addresses: batch },
+				EMPTY,
 			),
-		)
+		),
+	)
 
-		// Combine all results
-		const combinedCache = results.flatMap(
-			(result) => result?.data?.identityCache || [],
-		)
-
-		return { identityCache: combinedCache }
-	} catch {
-		return { identityCache: [] }
+	return {
+		identityCache: results.flatMap((result) => result.identityCache || []),
 	}
 }

--- a/packages/plugin-staking-api/src/queries/nominatorRewardTrend.ts
+++ b/packages/plugin-staking-api/src/queries/nominatorRewardTrend.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { NominatorRewardTrendData, RewardTrend } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query NominatorRewardTrend($network: String!, $who: String!, $eras: Int!) {
@@ -32,13 +32,10 @@ export const fetchNominatorRewardTrend = async (
 	who: string,
 	eras: number,
 ): Promise<RewardTrend> => {
-	try {
-		const result = await client.query<NominatorRewardTrendData>({
-			query: QUERY,
-			variables: { network, who, eras },
-		})
-		return result?.data?.nominatorRewardTrend || DEFAULT
-	} catch {
-		return DEFAULT
-	}
+	const data = await fetchQuery<NominatorRewardTrendData>(
+		QUERY,
+		{ network, who, eras },
+		{ nominatorRewardTrend: DEFAULT },
+	)
+	return data.nominatorRewardTrend || DEFAULT
 }

--- a/packages/plugin-staking-api/src/queries/poolCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/poolCandidates.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { PoolCandidatesData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query PoolCandidates($network: String!) {
@@ -15,16 +15,5 @@ const DEFAULT: PoolCandidatesData = {
 	poolCandidates: [],
 }
 
-export const fetchPoolCandidates = async (
-	network: string,
-): Promise<PoolCandidatesData> => {
-	try {
-		const result = await client.query<PoolCandidatesData>({
-			query: QUERY,
-			variables: { network },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchPoolCandidates = (network: string) =>
+	fetchQuery<PoolCandidatesData>(QUERY, { network }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolEraPoints.ts
+++ b/packages/plugin-staking-api/src/queries/poolEraPoints.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
 import type { PoolEraPointsData, QueryReturn } from '../types'
+import { useApiQuery } from './generic'
 
 const QUERY = gql`
   query PoolEraPoints(
@@ -29,19 +29,10 @@ const DEFAULT: PoolEraPointsData = {
 	poolEraPoints: [],
 }
 
-export const usePoolEraPoints = ({
-	network,
-	poolId,
-	fromEra,
-	depth,
-}: {
+export const usePoolEraPoints = (variables: {
 	network: string
 	poolId: number
 	fromEra: number
 	depth?: number
-}): QueryReturn<PoolEraPointsData> => {
-	const { loading, error, data, refetch } = useQuery<PoolEraPointsData>(QUERY, {
-		variables: { network, poolId, fromEra, depth },
-	})
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<PoolEraPointsData> =>
+	useApiQuery<PoolEraPointsData>(QUERY, variables, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolEraRewards.ts
+++ b/packages/plugin-staking-api/src/queries/poolEraRewards.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
-import { client } from '../Client'
 import type { PoolEraRewardsData, QueryReturn } from '../types'
+import { fetchQuery, useApiQuery } from './generic'
 
 const QUERY = gql`
   query PoolEraRewards($network: String!, $who: String!, $fromEra: Int!) {
@@ -31,29 +30,13 @@ export const usePoolEraRewards = ({
 	who: string
 	fromEra: number
 	skip?: boolean
-}): QueryReturn<PoolEraRewardsData> => {
-	const { loading, error, data, refetch } = useQuery<PoolEraRewardsData>(
-		QUERY,
-		{
-			variables: { network, who, fromEra },
-			skip,
-		},
-	)
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<PoolEraRewardsData> =>
+	useApiQuery<PoolEraRewardsData>(QUERY, { network, who, fromEra }, DEFAULT, {
+		skip,
+	})
 
-export const fetchPoolEraRewards = async (
+export const fetchPoolEraRewards = (
 	network: string,
 	who: string,
 	fromEra: number,
-): Promise<PoolEraRewardsData> => {
-	try {
-		const result = await client.query<PoolEraRewardsData>({
-			query: QUERY,
-			variables: { network, who, fromEra },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+) => fetchQuery<PoolEraRewardsData>(QUERY, { network, who, fromEra }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolMembers.ts
+++ b/packages/plugin-staking-api/src/queries/poolMembers.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { PoolMembersData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
 	query PoolMembers($network: String!, $poolId: Int!, $limit: Int, $offset: Int) {
@@ -31,19 +31,14 @@ const DEFAULT: PoolMembersData = {
 	},
 }
 
-export const fetchPoolMembers = async (
+export const fetchPoolMembers = (
 	network: string,
 	poolId: number,
 	limit?: number,
 	offset?: number,
-): Promise<PoolMembersData> => {
-	try {
-		const result = await client.query<PoolMembersData>({
-			query: QUERY,
-			variables: { network, poolId, limit, offset },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+) =>
+	fetchQuery<PoolMembersData>(
+		QUERY,
+		{ network, poolId, limit, offset },
+		DEFAULT,
+	)

--- a/packages/plugin-staking-api/src/queries/poolRewardTrend.ts
+++ b/packages/plugin-staking-api/src/queries/poolRewardTrend.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { PoolRewardTrendData, RewardTrend } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query PoolRewardTrend($network: String!, $who: String!, $duration: Int!) {
@@ -32,13 +32,10 @@ export const fetchPoolRewardTrend = async (
 	who: string,
 	duration: number,
 ): Promise<RewardTrend> => {
-	try {
-		const result = await client.query<PoolRewardTrendData>({
-			query: QUERY,
-			variables: { network, who, duration },
-		})
-		return result?.data?.poolRewardTrend || DEFAULT
-	} catch {
-		return DEFAULT
-	}
+	const data = await fetchQuery<PoolRewardTrendData>(
+		QUERY,
+		{ network, who, duration },
+		{ poolRewardTrend: DEFAULT },
+	)
+	return data.poolRewardTrend || DEFAULT
 }

--- a/packages/plugin-staking-api/src/queries/poolRewards.ts
+++ b/packages/plugin-staking-api/src/queries/poolRewards.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
-import { client } from '../Client'
 import type { PoolRewardData, QueryReturn } from '../types'
+import { fetchQuery, useApiQuery } from './generic'
 
 const QUERY = gql`
   query PoolRewards($network: String!, $who: String!, $from: Int!) {
@@ -21,33 +20,12 @@ const DEFAULT: PoolRewardData = {
 	poolRewards: [],
 }
 
-export const usePoolRewards = ({
-	network,
-	who,
-	from,
-}: {
+export const usePoolRewards = (variables: {
 	network: string
 	who: string
 	from: number
-}): QueryReturn<PoolRewardData> => {
-	const { loading, error, data, refetch } = useQuery<PoolRewardData>(QUERY, {
-		variables: { network, who, from },
-	})
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<PoolRewardData> =>
+	useApiQuery<PoolRewardData>(QUERY, variables, DEFAULT)
 
-export const fetchPoolRewards = async (
-	network: string,
-	who: string,
-	from: number,
-): Promise<PoolRewardData> => {
-	try {
-		const result = await client.query<PoolRewardData>({
-			query: QUERY,
-			variables: { network, who, from },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchPoolRewards = (network: string, who: string, from: number) =>
+	fetchQuery<PoolRewardData>(QUERY, { network, who, from }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolWarnings.ts
+++ b/packages/plugin-staking-api/src/queries/poolWarnings.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { PoolWarningsData, PoolWarningsResult } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
 	query PoolWarnings($network: String!, $addresses: [String!]!) {
@@ -28,17 +28,10 @@ export const fetchPoolWarnings = async (
 	if (addresses.length === 0) {
 		return DEFAULT
 	}
-
-	try {
-		const result = await client.query<PoolWarningsData>({
-			query: QUERY,
-			variables: { network, addresses },
-		})
-
-		return {
-			warnings: result?.data?.poolWarnings?.warnings || [],
-		}
-	} catch {
-		return DEFAULT
-	}
+	const data = await fetchQuery<PoolWarningsData>(
+		QUERY,
+		{ network, addresses },
+		{ poolWarnings: DEFAULT },
+	)
+	return { warnings: data.poolWarnings?.warnings || [] }
 }

--- a/packages/plugin-staking-api/src/queries/rewards.ts
+++ b/packages/plugin-staking-api/src/queries/rewards.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
-import { client } from '../Client'
 import type { AllRewardsData, QueryReturn } from '../types'
+import { fetchQuery, useApiQuery } from './generic'
 
 const QUERY = gql`
   query AllRewards($network: String!, $who: String!, $fromEra: Int!) {
@@ -23,33 +22,12 @@ const DEFAULT: AllRewardsData = {
 	allRewards: [],
 }
 
-export const useRewards = ({
-	network,
-	who,
-	fromEra,
-}: {
+export const useRewards = (variables: {
 	network: string
 	who: string
 	fromEra: number
-}): QueryReturn<AllRewardsData> => {
-	const { loading, error, data, refetch } = useQuery<AllRewardsData>(QUERY, {
-		variables: { network, who, fromEra },
-	})
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<AllRewardsData> =>
+	useApiQuery<AllRewardsData>(QUERY, variables, DEFAULT)
 
-export const fetchRewards = async (
-	network: string,
-	who: string,
-	fromEra: number,
-): Promise<AllRewardsData> => {
-	try {
-		const result = await client.query<AllRewardsData>({
-			query: QUERY,
-			variables: { network, who, fromEra },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchRewards = (network: string, who: string, fromEra: number) =>
+	fetchQuery<AllRewardsData>(QUERY, { network, who, fromEra }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/rpcEndpointHealth.ts
+++ b/packages/plugin-staking-api/src/queries/rpcEndpointHealth.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { RpcEndpointHealthData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query RpcEndpointHealth($network: String!) {
@@ -25,16 +25,5 @@ const DEFAULT: RpcEndpointHealthData = {
 	},
 }
 
-export const fetchRpcEndpointHealth = async (
-	network: string,
-): Promise<RpcEndpointHealthData> => {
-	try {
-		const result = await client.query<RpcEndpointHealthData>({
-			query: QUERY,
-			variables: { network },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchRpcEndpointHealth = (network: string) =>
+	fetchQuery<RpcEndpointHealthData>(QUERY, { network }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/searchValidators.ts
+++ b/packages/plugin-staking-api/src/queries/searchValidators.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { SearchValidatorsData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query SearchValidators($network: String!, $searchTerm: String!) {
@@ -27,17 +27,5 @@ const DEFAULT: SearchValidatorsData = {
 	},
 }
 
-export const fetchSearchValidators = async (
-	network: string,
-	searchTerm: string,
-): Promise<SearchValidatorsData> => {
-	try {
-		const result = await client.query<SearchValidatorsData>({
-			query: QUERY,
-			variables: { network, searchTerm },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchSearchValidators = (network: string, searchTerm: string) =>
+	fetchQuery<SearchValidatorsData>(QUERY, { network, searchTerm }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/tokenPrice.ts
+++ b/packages/plugin-staking-api/src/queries/tokenPrice.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { TokenPriceData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query TokenPrice($ticker: String!) {
@@ -21,19 +21,8 @@ const DEFAULT: TokenPriceData = {
 	},
 }
 
-export const fetchTokenPrice = async (
-	ticker: string,
-): Promise<TokenPriceData> => {
-	try {
-		const result = await client.query<TokenPriceData>({
-			query: QUERY,
-			variables: { ticker },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchTokenPrice = (ticker: string) =>
+	fetchQuery<TokenPriceData>(QUERY, { ticker }, DEFAULT)
 
 export const formatTokenPrice = (
 	maybePrice: number | null,

--- a/packages/plugin-staking-api/src/queries/unclaimedRewards.ts
+++ b/packages/plugin-staking-api/src/queries/unclaimedRewards.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
 import type { QueryReturn, UnclaimedRewardsData } from '../types'
+import { useApiQuery } from './generic'
 
 const QUERY = gql`
   query UnclaimedRewards($network: String!, $who: String!, $fromEra: Int!) {
@@ -29,20 +29,9 @@ const DEFAULT: UnclaimedRewardsData = {
 	},
 }
 
-export const useUnclaimedRewards = ({
-	network,
-	who,
-	fromEra,
-}: {
+export const useUnclaimedRewards = (variables: {
 	network: string
 	who: string
 	fromEra: number
-}): QueryReturn<UnclaimedRewardsData> => {
-	const { loading, error, data, refetch } = useQuery<UnclaimedRewardsData>(
-		QUERY,
-		{
-			variables: { network, who, fromEra },
-		},
-	)
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<UnclaimedRewardsData> =>
+	useApiQuery<UnclaimedRewardsData>(QUERY, variables, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/validatorAvgRewardRateBatch.ts
+++ b/packages/plugin-staking-api/src/queries/validatorAvgRewardRateBatch.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { ValidatorAvgRewardRateBatchData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query ValidatorAvgRewardRateBatch(
@@ -27,19 +27,14 @@ const DEFAULT: ValidatorAvgRewardRateBatchData = {
 	validatorAvgRewardRateBatch: [],
 }
 
-export const fetchValidatorAvgRewardRateBatch = async (
+export const fetchValidatorAvgRewardRateBatch = (
 	chain: string,
 	validators: string[],
 	fromEra: number,
 	depth?: number,
-): Promise<ValidatorAvgRewardRateBatchData> => {
-	try {
-		const result = await client.query<ValidatorAvgRewardRateBatchData>({
-			query: QUERY,
-			variables: { chain, validators, fromEra, depth },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+) =>
+	fetchQuery<ValidatorAvgRewardRateBatchData>(
+		QUERY,
+		{ chain, validators, fromEra, depth },
+		DEFAULT,
+	)

--- a/packages/plugin-staking-api/src/queries/validatorEraPoints.ts
+++ b/packages/plugin-staking-api/src/queries/validatorEraPoints.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
 import type { QueryReturn, ValidatorEraPointsData } from '../types'
+import { useApiQuery } from './generic'
 
 const QUERY = gql`
   query ValidatorEraPoints(
@@ -28,22 +28,10 @@ const DEFAULT: ValidatorEraPointsData = {
 	validatorEraPoints: [],
 }
 
-export const useValidatorEraPoints = ({
-	network,
-	validator,
-	fromEra,
-	depth,
-}: {
+export const useValidatorEraPoints = (variables: {
 	network: string
 	validator: string
 	fromEra: number
 	depth?: number
-}): QueryReturn<ValidatorEraPointsData> => {
-	const { loading, error, data, refetch } = useQuery<ValidatorEraPointsData>(
-		QUERY,
-		{
-			variables: { network, validator, fromEra, depth },
-		},
-	)
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<ValidatorEraPointsData> =>
+	useApiQuery<ValidatorEraPointsData>(QUERY, variables, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/validatorEraPointsBatch.ts
+++ b/packages/plugin-staking-api/src/queries/validatorEraPointsBatch.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { ValidatorEraPointsBatchData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query ValidatorEraPointsBatch(
@@ -32,19 +32,14 @@ const DEFAULT: ValidatorEraPointsBatchData = {
 	validatorEraPointsBatch: [],
 }
 
-export const fetchValidatorEraPointsBatch = async (
+export const fetchValidatorEraPointsBatch = (
 	network: string,
 	validators: string[],
 	fromEra: number,
 	depth?: number,
-): Promise<ValidatorEraPointsBatchData> => {
-	try {
-		const result = await client.query<ValidatorEraPointsBatchData>({
-			query: QUERY,
-			variables: { network, validators, fromEra, depth },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+) =>
+	fetchQuery<ValidatorEraPointsBatchData>(
+		QUERY,
+		{ network, validators, fromEra, depth },
+		DEFAULT,
+	)

--- a/packages/plugin-staking-api/src/queries/validatorRewards.ts
+++ b/packages/plugin-staking-api/src/queries/validatorRewards.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
 import type { QueryReturn, ValidatorRewardsData } from '../types'
+import { useApiQuery } from './generic'
 
 const QUERY = gql`
   query ValidatorRewards(
@@ -29,22 +29,10 @@ const DEFAULT: ValidatorRewardsData = {
 	validatorRewards: [],
 }
 
-export const useValidatorRewards = ({
-	network,
-	validator,
-	fromEra,
-	depth,
-}: {
+export const useValidatorRewards = (variables: {
 	network: string
 	validator: string
 	fromEra: number
 	depth?: number
-}): QueryReturn<ValidatorRewardsData> => {
-	const { loading, error, data, refetch } = useQuery<ValidatorRewardsData>(
-		QUERY,
-		{
-			variables: { network, validator, fromEra, depth },
-		},
-	)
-	return { loading, error, data: data || DEFAULT, refetch }
-}
+}): QueryReturn<ValidatorRewardsData> =>
+	useApiQuery<ValidatorRewardsData>(QUERY, variables, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/validatorStats.ts
+++ b/packages/plugin-staking-api/src/queries/validatorStats.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { gql } from '@apollo/client'
-import { client } from '../Client'
 import type { ValidatorStatsData } from '../types'
+import { fetchQuery } from './generic'
 
 const QUERY = gql`
   query ValidatorStats($network: String!) {
@@ -29,16 +29,5 @@ const DEFAULT: ValidatorStatsData = {
 	},
 }
 
-export const fetchValidatorStats = async (
-	network: string,
-): Promise<ValidatorStatsData> => {
-	try {
-		const result = await client.query<ValidatorStatsData>({
-			query: QUERY,
-			variables: { network },
-		})
-		return result?.data || DEFAULT
-	} catch {
-		return DEFAULT
-	}
-}
+export const fetchValidatorStats = (network: string) =>
+	fetchQuery<ValidatorStatsData>(QUERY, { network }, DEFAULT)


### PR DESCRIPTION
Refactors the `plugin-staking-api` query modules to share two generic helpers (`fetchQuery` and `useApiQuery`) instead of duplicating Apollo `client.query`/`useQuery` boilerplate with try/catch and default-data fallback in every file.

**Changes:**
- Adds `queries/generic.ts` exporting `fetchQuery` (async, swallows errors) and `useApiQuery` (Apollo `useQuery` wrapper with default data + optional `skip`).
- Rewrites every query file in `packages/plugin-staking-api/src/queries/` to delegate to these helpers, removing direct `client`/`useQuery` imports.
- Adds `activeValidatorRanks` and `generic` to the package's barrel exports in `src/index.ts`.