### PR TITLE
feat(fix): Re-derive own stake on account change

### DIFF
--- a/packages/app/src/contexts/EraStakers/index.tsx
+++ b/packages/app/src/contexts/EraStakers/index.tsx
@@ -3,7 +3,7 @@
 
 import { useActiveAccount } from '@polkadot-cloud/connect'
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
-import { setStateWithRef } from '@w3ux/utils'
+import { planckToUnit, setStateWithRef } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
 import { useNetwork } from 'contexts/Network'
 import { usePlugins } from 'contexts/Plugins'
@@ -294,6 +294,25 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 	const getActiveValidator = (who: MaybeAddress) => {
 		return eraStakers.stakers.find((s) => s.address === who)
 	}
+
+	// When the active account changes and stakers are already loaded, re-derive activeAccountOwnStake
+	// for the new account without re-fetching chain data.
+	useEffectIgnoreInitial(() => {
+		if (!eraStakersRef.current.stakers.length) {
+			return
+		}
+		const activeAccountOwnStake = eraStakersRef.current.stakers.flatMap(
+			({ address, others }) => {
+				const own = others.find(({ who }) => who === activeAddress)
+				return own ? [{ address, value: planckToUnit(own.value, units) }] : []
+			},
+		)
+		setStateWithRef(
+			{ ...eraStakersRef.current, activeAccountOwnStake },
+			setEraStakers,
+			eraStakersRef,
+		)
+	}, [activeAddress])
 
 	useEffectIgnoreInitial(() => {
 		if (getApiStatus(network) === 'connecting') {


### PR DESCRIPTION
Potential fix for: https://github.com/polkadot-cloud/polkadot-staking-dashboard/issues/3315

This PR updates the EraStakers context to recompute `activeAccountOwnStake` when the active account changes, using already-loaded staker data (avoiding an additional chain fetch / worker re-run solely for account switching).

**Changes:**
- Import `planckToUnit` and use it to re-derive `activeAccountOwnStake` on `activeAddress` changes.
- Add a `useEffectIgnoreInitial` that recalculates `activeAccountOwnStake` from `eraStakersRef.current.stakers` and updates context state via `setStateWithRef`.