### PR TITLE
feat(refactor): Support production pool candidates

### DIFF
--- a/packages/app-staking/src/canvas/Pool/index.tsx
+++ b/packages/app-staking/src/canvas/Pool/index.tsx
@@ -53,7 +53,10 @@ export const Pool = () => {
 	// pools
 	const getPoolCandidates = async () => {
 		if (pluginEnabled('staking_api')) {
-			const { poolCandidates } = await fetchPoolCandidates(network)
+			const { poolCandidates } = await fetchPoolCandidates(
+				network,
+				import.meta.env.PROD,
+			)
 			return poolCandidates
 		} else {
 			return bondedPools

--- a/packages/app-staking/src/hooks/useFetchMethods/index.tsx
+++ b/packages/app-staking/src/hooks/useFetchMethods/index.tsx
@@ -65,6 +65,7 @@ export const useFetchMethods = () => {
 		return favs
 	}
 
+	// TODO: Remove low commission (all commission now 0%).
 	const fetchLowCommission = () => {
 		let filtered = [...getValidators()]
 

--- a/packages/plugin-staking-api/src/queries/poolCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/poolCandidates.ts
@@ -6,8 +6,8 @@ import type { PoolCandidatesData } from '../types'
 import { fetchQuery } from './generic'
 
 const QUERY = gql`
-  query PoolCandidates($network: String!) {
-    poolCandidates(network: $network)
+  query PoolCandidates($network: String!, $production: Boolean = false) {
+    poolCandidates(network: $network, production: $production)
   }
 `
 
@@ -15,5 +15,5 @@ const DEFAULT: PoolCandidatesData = {
 	poolCandidates: [],
 }
 
-export const fetchPoolCandidates = (network: string) =>
-	fetchQuery<PoolCandidatesData>(QUERY, { network }, DEFAULT)
+export const fetchPoolCandidates = (network: string, production = false) =>
+	fetchQuery<PoolCandidatesData>(QUERY, { network, production }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/poolCandidates.ts
@@ -6,8 +6,8 @@ import type { PoolCandidatesData } from '../types'
 import { fetchQuery } from './generic'
 
 const QUERY = gql`
-  query PoolCandidates($network: String!, $production: Boolean = false) {
-    poolCandidates(network: $network, production: $production)
+  query PoolCandidates($network: String!, $knownOnly: Boolean = false) {
+    poolCandidates(network: $network, knownOnly: $knownOnly)
   }
 `
 
@@ -15,5 +15,5 @@ const DEFAULT: PoolCandidatesData = {
 	poolCandidates: [],
 }
 
-export const fetchPoolCandidates = (network: string, production = false) =>
-	fetchQuery<PoolCandidatesData>(QUERY, { network, production }, DEFAULT)
+export const fetchPoolCandidates = (network: string, knownOnly = false) =>
+	fetchQuery<PoolCandidatesData>(QUERY, { network, knownOnly }, DEFAULT)

--- a/packages/plugin-staking-api/src/queries/poolCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/poolCandidates.ts
@@ -6,7 +6,7 @@ import type { PoolCandidatesData } from '../types'
 import { fetchQuery } from './generic'
 
 const QUERY = gql`
-  query PoolCandidates($network: String!, $knownOnly: Boolean = false) {
+  query PoolCandidates($network: String!, $knownOnly: Boolean!) {
     poolCandidates(network: $network, knownOnly: $knownOnly)
   }
 `
@@ -15,5 +15,5 @@ const DEFAULT: PoolCandidatesData = {
 	poolCandidates: [],
 }
 
-export const fetchPoolCandidates = (network: string, knownOnly = false) =>
+export const fetchPoolCandidates = (network: string, knownOnly: boolean) =>
 	fetchQuery<PoolCandidatesData>(QUERY, { network, knownOnly }, DEFAULT)


### PR DESCRIPTION
Adds support for fetching “knownOnly” pool candidates by extending the staking API GraphQL query and wiring the production flag through the app’s pool-candidates fetch path.

**Changes:**
- Extend `PoolCandidates` GraphQL query to accept a `knownOnly` boolean variable and pass it to `poolCandidates(...)`.
- Update `fetchPoolCandidates` to accept an optional `knownOnly` parameter and include it in query variables.
- Update the staking app’s Pool canvas to request candidates with `import.meta.env.PROD`.
