### PR TITLE
feat(fix): Disable nominate submit for read-only accounts

### DIFF
--- a/packages/app/src/canvas/NominatorSetup/Summary/index.tsx
+++ b/packages/app/src/canvas/NominatorSetup/Summary/index.tsx
@@ -39,6 +39,11 @@ export const Summary = ({ section }: SetupStepProps) => {
 	const { getNominatorSetup, removeNominatorSetup } = useNominatorSetups()
 	const { unit, units } = getStakingChainData(network)
 
+	// Whether the active account (or its active proxy) can actually sign. Used to
+	// gate the submit button so read-only accounts cannot attempt to submit
+	const hasSigner =
+		accountHasSigner(activeAccount) || accountHasSigner(activeProxy)
+
 	const setup = getNominatorSetup(activeAddress)
 	const { progress } = setup
 	const { bond, nominations, payee } = progress
@@ -103,9 +108,7 @@ export const Summary = ({ section }: SetupStepProps) => {
 			/>
 
 			<MotionContainer thisSection={section} activeSection={setup.section}>
-				{!(
-					accountHasSigner(activeAccount) || accountHasSigner(activeProxy)
-				) && <Warning text={t('readOnly')} />}
+				{!hasSigner && <Warning text={t('readOnly')} />}
 				<SummaryWrapper style={{ marginTop: '1rem' }}>
 					<section>
 						<div>
@@ -151,7 +154,7 @@ export const Summary = ({ section }: SetupStepProps) => {
 				>
 					<SubmitTx
 						submitText={t('startNominating')}
-						valid={true}
+						valid={hasSigner}
 						{...submitExtrinsic}
 						displayFor="canvas"
 						stacked

--- a/packages/app/src/modals/SimpleNominate/index.tsx
+++ b/packages/app/src/modals/SimpleNominate/index.tsx
@@ -42,6 +42,11 @@ export const SimpleNominate = () => {
 	} = useAccountBalances(activeAddress)
 	const { units } = getStakingChainData(network)
 
+	// Whether the active account (or its active proxy) can actually sign. Used to
+	// gate the submit button so read-only accounts cannot attempt to submit
+	const hasSigner =
+		accountHasSigner(activeAccount) || accountHasSigner(activeProxy)
+
 	// Take optimal nominations from setup progress
 	const setup = getNominatorSetup(activeAddress)
 	const { progress } = setup
@@ -104,9 +109,7 @@ export const SimpleNominate = () => {
 			<Close />
 			<Padding>
 				<Title>{t('becomeNominator', { ns: 'modals' })}</Title>
-				{!(
-					accountHasSigner(activeAccount) || accountHasSigner(activeProxy)
-				) && <Warning text={t('readOnly')} />}
+				{!hasSigner && <Warning text={t('readOnly')} />}
 
 				<Separator transparent />
 				<BondFeedback
@@ -124,7 +127,7 @@ export const SimpleNominate = () => {
 				<SubmitTx
 					displayFor="card"
 					submitText={t('startNominating')}
-					valid={bondValid}
+					valid={bondValid && hasSigner}
 					{...submitExtrinsic}
 					stacked
 				/>


### PR DESCRIPTION
The two primary nominate onboarding flows hardcoded the submit button's `valid` prop,`valid={true}` in the NominatorSetup summary canvas and `valid={bondValid}` in the SimpleNominate modal. As a result a read-only / watch-only account saw a fully enabled, pulsing submit button that did nothing useful.

This aligns these flows with the Bond / Unbond / JoinPool flows, which already gate validity on whether the account can sign.

**Changes**
- Hoist the existing read-only condition into a `hasSigner` const in both flows
- Feed it into `SubmitTx`'s `valid` prop:
  - `Summary` (canvas): `valid={hasSigner}`
  - `SimpleNominate` (modal): `valid={bondValid && hasSigner}`
- Proxy signing is preserved via `accountHasSigner(activeProxy)`, so submitting through an active proxy still works
