### PR TITLE
feat(refactor): Move worker to standalone package

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -71,7 +71,8 @@
 		"ui-tips": "workspace:*",
 		"usehooks-ts": "^3.0.2",
 		"utils": "workspace:*",
-		"validator-assets": "workspace:*"
+		"validator-assets": "workspace:*",
+		"workers": "workspace:*"
 	},
 	"devDependencies": {
 		"types": "workspace:*",

--- a/packages/app/src/contexts/EraStakers/types.ts
+++ b/packages/app/src/contexts/EraStakers/types.ts
@@ -1,7 +1,12 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { MaybeAddress, NominationStatus, Staker } from 'types'
+import type {
+	ActiveAccountOwnStake,
+	MaybeAddress,
+	NominationStatus,
+	Staker,
+} from 'types'
 
 export interface EraStakersContextInterface {
 	eraStakers: EraStakers
@@ -20,10 +25,6 @@ export interface EraStakersContextInterface {
 	}
 }
 
-export interface ActiveAccountOwnStake {
-	address: string
-	value: string
-}
 export interface EraStakers {
 	activeAccountOwnStake: ActiveAccountOwnStake[]
 	stakers: Staker[]

--- a/packages/hooks/src/useStaking/types.ts
+++ b/packages/hooks/src/useStaking/types.ts
@@ -1,18 +1,10 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+export type { ActiveAccountOwnStake, ActiveAccountStaker } from 'types'
+
 export interface StakingHookInterface {
 	isBonding: boolean
 	isNominating: boolean
 	isNominator: boolean
-}
-
-export interface ActiveAccountOwnStake {
-	address: string
-	value: string
-}
-
-export interface ActiveAccountStaker {
-	address: string
-	value: string
 }

--- a/packages/types/src/staking.ts
+++ b/packages/types/src/staking.ts
@@ -39,6 +39,13 @@ export type Staker = ExposureValue & {
 	address: string
 }
 
+export interface ActiveAccountOwnStake {
+	address: string
+	value: string
+}
+
+export type ActiveAccountStaker = ActiveAccountOwnStake
+
 export interface Exposure {
 	keys: string[]
 	val: ExposureValue

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "workers",
+	"version": "0.1.0",
+	"license": "GPL-3.0-only",
+	"type": "module",
+	"exports": {
+		"./stakers": "./src/stakers.ts",
+		"./types": "./src/types.ts"
+	},
+	"scripts": {
+		"clear": "rm -rf build tsconfig.tsbuildinfo dist node_modules",
+		"check": "biome check .",
+		"lint": "biome check --write ."
+	},
+	"dependencies": {
+		"@w3ux/utils": "^3.1.1",
+		"bignumber.js": "^11.1.3"
+	},
+	"devDependencies": {
+		"types": "workspace:*"
+	}
+}

--- a/packages/workers/src/stakers.ts
+++ b/packages/workers/src/stakers.ts
@@ -3,8 +3,7 @@
 
 import { planckToUnit } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
-import type { ActiveAccountStaker } from 'hooks/useStaking'
-import type { Staker } from 'types'
+import type { ActiveAccountOwnStake, Staker } from 'types'
 import type { ProcessExposuresArgs } from './types'
 
 // biome-ignore lint/suspicious/noExplicitAny: <>
@@ -25,7 +24,7 @@ const processExposures = (data: ProcessExposuresArgs) => {
 	const { task, networkName, era, units, exposures, activeAccount } = data
 
 	const stakers: Staker[] = []
-	const activeAccountOwnStake: ActiveAccountStaker[] = []
+	const activeAccountOwnStake: ActiveAccountOwnStake[] = []
 
 	exposures.forEach(({ keys, val }) => {
 		const address = keys[1]

--- a/packages/workers/src/types.ts
+++ b/packages/workers/src/types.ts
@@ -1,8 +1,13 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { ActiveAccountStaker } from 'hooks/useStaking'
-import type { Exposure, MaybeAddress, NetworkId, Staker } from 'types'
+import type {
+	ActiveAccountOwnStake,
+	Exposure,
+	MaybeAddress,
+	NetworkId,
+	Staker,
+} from 'types'
 
 export interface ProcessExposuresArgs {
 	task: string
@@ -18,6 +23,6 @@ export interface ProcessExposuresResponse {
 	networkName: NetworkId
 	era: string
 	stakers: Staker[]
-	activeAccountOwnStake: ActiveAccountStaker[]
+	activeAccountOwnStake: ActiveAccountOwnStake[]
 	who: MaybeAddress
 }

--- a/packages/workers/tsconfig.json
+++ b/packages/workers/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src", "../../env.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       validator-assets:
         specifier: workspace:*
         version: link:../validator-assets
+      workers:
+        specifier: workspace:*
+        version: link:../workers
     devDependencies:
       types:
         specifier: workspace:*
@@ -837,6 +840,19 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(sass@1.100.0)(tsx@4.22.4)
+
+  packages/workers:
+    dependencies:
+      '@w3ux/utils':
+        specifier: ^3.1.1
+        version: 3.1.1
+      bignumber.js:
+        specifier: ^11.1.3
+        version: 11.1.3
+    devDependencies:
+      types:
+        specifier: workspace:*
+        version: link:../types
 
 packages:
 


### PR DESCRIPTION
This PR refactors the staking-era “stakers” web worker into a standalone workspace package (`packages/workers`) and centralizes the related `ActiveAccountOwnStake` / `ActiveAccountStaker` types in the shared `types` package so both the app and worker can depend on the same definitions.

**Changes:**
- Add new `packages/workers` workspace package exporting the stakers worker entry and its message types.
- Move/align “active account own stake” typings into `packages/types` and re-export them from `packages/hooks`.
- Wire the app to depend on the new `workers` workspace package via `package.json` + lockfile updates.