### PR TITLE
feat: Lazy load date formats

### DIFF
--- a/packages/app/src/canvas/Pool/Overview/Performance/ActiveGraph.tsx
+++ b/packages/app/src/canvas/Pool/Overview/Performance/ActiveGraph.tsx
@@ -4,7 +4,7 @@
 import { planckToUnit } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useRewards } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -29,6 +29,7 @@ export const ActiveGraph = ({
 	const { i18n, t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
 	const { unit } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const {
 		data: { allRewards },
 		loading,
@@ -58,7 +59,7 @@ export const ActiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('date', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/Pool/Overview/Performance/InactiveGraph.tsx
+++ b/packages/app/src/canvas/Pool/Overview/Performance/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { PayoutLine } from 'ui-graphs'
 
@@ -19,6 +19,7 @@ export const InactiveGraph = ({
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
 	const { unit } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	return (
 		<PayoutLine
@@ -28,7 +29,7 @@ export const InactiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('era', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/EraPoints/ActiveGraph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useValidatorEraPoints } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -24,6 +24,7 @@ export const ActiveGraph = ({
 }: Props) => {
 	const { i18n, t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const { data, loading, error } = useValidatorEraPoints({
 		network,
 		validator,
@@ -40,7 +41,7 @@ export const ActiveGraph = ({
 			width={width}
 			height={height}
 			getThemeValue={getThemeValue}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale]?.dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				date: t('date', { ns: 'app' }),
 				era: t('era', { ns: 'app' }),

--- a/packages/app/src/canvas/ValidatorMetrics/EraPoints/InactiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/EraPoints/InactiveGraph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useTranslation } from 'react-i18next'
 import { EraPointsLine } from 'ui-graphs'
 
@@ -15,6 +15,7 @@ export const InactiveGraph = ({
 }) => {
 	const { i18n, t } = useTranslation()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	return (
 		<EraPointsLine
@@ -23,7 +24,7 @@ export const InactiveGraph = ({
 			width={width}
 			height={height}
 			getThemeValue={getThemeValue}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale]?.dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				date: t('date', { ns: 'app' }),
 				era: t('era', { ns: 'app' }),

--- a/packages/app/src/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/Rewards/ActiveGraph.tsx
@@ -4,7 +4,7 @@
 import { planckToUnit } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
-import { DefaultLocale, locales } from 'locales'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useValidatorRewards } from 'plugin-staking-api'
 import { useTranslation } from 'react-i18next'
 import type { NetworkId } from 'types'
@@ -32,6 +32,7 @@ export const ActiveGraph = ({
 		fromEra,
 	})
 	const { units, unit } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	const list =
 		loading || error
@@ -52,7 +53,7 @@ export const ActiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('date', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/canvas/ValidatorMetrics/Rewards/InactiveGraph.tsx
+++ b/packages/app/src/canvas/ValidatorMetrics/Rewards/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { PayoutLine } from 'ui-graphs'
 
@@ -19,6 +19,7 @@ export const InactiveGraph = ({
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
 	const { unit } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	return (
 		<PayoutLine
@@ -28,7 +29,7 @@ export const InactiveGraph = ({
 			height={height}
 			getThemeValue={getThemeValue}
 			unit={unit}
-			dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+			dateFormat={dateFormat}
 			labels={{
 				era: t('era', { ns: 'app' }),
 				reward: t('reward', { ns: 'modals' }),

--- a/packages/app/src/hooks/useDateFormat/index.tsx
+++ b/packages/app/src/hooks/useDateFormat/index.tsx
@@ -1,0 +1,30 @@
+// Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { Locale } from 'date-fns'
+import { DefaultLocale, getLoadedDateFormat, loadDateFormat } from 'locales'
+import { useEffect, useState } from 'react'
+
+export const useDateFormat = (lng?: string): Locale => {
+	const language = lng ?? DefaultLocale
+	const [dateFormat, setDateFormat] = useState<Locale>(() =>
+		getLoadedDateFormat(language),
+	)
+
+	useEffect(() => {
+		let mounted = true
+
+		setDateFormat(getLoadedDateFormat(language))
+		loadDateFormat(language).then((loadedDateFormat) => {
+			if (mounted) {
+				setDateFormat(loadedDateFormat)
+			}
+		})
+
+		return () => {
+			mounted = false
+		}
+	}, [language])
+
+	return dateFormat
+}

--- a/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/ActiveGraph.tsx
@@ -7,8 +7,8 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useApi } from 'hooks/useApi'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import {
 	usePoolEraRewards,
 	usePoolRewards,
@@ -42,6 +42,7 @@ export const ActiveGraph = ({
 	const { getThemeValue } = useThemeValues()
 	const { activeAddress } = useActiveAccount()
 	const { unit, units } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	const { data: nominatorRewardData, loading: rewardsLoading } = useRewards({
 		network,
@@ -108,7 +109,7 @@ export const ActiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Overview/Payouts/InactiveGraph.tsx
+++ b/packages/app/src/pages/Overview/Payouts/InactiveGraph.tsx
@@ -3,8 +3,8 @@
 
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import type { NominatorReward } from 'plugin-staking-api/types'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,6 +18,7 @@ export const InactiveGraph = ({
 	const { i18n, t } = useTranslation()
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const { unit, units } = getStakingChainData(network)
 
 	useEffect(() => {
@@ -36,7 +37,7 @@ export const InactiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Overview/Payouts/index.tsx
+++ b/packages/app/src/pages/Overview/Payouts/index.tsx
@@ -8,6 +8,7 @@ import { getStakingChainData } from 'consts/util'
 import { formatDistance, fromUnixTime, getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useCurrency } from 'hooks/useCurrency'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
@@ -15,7 +16,6 @@ import { useSyncing } from 'hooks/useSyncing'
 import { useUi } from 'hooks/useUi'
 import { Balance } from 'library/Balance'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import type { RewardResult } from 'plugin-staking-api/types'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,6 +34,7 @@ export const Payouts = () => {
 	const { currency } = useCurrency()
 	const { isBonding } = useStaking()
 	const { pluginEnabled } = usePlugins()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	const { units } = getStakingChainData(network)
 	const Token = getChainIcons(network).token
@@ -61,10 +62,10 @@ export const Payouts = () => {
 			formatTo: now,
 			formatOpts: {
 				addSuffix: true,
-				locale: locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
+				locale: dateFormat,
 			},
 		}
-	}, [lastReward, i18n.resolvedLanguage])
+	}, [lastReward, dateFormat])
 
 	const lastRewardUnit = planckToUnitBn(
 		new BigNumber(lastReward?.reward || 0),

--- a/packages/app/src/pages/Pools/PoolShares/index.tsx
+++ b/packages/app/src/pages/Pools/PoolShares/index.tsx
@@ -12,13 +12,13 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { getUnixTime } from 'date-fns'
 import { useActivePool } from 'hooks/useActivePool'
 import { useCurrency } from 'hooks/useCurrency'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
 import { useSyncing } from 'hooks/useSyncing'
 import { Balance } from 'library/Balance'
 import { CardWrapper } from 'library/Card/Wrappers'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import { fetchCombinedPoolRewards, isPoolShareReward } from 'plugin-staking-api'
 import type { CombinedPoolReward } from 'plugin-staking-api/types'
 import { useEffect, useMemo, useState } from 'react'
@@ -137,7 +137,7 @@ export const PoolShares = () => {
 		}
 	}, [graphActive, network, activeAddress, fromTimestamp])
 
-	const dateFormat = locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const graphHeight = '175px'
 	const graphLabels = {
 		poolShares: t('share', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/ActiveGraph.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/ActiveGraph.tsx
@@ -5,8 +5,8 @@ import { useActiveAccount } from '@polkadot-cloud/connect'
 import { MaxPayoutDays } from 'consts'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import type { PayoutHistoryProps } from 'pages/Rewards/types'
 import { useTranslation } from 'react-i18next'
 import { AveragePayoutLine, PayoutBar } from 'ui-graphs'
@@ -30,6 +30,7 @@ export const ActiveGraph = ({
 	const { activeAddress } = useActiveAccount()
 	const { getThemeValue } = useThemeValues()
 	const { unit, units } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	return (
 		<>
@@ -43,7 +44,7 @@ export const ActiveGraph = ({
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/InactiveGraph.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/InactiveGraph.tsx
@@ -4,8 +4,8 @@
 import { MaxPayoutDays } from 'consts'
 import { getStakingChainData } from 'consts/util'
 import { useThemeValues } from 'contexts/ThemeValues'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
-import { DefaultLocale, locales } from 'locales'
 import { useTranslation } from 'react-i18next'
 import { AveragePayoutLine, PayoutBar } from 'ui-graphs'
 
@@ -14,6 +14,7 @@ export const InactiveGraph = () => {
 	const { network } = useNetwork()
 	const { getThemeValue } = useThemeValues()
 	const { unit, units } = getStakingChainData(network)
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
 	return (
 		<>
@@ -27,7 +28,7 @@ export const InactiveGraph = () => {
 				getThemeValue={getThemeValue}
 				unit={unit}
 				units={units}
-				dateFormat={locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat}
+				dateFormat={dateFormat}
 				labels={{
 					payout: t('payouts', { ns: 'app' }),
 					poolClaim: t('poolClaim', { ns: 'app' }),

--- a/packages/app/src/pages/Rewards/Overview/PayoutGraph/index.tsx
+++ b/packages/app/src/pages/Rewards/Overview/PayoutGraph/index.tsx
@@ -3,12 +3,12 @@
 
 import { useSize } from '@w3ux/hooks'
 import { useActivePool } from 'hooks/useActivePool'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
 import { useSyncing } from 'hooks/useSyncing'
 import { useUi } from 'hooks/useUi'
 import { StatusLabel } from 'library/StatusLabel'
-import { DefaultLocale, locales } from 'locales'
 import type { PayoutHistoryProps } from 'pages/Rewards/types'
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -31,15 +31,10 @@ export const RecentPayouts = ({
 	const { inPool } = useActivePool()
 	const { isBonding } = useStaking()
 	const { pluginEnabled } = usePlugins()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 
-	const payoutsFromDate = getPayoutsFromDate(
-		payoutsList,
-		locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
-	)
-	const payoutsToDate = getPayoutsToDate(
-		payoutsList,
-		locales[i18n.resolvedLanguage ?? DefaultLocale].dateFormat,
-	)
+	const payoutsFromDate = getPayoutsFromDate(payoutsList, dateFormat)
+	const payoutsToDate = getPayoutsToDate(payoutsList, dateFormat)
 	const staking = isBonding || inPool
 	const notStaking = !syncing && !staking
 

--- a/packages/app/src/pages/Rewards/PayoutList/Inner.tsx
+++ b/packages/app/src/pages/Rewards/PayoutList/Inner.tsx
@@ -12,13 +12,13 @@ import { useThemeValues } from 'contexts/ThemeValues'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { formatDistance, fromUnixTime } from 'date-fns'
 import { useApi } from 'hooks/useApi'
+import { useDateFormat } from 'hooks/useDateFormat'
 import { useNetwork } from 'hooks/useNetwork'
 import { Header, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer } from 'library/List/MotionContainer'
 import { Pagination } from 'library/List/Pagination'
 import { Identity } from 'library/ListItem/Labels/Identity'
 import { PoolIdentity } from 'library/ListItem/Labels/PoolIdentity'
-import { DefaultLocale, locales } from 'locales'
 import { motion } from 'motion/react'
 import { isPoolReward, isPoolShareReward } from 'plugin-staking-api'
 import type {
@@ -49,6 +49,7 @@ export const PayoutList = ({
 	const { bondedPools } = useBondedPools()
 	const { getValidators } = useValidators()
 	const { getThemeValue } = useThemeValues()
+	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const {
 		listFormat,
 		setListFormat,
@@ -238,10 +239,7 @@ export const PayoutList = ({
 																new Date(),
 																{
 																	addSuffix: true,
-																	locale:
-																		locales[
-																			i18n.resolvedLanguage ?? DefaultLocale
-																		].dateFormat,
+																	locale: dateFormat,
 																},
 															)}
 														</h5>

--- a/packages/locales/src/config.ts
+++ b/packages/locales/src/config.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { localeDefinitions } from 'consts/locales'
-import { de, enGB, es, ko, type Locale, ptBR, tr, zhCN } from 'date-fns/locale'
+import type { Locale } from 'date-fns'
+import { enGB } from 'date-fns/locale/en-GB'
 import appEn from './resources/en/app.json'
 import helpEn from './resources/en/help.json'
 import modalsEn from './resources/en/modals.json'
@@ -13,31 +14,48 @@ import type { LocaleEntry } from './types'
 // The default locale
 export const DefaultLocale = 'en'
 
-// Date formats for each locale
-const dateFormats: Record<string, Locale> = {
-	en: enGB,
-	de: de,
-	ko: ko,
-	pt: ptBR,
-	tr: tr,
-	zh: zhCN,
-	es: es,
-}
+type LocaleKey = keyof typeof localeDefinitions
 
 // Available locales as key value pairs
-export const locales: Record<string, LocaleEntry> = Object.entries(
-	localeDefinitions,
-).reduce(
-	(acc, [key, value]) => {
-		const dateFormat = dateFormats[key]
-		if (!dateFormat) {
-			throw new Error(`Missing date format for locale: ${key}`)
-		}
-		acc[key] = { ...value, dateFormat }
-		return acc
-	},
-	{} as Record<string, LocaleEntry>,
-)
+export const locales: Record<string, LocaleEntry> = localeDefinitions
+
+// Map app locale codes to date-fns locale loaders so non-default formats stay code-split.
+const dateFormatLoaders = {
+	en: async () => enGB,
+	de: () => import('date-fns/locale/de').then(({ de }) => de),
+	ko: () => import('date-fns/locale/ko').then(({ ko }) => ko),
+	pt: () => import('date-fns/locale/pt-BR').then(({ ptBR }) => ptBR),
+	tr: () => import('date-fns/locale/tr').then(({ tr }) => tr),
+	zh: () => import('date-fns/locale/zh-CN').then(({ zhCN }) => zhCN),
+	es: () => import('date-fns/locale/es').then(({ es }) => es),
+} satisfies Record<LocaleKey, () => Promise<Locale>>
+
+// Keep the default date format synchronously available and cache lazy-loaded formats.
+const dateFormatCache: Partial<Record<LocaleKey, Locale>> = {
+	en: enGB,
+}
+
+const isLocaleKey = (lng: string): lng is LocaleKey => lng in dateFormatLoaders
+
+// Normalize runtime language strings before cache or loader lookups.
+const getDateFormatKey = (lng: string): LocaleKey =>
+	isLocaleKey(lng) ? lng : DefaultLocale
+
+// Return an already-loaded date format, falling back to the default while lazy formats load.
+export const getLoadedDateFormat = (lng: string): Locale =>
+	dateFormatCache[getDateFormatKey(lng)] ?? enGB
+
+// Load and cache the requested date-fns locale only when it is needed.
+export const loadDateFormat = async (lng: string): Promise<Locale> => {
+	const key = getDateFormatKey(lng)
+	const cachedDateFormat = dateFormatCache[key]
+	if (cachedDateFormat) {
+		return cachedDateFormat
+	}
+	const dateFormat = await dateFormatLoaders[key]()
+	dateFormatCache[key] = dateFormat
+	return dateFormat
+}
 
 // Supported namespaces
 export const lngNamespaces: string[] = [

--- a/packages/locales/src/config.ts
+++ b/packages/locales/src/config.ts
@@ -52,9 +52,13 @@ export const loadDateFormat = async (lng: string): Promise<Locale> => {
 	if (cachedDateFormat) {
 		return cachedDateFormat
 	}
-	const dateFormat = await dateFormatLoaders[key]()
-	dateFormatCache[key] = dateFormat
-	return dateFormat
+	try {
+		const dateFormat = await dateFormatLoaders[key]()
+		dateFormatCache[key] = dateFormat
+		return dateFormat
+	} catch {
+		return enGB
+	}
 }
 
 // Supported namespaces

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -8,7 +8,9 @@ import { DefaultLocale } from './config'
 export {
 	DefaultLocale,
 	fallbackResources,
+	getLoadedDateFormat,
 	lngNamespaces,
+	loadDateFormat,
 	locales,
 } from './config'
 

--- a/packages/locales/src/types.ts
+++ b/packages/locales/src/types.ts
@@ -1,8 +1,6 @@
 // Copyright 2026 @polkadot-cloud/polkadot-staking-dashboard authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { Locale } from 'date-fns'
-
 export interface LocaleJson {
 	[key: string]:
 		| string
@@ -22,6 +20,5 @@ export type LocaleJsonValue =
 	| LocaleJson[]
 
 export interface LocaleEntry {
-	dateFormat: Locale
 	label: string
 }


### PR DESCRIPTION
Re-implements https://github.com/polkadot-cloud/polkadot-staking-dashboard/pull/3574 but with some small API design changes. Also synchronously loads `enGB` date format by default to prevent a window of no assigned date format.