### PR TITLE
chore: update bond duration

### DIFF
--- a/packages/app-staking/src/canvas/PoolMembers/Prompts/UnbondMember.tsx
+++ b/packages/app-staking/src/canvas/PoolMembers/Prompts/UnbondMember.tsx
@@ -43,12 +43,14 @@ export const UnbondMember = ({
 	const { activeAddress, activeAccount } = useActiveAccount()
 
 	const { points } = member
-	const { bondDuration } = getConsts(network)
+	const { bondDuration, nominatorFastUnbondDuration } = getConsts(network)
+	const unbondDuration =
+		network === 'polkadot' ? nominatorFastUnbondDuration : bondDuration
 	const freeToUnbond = planckToUnitBn(new BigNumber(points), units)
 	const bondDurationFormatted = timeleftAsString(
 		t,
 		getUnixTime(new Date()) + 1,
-		erasToSeconds(bondDuration),
+		erasToSeconds(unbondDuration),
 		true,
 	)
 
@@ -103,7 +105,7 @@ export const UnbondMember = ({
 						value={bondDurationFormatted}
 						tKey="onceUnbondingPoolMember"
 						valueKey="bondDurationFormatted"
-						deps={[bondDuration]}
+						deps={[unbondDuration]}
 					/>
 				</Notes>
 			</Padding>

--- a/packages/app-staking/src/canvas/PoolMembers/Prompts/UnbondMember.tsx
+++ b/packages/app-staking/src/canvas/PoolMembers/Prompts/UnbondMember.tsx
@@ -43,14 +43,12 @@ export const UnbondMember = ({
 	const { activeAddress, activeAccount } = useActiveAccount()
 
 	const { points } = member
-	const { bondDuration, nominatorFastUnbondDuration } = getConsts(network)
-	const unbondDuration =
-		network === 'polkadot' ? nominatorFastUnbondDuration : bondDuration
+	const { bondDuration } = getConsts(network)
 	const freeToUnbond = planckToUnitBn(new BigNumber(points), units)
 	const bondDurationFormatted = timeleftAsString(
 		t,
 		getUnixTime(new Date()) + 1,
-		erasToSeconds(unbondDuration),
+		erasToSeconds(bondDuration),
 		true,
 	)
 
@@ -105,7 +103,7 @@ export const UnbondMember = ({
 						value={bondDurationFormatted}
 						tKey="onceUnbondingPoolMember"
 						valueKey="bondDurationFormatted"
-						deps={[unbondDuration]}
+						deps={[bondDuration]}
 					/>
 				</Notes>
 			</Padding>

--- a/packages/app-staking/src/modals/UnlockChunks/Chunk.tsx
+++ b/packages/app-staking/src/modals/UnlockChunks/Chunk.tsx
@@ -48,7 +48,7 @@ export const Chunk = ({ chunk, bondFor, onRebond }: ChunkProps) => {
 	const formatted = formatTimeleft(t, timeleft.raw)
 
 	// Calculate unbonding progress percentage. Adapts dynamically to bond
-	// duration from chain constants (works for both 28-day and 1-day unbonding).
+	// duration from chain constants.
 	const isUnlocked = left.isLessThanOrEqualTo(0)
 	const startEra = era - bondDuration
 	const erasCompleted = activeEra.index - startEra

--- a/packages/dedot-api/src/consts/staking.ts
+++ b/packages/dedot-api/src/consts/staking.ts
@@ -7,6 +7,7 @@ import type { StakingChain } from '../types'
 
 export class StakingConsts<T extends StakingChain> {
 	bondDuration: number
+	nominatorFastUnbondDuration: number
 	sessionsPerEra: number
 	maxExposurePageSize: number
 	historyDepth: number
@@ -19,6 +20,8 @@ export class StakingConsts<T extends StakingChain> {
 
 	fetch() {
 		this.bondDuration = this.api.consts.staking.bondingDuration
+		this.nominatorFastUnbondDuration =
+			this.api.consts.staking.nominatorFastUnbondDuration
 		this.sessionsPerEra = this.api.consts.staking.sessionsPerEra
 		this.maxExposurePageSize = this.api.consts.staking.maxExposurePageSize
 		this.historyDepth = this.api.consts.staking.historyDepth
@@ -28,6 +31,7 @@ export class StakingConsts<T extends StakingChain> {
 	get() {
 		return {
 			bondDuration: this.bondDuration,
+			nominatorFastUnbondDuration: this.nominatorFastUnbondDuration,
 			sessionsPerEra: this.sessionsPerEra,
 			maxExposurePageSize: this.maxExposurePageSize,
 			historyDepth: this.historyDepth,

--- a/packages/global-bus/src/consts/default.ts
+++ b/packages/global-bus/src/consts/default.ts
@@ -5,6 +5,7 @@ import type { ChainConsts } from 'types'
 
 export const defaultConsts: ChainConsts = {
 	bondDuration: 0,
+	nominatorFastUnbondDuration: 0,
 	sessionsPerEra: 0,
 	maxExposurePageSize: 0,
 	historyDepth: 0,

--- a/packages/hooks/src/useApi/index.ts
+++ b/packages/hooks/src/useApi/index.ts
@@ -117,7 +117,17 @@ export const useApi = (): ApiHookInterface => {
 		[chainSpecs],
 	)
 	const getConsts = useCallback(
-		(chain: ChainId): ChainConsts => consts[chain] || defaultConsts,
+		(chain: ChainId): ChainConsts => {
+			const chainConsts = consts[chain] || defaultConsts
+			if (chain !== 'polkadot') {
+				return chainConsts
+			}
+
+			return {
+				...chainConsts,
+				bondDuration: chainConsts.nominatorFastUnbondDuration,
+			}
+		},
 		[consts],
 	)
 	const getRpcEndpoint = useCallback((chain: ChainId): string => {

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -58,6 +58,7 @@ export interface ChainSpecVersion {
 
 export interface ChainConsts {
 	bondDuration: number
+	nominatorFastUnbondDuration: number
 	sessionsPerEra: number
 	maxExposurePageSize: number
 	historyDepth: number


### PR DESCRIPTION
Updates staking chain constants to include `nominatorFastUnbondDuration` and uses it to adjust the effective `bondDuration` returned by `useApi` for Polkadot, aligning UI timing calculations with the intended unbonding duration behavior.

**Changes:**
- Extend `ChainConsts` with `nominatorFastUnbondDuration` and propagate it through defaults.
- Fetch and expose `staking.nominatorFastUnbondDuration` from the Dedot API constants layer.
- Adjust `useApi.getConsts` to override Polkadot’s `bondDuration` with `nominatorFastUnbondDuration`.
