### PR TITLE
ci: exclude SVG files from Biome checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["**", "!dist", "!build", "!node_modules"]
+		"includes": ["**", "!dist", "!build", "!node_modules", "!**/*.svg"]
 	},
 	"formatter": {
 		"enabled": true,


### PR DESCRIPTION
Biome 2.5.0 attempts to parse .svg files as markup and fails on the XML prolog (e.g. packages/assets discord.svg, paseoInline.svg). Exclude *.svg from the root biome.json includes so `pnpm check` passes.