### PR TITLE
feat(ux): Show reward trend demo when no active pool

### DIFF
--- a/packages/app-staking/src/pages/Pools/Overview.tsx
+++ b/packages/app-staking/src/pages/Pools/Overview.tsx
@@ -43,9 +43,9 @@ export const PoolOverview = ({
 					/>
 				</Page.RowSection>
 			</Page.Row>
+			{network === 'polkadot' && <PoolShares />}
 			{activePool !== undefined && (
 				<>
-					{network === 'polkadot' && <PoolShares />}
 					<ManagePool />
 					<Page.Row>
 						<CardWrapper>

--- a/packages/app-staking/src/pages/Pools/PoolShares/index.tsx
+++ b/packages/app-staking/src/pages/Pools/PoolShares/index.tsx
@@ -182,9 +182,14 @@ export const PoolShares = () => {
 					{poolShareUnavailable ? (
 						<>
 							<StatusLabel
+								hideIcon={!activePool}
 								backgroundOpacity={0.95}
 								status="pool_share_unavailable"
-								title={t('availableForPolkadotCloudPoolsOnly')}
+								title={t(
+									activePool
+										? 'availableForPolkadotCloudPoolsOnly'
+										: 'joinPolkadotCloudPoolToSeeRewardTrends',
+								)}
 								topOffset="38%"
 							/>
 							<PoolSharesDemoGraph

--- a/packages/locales/src/resources/de/pages.json
+++ b/packages/locales/src/resources/de/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "Inaktive Nominierungen",
 		"inactivePoolNotNominating": "Inaktiv: Pool nominiert nicht",
 		"joinAnotherPool": "Einem anderen Pool beitreten",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Tritt einem Polkadot Cloud-Pool bei, um Belohnungstrends zu sehen",
 		"joinPool": "Pool beitreten",
 		"joinPoolHeading": "Tritt {{totalMembers}} Pool-Mitgliedern bei, die insgesamt {{totalPoolPoints}} {{unit}} auf {{network}} staken.",
 		"last30DayReward": "Belohnung der letzten 30 Tage",

--- a/packages/locales/src/resources/en/pages.json
+++ b/packages/locales/src/resources/en/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "Inactive Nominations",
 		"inactivePoolNotNominating": "Inactive: Pool Not Nominating",
 		"joinAnotherPool": "Join Another Pool",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Join a Polkadot Cloud Pool to see Reward Trends",
 		"joinPool": "Join Pool",
 		"joinPoolHeading": "Join {{totalMembers}} pool members staking a total of {{totalPoolPoints}} {{unit}} on {{network}}.",
 		"last30DayReward": "Last 30 Days Reward",

--- a/packages/locales/src/resources/es/pages.json
+++ b/packages/locales/src/resources/es/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "Nominaciones inactivas",
 		"inactivePoolNotNominating": "Inactivo: Pool no está nominando",
 		"joinAnotherPool": "Unirse a Otro Pool",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Únete a un pool de Polkadot Cloud para ver las tendencias de recompensas",
 		"joinPool": "Unirse al Pool",
 		"joinPoolHeading": "Únete a {{totalMembers}} miembros del Pool haciendo staking de un total de {{totalPoolPoints}} {{unit}} en {{network}}.",
 		"last30DayReward": "Recompensa de los últimos 30 días",

--- a/packages/locales/src/resources/fr/pages.json
+++ b/packages/locales/src/resources/fr/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "Nominations inactives",
 		"inactivePoolNotNominating": "Inactif : le pool ne nomine pas",
 		"joinAnotherPool": "Rejoindre un autre pool",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Rejoignez un pool Polkadot Cloud pour voir les tendances des récompenses",
 		"joinPool": "Rejoindre le pool",
 		"joinPoolHeading": "Rejoignez {{totalMembers}} membres du pool qui stakent un total de {{totalPoolPoints}} {{unit}} sur {{network}}.",
 		"last30DayReward": "Récompense des 30 derniers jours",

--- a/packages/locales/src/resources/ko/pages.json
+++ b/packages/locales/src/resources/ko/pages.json
@@ -75,6 +75,7 @@
 		"inactiveNominations": "비활성 지명",
 		"inactivePoolNotNominating": "비활성: 풀이 지명하지 않음",
 		"joinAnotherPool": "다른 풀에 가입",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "보상 추이를 확인하려면 Polkadot Cloud 풀에 가입하세요",
 		"joinPool": "풀에 가입",
 		"joinPoolHeading": "{{network}}에서 총 {{totalPoolPoints}} {{unit}}을 스테이킹하는 {{totalMembers}}명의 풀 회원에게 가입하세요.",
 		"last30DayReward": "지난 30일 보상",

--- a/packages/locales/src/resources/pt/pages.json
+++ b/packages/locales/src/resources/pt/pages.json
@@ -75,6 +75,7 @@
 		"inactiveNominations": "Nomeações Inativas",
 		"inactivePoolNotNominating": "Inativo: Pool Não Está Nomeando",
 		"joinAnotherPool": "Entrar em Outro Pool",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Entre em um pool do Polkadot Cloud para ver as tendências de recompensas",
 		"joinPool": "Entrar no Pool",
 		"joinPoolHeading": "Junte-se a {{totalMembers}} membros do pool fazendo staking de um total de {{totalPoolPoints}} {{unit}} em {{network}}.",
 		"last30DayReward": "Recompensa dos Últimos 30 Dias",

--- a/packages/locales/src/resources/tr/pages.json
+++ b/packages/locales/src/resources/tr/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "Pasif Nominasyonlar",
 		"inactivePoolNotNominating": "Pasif: Havuz Nominasyon Yapmıyor",
 		"joinAnotherPool": "Başka Bir Havuza Katıl",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "Ödül trendlerini görmek için bir Polkadot Cloud havuzuna katılın",
 		"joinPool": "Havuza Katıl",
 		"joinPoolHeading": "{{network}} üzerinde toplam {{totalPoolPoints}} {{unit}} stake eden {{totalMembers}} havuz üyesine katılın.",
 		"last30DayReward": "Son 30 Günlük Ödül",

--- a/packages/locales/src/resources/zh/pages.json
+++ b/packages/locales/src/resources/zh/pages.json
@@ -73,6 +73,7 @@
 		"inactiveNominations": "非活跃提名人",
 		"inactivePoolNotNominating": "非活跃：提名池未提名任何验证人",
 		"joinAnotherPool": "加入另一个提名池",
+		"joinPolkadotCloudPoolToSeeRewardTrends": "加入 Polkadot Cloud 池以查看奖励趋势",
 		"joinPool": "加入提名池",
 		"joinPoolHeading": " {{totalMembers}} 个提名池成员在{{network}}上抵押共{{totalPoolPoints}} 个{{unit}} ",
 		"last30DayReward": "过去30天的奖励",


### PR DESCRIPTION
Adds a clearer “reward trends” empty-state for users who don’t currently have an active pool (Polkadot-only), by ensuring the PoolShares section still renders and shows an appropriate prompt plus localized copy.

**Changes:**
- Render `PoolShares` on Polkadot even when `activePool` is not set (so the section can show a demo/empty state).
- Update `PoolShares` unavailable-state label to switch messaging based on whether an active pool exists, and hide the warning icon when there is no active pool.
- Add the new localization key `joinPolkadotCloudPoolToSeeRewardTrends` across supported locales.
