### PR TITLE
perf(worker): use BigInt compare for staker sort instead of BigNumber

### DIFF
--- a/packages/workers/src/stakers.ts
+++ b/packages/workers/src/stakers.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { planckToUnit } from '@w3ux/utils'
-import BigNumber from 'bignumber.js'
 import type { ActiveAccountOwnStake, Staker } from 'types'
 import type { ProcessExposuresArgs } from './types'
 
@@ -35,10 +34,12 @@ const processExposures = (data: ProcessExposuresArgs) => {
 			})) ?? []
 
 		if (others.length) {
-			// Sort `others` by value bonded, largest first.
+			// Sort `others` by value bonded, largest first. Values are planck
+			// integer strings, so a BigInt compare avoids per-comparison BigNumber
+			// allocation.
 			others = others.sort((a, b) => {
-				const r = new BigNumber(b.value).minus(a.value)
-				return r.isZero() ? 0 : r.isLessThan(0) ? -1 : 1
+				const r = BigInt(b.value) - BigInt(a.value)
+				return r === 0n ? 0 : r < 0n ? -1 : 1
 			})
 			stakers.push({
 				address,

--- a/packages/workers/src/stakers.ts
+++ b/packages/workers/src/stakers.ts
@@ -34,9 +34,7 @@ const processExposures = (data: ProcessExposuresArgs) => {
 			})) ?? []
 
 		if (others.length) {
-			// Sort `others` by value bonded, largest first. Values are planck
-			// integer strings, so a BigInt compare avoids per-comparison BigNumber
-			// allocation.
+			// Sort `others` by value bonded, largest first.
 			others = others.sort((a, b) => {
 				const r = BigInt(b.value) - BigInt(a.value)
 				return r === 0n ? 0 : r < 0n ? -1 : 1


### PR DESCRIPTION
## Summary

The stakers worker sorted each validator's `others` by bonded value using a
`new BigNumber(...).minus(...)` per comparison. The values are planck integer
strings, so a native `BigInt` compare does the same job without allocating a
BigNumber object on every comparison across thousands of nominators.

## Changes

- Replace the `BigNumber`-based comparator with `BigInt(b.value) - BigInt(a.value)`.
- Drop the now-unused `bignumber.js` import from the worker.
