### PR TITLE
perf(locales): lazy-load date-fns locale for active language

### DIFF
--- a/packages/app/src/canvas/Pool/Overview/Performance/ActiveGraph.tsx
+++ b/packages/app/src/canvas/Pool/Overview/Performance/ActiveGraph.tsx
@@ -4,7 +4,7 @@
 import { planckToUnit } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useRewards } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -26,8 +26,9 @@ export const ActiveGraph = ({
 	height,
 	units,
 }: Props) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit } = getStakingChainData(network)
 	const {
 		data: { allRewards },
@@ -58,7 +59,7 @@ export const ActiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('date', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/Pool/Overview/Performance/InactiveGraph.tsx
+++ b/packages/app/src/canvas/Pool/Overview/Performance/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { PayoutLine } from 'ui-graphs'
 
@@ -15,9 +15,10 @@ export const InactiveGraph = ({
 	width: string | number
 	height: string | number
 }) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit } = getStakingChainData(network)
 
 	return (
@@ -28,7 +29,7 @@ export const InactiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('era', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useValidatorEraPoints } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -22,8 +22,9 @@ export const ActiveGraph = ({
 	width,
 	height,
 }: Props) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { data, loading, error } = useValidatorEraPoints({
 		network,
 		validator,
@@ -40,7 +41,7 @@ export const ActiveGraph = ({
 			width={width}
 			height={height}
 			getThemeValue={getThemeValue}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale]?.dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				date: t('date', { ns: 'app' }),
 				era: t('era', { ns: 'app' }),

--- a/packages/app/src/canvas/ValidatorMetrics/EraPoints/InactiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/EraPoints/InactiveGraph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useTranslation } from 'react-i18next'
 import { EraPointsLine } from 'ui-graphs'
 
@@ -13,8 +13,9 @@ export const InactiveGraph = ({
 	width: string | number
 	height: string | number
 }) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 
 	return (
 		<EraPointsLine
@@ -23,7 +24,7 @@ export const InactiveGraph = ({
 			width={width}
 			height={height}
 			getThemeValue={getThemeValue}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale]?.dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				date: t('date', { ns: 'app' }),
 				era: t('era', { ns: 'app' }),

--- a/packages/app/src/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
@@ -4,7 +4,7 @@
 import { planckToUnit } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useValidatorRewards } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -24,8 +24,9 @@ export const ActiveGraph = ({
 	width,
 	height,
 }: Props) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { data, loading, error } = useValidatorRewards({
 		network,
 		validator,
@@ -52,7 +53,7 @@ export const ActiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('date', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/ValidatorMetrics/Rewards/InactiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/Rewards/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { PayoutLine } from 'ui-graphs'
 
@@ -15,9 +15,10 @@ export const InactiveGraph = ({
 	width: string | number
 	height: string | number
 }) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit } = getStakingChainData(network)
 
 	return (
@@ -28,7 +29,7 @@ export const InactiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('era', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/hooks/useDateFormat/index.ts
+++ b/packages/app/src/hooks/useDateFormat/index.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { Locale } from 'date-fns'
+import { DefaultLocale, getDateFormat, loadDateFormat } from 'locales'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+// Returns the date-fns `Locale` for the active language, lazy-loading it on
+// demand. Returns `undefined` until the locale's date format has loaded, at
+// which point date-fns falls back to its default formatting.
+export const useDateFormat = (): Locale | undefined => {
+	const { i18n } = useTranslation()
+	const lng = i18n.resolvedLanguage ?? DefaultLocale
+
+	const [dateFormat, setDateFormat] = useState<Locale | undefined>(() =>
+		getDateFormat(lng),
+	)
+
+	useEffect(() => {
+		let active = true
+		loadDateFormat(lng).then((locale) => {
+			if (active) {
+				setDateFormat(locale)
+			}
+		})
+		return () => {
+			active = false
+		}
+	}, [lng])
+
+	return dateFormat
+}

--- a/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
@@ -7,8 +7,8 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useApi } from 'hooks/useApi'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import {
 	usePoolEraRewards,
 	usePoolRewards,
@@ -35,12 +35,13 @@ export const ActiveGraph = ({
 	lineMarginTop,
 	setLastReward,
 }: Props) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { activeEra } = useApi()
 	const { network } = useNetwork()
 	const { activePool } = useActivePool()
 	const { getThemeValue } = useThemeValues()
 	const { activeAddress } = useActiveAccount()
+	const dateFormat = useDateFormat()
 	const { unit, units } = getStakingChainData(network)
 
 	const { data: nominatorRewardData, loading: rewardsLoading } = useRewards({
@@ -108,7 +109,7 @@ export const ActiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Overview/Payouts/InactiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import type { NominatorReward } from 'plugin-staking-api/types'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,9 +15,10 @@ export const InactiveGraph = ({
 }: {
 	setLastReward: (reward: NominatorReward | undefined) => void
 }) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit, units } = getStakingChainData(network)
 
 	useEffect(() => {
@@ -36,7 +37,7 @@ export const InactiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -8,6 +8,7 @@ import { getStakingChainData } from 'consts/util'
 import { formatDistance, fromUnixTime, getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useCurrency } from 'hooks/useCurrency'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
@@ -15,7 +16,6 @@ import { useSyncing } from 'hooks/useSyncing'
 import { useUi } from 'hooks/useUi'
 import { Balance } from 'library/Balance'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import type { RewardResult } from 'plugin-staking-api/types'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +26,7 @@ import { ActiveGraph } from './ActiveGraph'
 import { InactiveGraph } from './InactiveGraph'
 
 export const Payouts = () => {
-	const { i18n, t } = useTranslation('pages')
+	const { t } = useTranslation('pages')
 	const { network } = useNetwork()
 	const { syncing } = useSyncing()
 	const { containerRefs } = useUi()
@@ -34,6 +34,7 @@ export const Payouts = () => {
 	const { currency } = useCurrency()
 	const { isBonding } = useStaking()
 	const { pluginEnabled } = usePlugins()
+	const dateFormat = useDateFormat()
 
 	const { units } = getStakingChainData(network)
 	const Token = getChainIcons(network).token
@@ -61,10 +62,10 @@ export const Payouts = () => {
 			formatTo: now,
 			formatOpts: {
 				addSuffix: true,
-				locale: locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
+				locale: dateFormat,
 			},
 		}
-	}, [lastReward, i18n.resolvedLanguage])
+	}, [lastReward, dateFormat])
 
 	const lastRewardUnit = planckToUnitBn(
 		new BigNumber(lastReward?.reward || 0),

--- a/packages/app/src/pages/Pools/PoolShares/DemoGraph.tsx
+++ b/packages/app/src/pages/Pools/PoolShares/DemoGraph.tsx
@@ -41,7 +41,7 @@ const Fade = styled.div`
 
 export interface PoolSharesDemoGraphProps {
 	activeAddress?: string
-	dateFormat: Locale
+	dateFormat?: Locale
 	getThemeValue: (key: string) => string
 	height: string
 	poolId?: number

--- a/packages/app/src/pages/Pools/PoolShares/index.tsx
+++ b/packages/app/src/pages/Pools/PoolShares/index.tsx
@@ -12,13 +12,13 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useCurrency } from 'hooks/useCurrency'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
 import { useSyncing } from 'hooks/useSyncing'
 import { Balance } from 'library/Balance'
 import { CardWrapper } from 'library/Card/Wrappers'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import { fetchCombinedPoolRewards, isPoolShareReward } from 'plugin-staking-api'
 import type { CombinedPoolReward } from 'plugin-staking-api/types'
 import { useEffect, useMemo, useState } from 'react'
@@ -32,7 +32,7 @@ const POOL_SHARE_FETCH_LIMIT = 100
 const MAX_POOL_SHARE_FETCH_PAGES = 5
 
 export const PoolShares = () => {
-	const { i18n, t } = useTranslation('pages')
+	const { t } = useTranslation('pages')
 	const { network } = useNetwork()
 	const { currency } = useCurrency()
 	const { pluginEnabled } = usePlugins()
@@ -137,7 +137,7 @@ export const PoolShares = () => {
 		}
 	}, [graphActive, network, activeAddress, fromTimestamp])
 
-	const dateFormat = locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat
+	const dateFormat = useDateFormat()
 	const graphHeight = '175px'
 	const graphLabels = {
 		poolShares: t('share', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/ActiveGraph.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/ActiveGraph.tsx
@@ -5,8 +5,8 @@ import { useActiveAccount } from '@polkadot-cloud/connect'
 import { MaxPayoutDays } from 'consts'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import type { PayoutHistoryProps } from 'pages/Rewards/types'
 import { useTranslation } from 'react-i18next'
 import { AveragePayoutLine, PayoutBar } from 'ui-graphs'
@@ -25,10 +25,11 @@ export const ActiveGraph = ({
 	payoutGraphData: { payouts, unclaimedPayouts, poolClaims, poolShareRewards },
 	loading,
 }: Props) => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { network } = useNetwork()
 	const { activeAddress } = useActiveAccount()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit, units } = getStakingChainData(network)
 
 	return (
@@ -43,7 +44,7 @@ export const ActiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/InactiveGraph.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/InactiveGraph.tsx
@@ -4,15 +4,16 @@
 import { MaxPayoutDays } from 'consts'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { AveragePayoutLine, PayoutBar } from 'ui-graphs'
 
 export const InactiveGraph = () => {
-	const { i18n, t } = useTranslation()
+	const { t } = useTranslation()
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat()
 	const { unit, units } = getStakingChainData(network)
 
 	return (
@@ -27,7 +28,7 @@ export const InactiveGraph = () => {
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/index.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/index.tsx
@@ -3,12 +3,12 @@
 
 import { useSize } from '@w3ux/hooks'
 import { useActivePool } from 'hooks/useActivePool'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
 import { useSyncing } from 'hooks/useSyncing'
 import { useUi } from 'hooks/useUi'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import type { PayoutHistoryProps } from 'pages/Rewards/types'
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -25,21 +25,16 @@ export const RecentPayouts = ({
 	payoutGraphData,
 	loading,
 }: PayoutHistoryProps) => {
-	const { i18n, t } = useTranslation('pages')
+	const { t } = useTranslation('pages')
 	const { syncing } = useSyncing()
 	const { containerRefs } = useUi()
 	const { inPool } = useActivePool()
 	const { isBonding } = useStaking()
 	const { pluginEnabled } = usePlugins()
+	const dateFormat = useDateFormat()
 
-	const payoutsFromDate = getPayoutsFromDate(
-		payoutsList,
-		locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
-	)
-	const payoutsToDate = getPayoutsToDate(
-		payoutsList,
-		locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
-	)
+	const payoutsFromDate = getPayoutsFromDate(payoutsList, dateFormat)
+	const payoutsToDate = getPayoutsToDate(payoutsList, dateFormat)
 	const staking = isBonding || inPool
 	const notStaking = !syncing && !staking
 

--- a/packages/app/src/pages/Rewards/PayoutList/Inner.tsx
+++ b/packages/app/src/pages/Rewards/PayoutList/Inner.tsx
@@ -12,13 +12,13 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { formatDistance, fromUnixTime } from 'date-fns'
 import { useApi } from 'hooks/useApi'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { Header, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer } from 'library/List/MotionContainer'
 import { Pagination } from 'library/List/Pagination'
 import { Identity } from 'library/ListItem/Labels/Identity'
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity'
-import { DefaultLocale, locales } from 'locales'
 import { motion } from 'motion/react'
 import { isPoolReward, isPoolShareReward } from 'plugin-staking-api'
 import type {
@@ -43,7 +43,7 @@ export const PayoutList = ({
 	loading,
 	remotePagination,
 }: PayoutListProps) => {
-	const { i18n, t } = useTranslation('pages')
+	const { t } = useTranslation('pages')
 	const { isReady, activeEra } = useApi()
 	const { network } = useNetwork()
 	const { bondedPools } = useBondedPools()
@@ -55,6 +55,7 @@ export const PayoutList = ({
 		pagination: { page, setPage },
 	} = useList()
 	const { unit, units } = getStakingChainData(network)
+	const dateFormat = useDateFormat()
 
 	// Manipulated list (ordering, filtering) of payouts
 	const [payouts, setPayouts] = useState<RewardResults>(initialPayouts)
@@ -238,10 +239,7 @@ export const PayoutList = ({
 																new Date(),
 																{
 																	addSuffix: true,
-																	locale:
-																		locales[
-																			i18n.resolvedLanguage ?? DefaultLocale
-																		].dateFormat,
+																	locale: dateFormat,
 																},
 															)}
 														</h5>

--- a/packages/locales/src/config.ts
+++ b/packages/locales/src/config.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { localeDefinitions } from 'consts/locales'
-import { de, enGB, es, ko, type Locale, ptBR, tr, zhCN } from 'date-fns/locale'
+import type { Locale } from 'date-fns'
 import appEn from './resources/en/app.json'
 import helpEn from './resources/en/help.json'
 import modalsEn from './resources/en/modals.json'
@@ -13,31 +13,48 @@ import type { LocaleEntry } from './types'
 // The default locale
 export const DefaultLocale = 'en'
 
-// Date formats for each locale
-const dateFormats: Record<string, Locale> = {
-	en: enGB,
-	de: de,
-	ko: ko,
-	pt: ptBR,
-	tr: tr,
-	zh: zhCN,
-	es: es,
+// Available locales as key value pairs
+export const locales: Record<string, LocaleEntry> = Object.fromEntries(
+	Object.entries(localeDefinitions).map(([key, value]) => [
+		key,
+		{ label: value.label },
+	]),
+)
+
+// Lazy loaders for each locale's date-fns `Locale`. These are dynamically
+// imported so that only the active locale's date format data is pulled into the
+// bundle, rather than eagerly bundling every locale.
+const dateFormatLoaders: Record<string, () => Promise<Locale>> = {
+	en: () => import('date-fns/locale/en-GB').then((m) => m.enGB),
+	de: () => import('date-fns/locale/de').then((m) => m.de),
+	ko: () => import('date-fns/locale/ko').then((m) => m.ko),
+	pt: () => import('date-fns/locale/pt-BR').then((m) => m.ptBR),
+	tr: () => import('date-fns/locale/tr').then((m) => m.tr),
+	zh: () => import('date-fns/locale/zh-CN').then((m) => m.zhCN),
+	es: () => import('date-fns/locale/es').then((m) => m.es),
 }
 
-// Available locales as key value pairs
-export const locales: Record<string, LocaleEntry> = Object.entries(
-	localeDefinitions,
-).reduce(
-	(acc, [key, value]) => {
-		const dateFormat = dateFormats[key]
-		if (!dateFormat) {
-			throw new Error(`Missing date format for locale: ${key}`)
-		}
-		acc[key] = { ...value, dateFormat }
-		return acc
-	},
-	{} as Record<string, LocaleEntry>,
-)
+// Cache of date formats that have already been loaded, keyed by locale
+const dateFormatCache = new Map<string, Locale>()
+
+// Lazy-load (and cache) the date-fns `Locale` for the given language, falling
+// back to the default locale's loader for unknown keys
+export const loadDateFormat = async (
+	lng: string,
+): Promise<Locale | undefined> => {
+	const cached = dateFormatCache.get(lng)
+	if (cached) {
+		return cached
+	}
+	const loader = dateFormatLoaders[lng] ?? dateFormatLoaders[DefaultLocale]
+	const dateFormat = await loader()
+	dateFormatCache.set(lng, dateFormat)
+	return dateFormat
+}
+
+// Synchronously read an already-loaded date format from the cache
+export const getDateFormat = (lng: string): Locale | undefined =>
+	dateFormatCache.get(lng)
 
 // Supported namespaces
 export const lngNamespaces: string[] = [

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -3,12 +3,14 @@
 
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
-import { DefaultLocale } from './config'
+import { DefaultLocale, loadDateFormat } from './config'
 
 export {
 	DefaultLocale,
 	fallbackResources,
+	getDateFormat,
 	lngNamespaces,
+	loadDateFormat,
 	locales,
 } from './config'
 
@@ -37,6 +39,9 @@ i18next
 		lng: defaultLng,
 		resources,
 	})
+
+// Warm the date format cache for the active language
+loadDateFormat(lng)
 
 // Dynamically load default language resources if needed
 if (dynamicLoad) {

--- a/packages/locales/src/types.ts
+++ b/packages/locales/src/types.ts
@@ -1,8 +1,6 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { Locale } from 'date-fns'
-
 export interface LocaleJson {
 	[key: string]:
 		| string
@@ -22,6 +20,5 @@ export type LocaleJsonValue =
 	| LocaleJson[]
 
 export interface LocaleEntry {
-	dateFormat: Locale
 	label: string
 }

--- a/packages/locales/src/util/language.ts
+++ b/packages/locales/src/util/language.ts
@@ -8,6 +8,7 @@ import {
 	DefaultLocale,
 	fallbackResources,
 	lngNamespaces,
+	loadDateFormat,
 	locales,
 } from '../config'
 import type { LocaleJson, LocaleJsonValue } from '../types'
@@ -72,6 +73,9 @@ export const getResources = (lng: string, i18n?: i18n) => {
 
 export const changeLanguage = async (lng: string, i18next: i18n) => {
 	onLocaleFromModalEvent(lng)
+
+	// Warm the date format cache for the newly selected language
+	loadDateFormat(lng)
 
 	// check whether resources exist and need to by dynamically loaded.
 	const { resources, dynamicLoad } = getResources(lng, i18next)

--- a/packages/ui-graphs/src/types.ts
+++ b/packages/ui-graphs/src/types.ts
@@ -21,7 +21,7 @@ export interface EraPointsLineProps {
 	width: string | number
 	height: string | number
 	getThemeValue: (key: string) => string
-	dateFormat: Locale
+	dateFormat?: Locale
 	labels: {
 		date: string
 		era: string
@@ -39,7 +39,7 @@ export interface PayoutBarProps {
 	getThemeValue: (key: string) => string
 	unit: string
 	units: number
-	dateFormat: Locale
+	dateFormat?: Locale
 	labels: {
 		payout: string
 		poolClaim: string
@@ -57,7 +57,7 @@ export interface PayoutLineProps {
 	height: string | number
 	getThemeValue: (key: string) => string
 	unit: string
-	dateFormat: Locale
+	dateFormat?: Locale
 	labels: {
 		era: string
 		reward: string
@@ -75,7 +75,7 @@ export interface PoolSharesBarProps {
 	getThemeValue: (key: string) => string
 	unit: string
 	units: number
-	dateFormat: Locale
+	dateFormat?: Locale
 	labels: {
 		poolShares: string
 		claim: string

--- a/packages/ui-graphs/src/util/dateUtils.ts
+++ b/packages/ui-graphs/src/util/dateUtils.ts
@@ -115,7 +115,7 @@ export const filterAndSortRewards = (payouts: RewardResults) => {
 /**
  * Calculate the earliest date of a payout list
  */
-export const getPayoutsFromDate = (payouts: RewardResults, locale: Locale) => {
+export const getPayoutsFromDate = (payouts: RewardResults, locale?: Locale) => {
 	if (!payouts.length) {
 		return undefined
 	}
@@ -133,7 +133,7 @@ export const getPayoutsFromDate = (payouts: RewardResults, locale: Locale) => {
 /**
  * Calculate the latest date of a payout list
  */
-export const getPayoutsToDate = (payouts: RewardResults, locale: Locale) => {
+export const getPayoutsToDate = (payouts: RewardResults, locale?: Locale) => {
 	if (!payouts.length) {
 		return undefined
 	}


### PR DESCRIPTION
Replace eager import of all 7 date-fns locales with on-demand dynamic imports, keyed per locale. Add `loadDateFormat/getDateFormat `helpers and a `useDateFormat()` hook; consumers read the active locale's format reactively.

Locale date data now splits into separate lazy chunks instead of the entry bundle.