### PR TITLE
chore: format AssetHubPolkadotSubscanURL to satisfy Biome

### DIFF
--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -13,8 +13,7 @@ export const PlatformSupportEmail = 'staking@polkadot.cloud'
 export const PlatformGitHubURL =
 	'https://github.com/polkadot-cloud/polkadot-staking-dashboard'
 export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'
-export const AssetHubPolkadotSubscanURL =
-	'https://assethub-polkadot.subscan.io'
+export const AssetHubPolkadotSubscanURL = 'https://assethub-polkadot.subscan.io'
 export const ManualSigners = ['ledger', 'vault', 'wallet_connect']
 
 // Analytics


### PR DESCRIPTION
## Summary

`packages/consts/src/index.ts` declares `AssetHubPolkadotSubscanURL` split across two lines. Biome's formatter expects it on a single line, so `biome check .` fails in the `consts` package — which in turn fails the repo-wide `pnpm check` step in CI.

This is a one-line formatting fix that unblocks CI. The error currently affects **any branch based on `main`** that runs `pnpm check`, so landing it at the source resolves it across in-flight branches.