### PR TITLE
perf(bundle): lazy-load page routes and split heavy vendor chunks

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -10,15 +10,35 @@ import {
 	faUserGear,
 	faUsers,
 } from '@fortawesome/free-solid-svg-icons'
-import { Nominate } from 'pages/Nominate'
-import { Operators } from 'pages/Operators'
-import { Overview } from 'pages/Overview'
-import { Pools } from 'pages/Pools'
-import { PoolsList } from 'pages/PoolsList'
-import { Rewards } from 'pages/Rewards'
-import { Stake } from 'pages/Stake'
-import { Validators } from 'pages/Validators'
+import { lazy } from 'react'
 import type { PageCategoryItems, PagesConfigItems } from 'types'
+
+// Pages are lazily imported so each route lands in its own chunk rather than the
+// entry bundle, keeping chart.js, chroma-js etc. out of initial load
+const Overview = lazy(() =>
+	import('pages/Overview').then((m) => ({ default: m.Overview })),
+)
+const Stake = lazy(() =>
+	import('pages/Stake').then((m) => ({ default: m.Stake })),
+)
+const Pools = lazy(() =>
+	import('pages/Pools').then((m) => ({ default: m.Pools })),
+)
+const Nominate = lazy(() =>
+	import('pages/Nominate').then((m) => ({ default: m.Nominate })),
+)
+const Rewards = lazy(() =>
+	import('pages/Rewards').then((m) => ({ default: m.Rewards })),
+)
+const Validators = lazy(() =>
+	import('pages/Validators').then((m) => ({ default: m.Validators })),
+)
+const Operators = lazy(() =>
+	import('pages/Operators').then((m) => ({ default: m.Operators })),
+)
+const PoolsList = lazy(() =>
+	import('pages/PoolsList').then((m) => ({ default: m.PoolsList })),
+)
 
 // Pages categories config - order determines the order of items in the sidebar
 export const PageCategories: PageCategoryItems = [

--- a/packages/app/src/library/PageWithTitle/index.tsx
+++ b/packages/app/src/library/PageWithTitle/index.tsx
@@ -1,6 +1,8 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { PagePreloader } from 'library/PagePreloader'
+import { Suspense } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 import type { PageItem } from 'types'
@@ -17,7 +19,9 @@ export const PageWithTitle = ({ page }: { page: PageItem }) => {
 					ns: 'app',
 				})}`}</title>
 			</Helmet>
-			<Entry page={page} />
+			<Suspense fallback={<PagePreloader />}>
+				<Entry page={page} />
+			</Suspense>
 		</Page.Container>
 	)
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -21,6 +21,26 @@ export default defineConfig({
 	},
 	build: {
 		outDir: 'build',
+		rollupOptions: {
+			output: {
+				// Split heavy vendor libraries into their own cacheable chunks so
+				// they stay out of the entry bundle
+				manualChunks: (id) => {
+					if (!id.includes('node_modules')) {
+						return
+					}
+					if (/chart\.js|chartjs|react-chartjs-2|chroma-js/.test(id)) {
+						return 'charts'
+					}
+					if (id.includes('dedot')) {
+						return 'dedot'
+					}
+					if (id.includes('@fortawesome')) {
+						return 'fontawesome'
+					}
+				},
+			},
+		},
 	},
 	server: {
 		fs: {

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { IconProp } from '@fortawesome/fontawesome-svg-core'
-import type { FC } from 'react'
+import type { ComponentType } from 'react'
 
 // biome-ignore lint/suspicious/noExplicitAny: <>
 export type AnyJson = any
@@ -24,7 +24,8 @@ export interface PageItem {
 	key: string
 	uri: string
 	hash: string
-	Entry: FC<PageProps>
+	// ComponentType (rather than FC) so lazy()-wrapped pages are assignable
+	Entry: ComponentType<PageProps>
 	faIcon: IconProp
 	advanced: boolean
 	bullet?: BulletType


### PR DESCRIPTION
## Summary

All 8 pages were static imports, so heavy page-only dependencies (chart.js,
chartjs-plugin-annotation, chroma-js, etc.) landed in the entry chunk even
though modals and canvases were already lazy-loaded.

## Changes

- Convert every `PagesConfig` entry to `React.lazy(() => import(...))` so each
  route is emitted as its own chunk and loaded on navigation.
- Wrap the page render in `PageWithTitle` with a `Suspense` boundary using the
  existing `PagePreloader` fallback.
- Widen `PageItem.Entry` to `ComponentType<PageProps>` so lazy components are
  assignable.
- Add `manualChunks` to split `charts` (chart.js & friends), `dedot`, and
  `@fortawesome` into separate cacheable vendor chunks.