### PR TITLE
feat(fix): Trim whitespace from pasted addresses in account input

### DIFF
--- a/packages/app/src/library/AccountInput/index.tsx
+++ b/packages/app/src/library/AccountInput/index.tsx
@@ -51,8 +51,6 @@ export const AccountInput = ({
 	const [successLock, setSuccessLocked] = useState<boolean>(locked)
 
 	const handleChange = (e: FormEvent<HTMLInputElement>) => {
-		// Trim surrounding whitespace so addresses pasted from an explorer/wallet
-		// (which often carry a leading/trailing space) still validate and import.
 		const newValue = e.currentTarget.value.trim()
 		// set value on key change
 		setValue(newValue)

--- a/packages/app/src/library/AccountInput/index.tsx
+++ b/packages/app/src/library/AccountInput/index.tsx
@@ -51,7 +51,9 @@ export const AccountInput = ({
 	const [successLock, setSuccessLocked] = useState<boolean>(locked)
 
 	const handleChange = (e: FormEvent<HTMLInputElement>) => {
-		const newValue = e.currentTarget.value
+		// Trim surrounding whitespace so addresses pasted from an explorer/wallet
+		// (which often carry a leading/trailing space) still validate and import.
+		const newValue = e.currentTarget.value.trim()
 		// set value on key change
 		setValue(newValue)
 


### PR DESCRIPTION
Pasting an SS58 address copied from a block explorer or wallet often carries a leading or trailing space. `AccountInput.handleChange` stored the raw value and ran `isValidAddress` on it, so the field showed "Invalid" and the Import button stayed disabled even though the address was correct, with no visible clue that an invisible space was the cause.