### PR TITLE
feat(fix): Fix pool nomination refresh on update

### DIFF
--- a/packages/dedot-api/src/subscribe/activePool.ts
+++ b/packages/dedot-api/src/subscribe/activePool.ts
@@ -4,9 +4,9 @@
 import type { DedotClient } from 'dedot'
 import type { Unsub } from 'dedot/types'
 import {
-	addActivePool,
 	removeActivePool,
 	removePoolRoleIdentities,
+	setActivePool,
 } from 'global-bus'
 import type { ActivePool, ServiceInterface } from 'types'
 import { createPoolAccounts } from 'utils'
@@ -106,7 +106,7 @@ export class ActivePoolQuery<T extends StakingChain> {
 							submittedIn,
 						},
 					}
-					addActivePool(activePool)
+					setActivePool(activePool)
 				} else {
 					removeActivePool(this.poolId)
 				}

--- a/packages/global-bus/src/activePools/index.ts
+++ b/packages/global-bus/src/activePools/index.ts
@@ -15,8 +15,11 @@ export const getActivePool = (poolId: number) =>
 
 export const addActivePool = (value: ActivePool) => {
 	const next = [..._activePools.getValue()]
-	if (!next.find((pool) => pool.id === value.id)) {
+	const index = next.findIndex((pool) => pool.id === value.id)
+	if (index === -1) {
 		next.push(value)
+	} else {
+		next[index] = value
 	}
 	_activePools.next(next)
 }

--- a/packages/global-bus/src/activePools/index.ts
+++ b/packages/global-bus/src/activePools/index.ts
@@ -13,7 +13,7 @@ export const resetActivePools = () => {
 export const getActivePool = (poolId: number) =>
 	_activePools.getValue().find((pool) => pool.id === poolId)
 
-export const addActivePool = (value: ActivePool) => {
+export const setActivePool = (value: ActivePool) => {
 	const next = [..._activePools.getValue()]
 	const index = next.findIndex((pool) => pool.id === value.id)
 	if (index === -1) {


### PR DESCRIPTION
This PR adjusts the global-bus active pool cache behavior so that when a pool that already exists in `_activePools` is “added” again, the stored entry is refreshed rather than ignored. This supports fixing cases where pool nominations (or other pool data) must update after an upstream change.

**Changes:**
- Change `addActivePool -> setActivePool` to update an existing pool entry (by `id`) instead of no-op’ing when already present.
- Preserve existing array behavior by emitting a new array via `_activePools.next(next)`.
