### PR TITLE
feat(refactor): Amend consts config, abstract rpc endpoints

### DIFF
--- a/packages/app-staking/src/Providers.tsx
+++ b/packages/app-staking/src/Providers.tsx
@@ -6,7 +6,7 @@ import { ConnectProvider } from '@polkadot-cloud/connect'
 import { LedgerAdaptor } from '@polkadot-cloud/connect-ledger'
 import { createProxiesAdaptor } from '@polkadot-cloud/connect-proxies'
 import { withProviders } from '@w3ux/factories'
-import { DappName } from 'consts'
+import { StakingDappName } from 'consts'
 import { getStakingChainData } from 'consts/util'
 import { EraStakersProvider } from 'contexts/EraStakers'
 import { FiltersProvider } from 'contexts/Filters'
@@ -30,7 +30,7 @@ export const Providers = () => {
 				ConnectProvider,
 				{
 					network,
-					dappName: DappName,
+					dappName: StakingDappName,
 					ss58,
 					adaptors: [LedgerAdaptor, createProxiesAdaptor(network)],
 				},

--- a/packages/app-staking/src/hooks/useSubmitExtrinsic/index.tsx
+++ b/packages/app-staking/src/hooks/useSubmitExtrinsic/index.tsx
@@ -13,7 +13,7 @@ import {
 	type VaultSignStatus,
 } from '@polkadot-cloud/connect-vault'
 import type { HardwareAccount } from '@w3ux/types'
-import { DappName, ManualSigners } from 'consts'
+import { ManualSigners, StakingDappName } from 'consts'
 import { TxErrorKeyMap } from 'consts/tx'
 import { getStakingChainData } from 'consts/util'
 import { compactU32 } from 'dedot/shape'
@@ -149,7 +149,7 @@ export const useSubmitExtrinsic = ({
 				throw new Error(`${t('walletNotFound')}`)
 			}
 			// NOTE: Summons extension popup if not already connected
-			window.injectedWeb3[source].enable(DappName)
+			window.injectedWeb3[source].enable(StakingDappName)
 		}
 
 		// Pre-submission state update

--- a/packages/app-staking/src/library/Headers/Popovers/MenuPopover/index.tsx
+++ b/packages/app-staking/src/library/Headers/Popovers/MenuPopover/index.tsx
@@ -25,9 +25,9 @@ import { capitalizeFirstLetter } from '@w3ux/utils'
 import DiscordSVG from 'assets/brands/discord.svg?react'
 import EnvelopeSVG from 'assets/icons/envelope.svg?react'
 import {
-	DappOrganisation,
 	PlatformDocsURL,
 	PlatformGitHubURL,
+	PlatformName,
 	PlatformURL,
 } from 'consts'
 import { getRelayChainData } from 'consts/util/chains'
@@ -262,7 +262,7 @@ export const MenuPopover = ({
 				}}
 			/>
 			<DefaultButton
-				text={DappOrganisation}
+				text={PlatformName}
 				iconLeft={faCloud}
 				iconRight={faExternalLinkAlt}
 				accent

--- a/packages/app-staking/src/library/ListItem/Buttons/ShareLink.tsx
+++ b/packages/app-staking/src/library/ListItem/Buttons/ShareLink.tsx
@@ -3,7 +3,7 @@
 
 import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { ProductionURL } from 'consts'
+import { StakingProductionURL } from 'consts'
 import { emitNotification } from 'global-bus'
 import { useTooltip } from 'hooks/useTooltip'
 import { useTranslation } from 'react-i18next'
@@ -24,7 +24,7 @@ export const ShareLink = ({ paramValue, paramKey }: ShareLinkProps) => {
 	const tooltipText = t('copyShareLink')
 
 	const buildShareUrl = () => {
-		const base = `${ProductionURL}/#/overview`
+		const base = `${StakingProductionURL}/#/overview`
 		return `${base}?${paramKey}=${paramValue}`
 	}
 

--- a/packages/app-staking/src/modals/Invite/index.tsx
+++ b/packages/app-staking/src/modals/Invite/index.tsx
@@ -4,7 +4,7 @@
 import { faEnvelopeOpenText, faList } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActiveAccount } from '@polkadot-cloud/connect'
-import { ProductionURL } from 'consts'
+import { StakingProductionURL } from 'consts'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useBalances } from 'hooks/useBalances'
 import { useNetwork } from 'hooks/useNetwork'
@@ -32,7 +32,7 @@ export const Invite = () => {
 	let faIcon = faEnvelopeOpenText
 
 	if (membership) {
-		toCopy = `${ProductionURL}/#/overview?n=${network}&i=pool&id=${poolId}`
+		toCopy = `${StakingProductionURL}/#/overview?n=${network}&i=pool&id=${poolId}`
 		title = t('copyPoolInviteLink', { ns: 'app' })
 		subtitle = toCopy
 	} else if (nominated.length > 0) {

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -1,15 +1,20 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-// Global Constants
-export const DappName = 'Polkadot Cloud Staking'
-export const DappOrganisation = 'Polkadot Cloud'
-export const PlatformURL = 'https://polkadot.cloud'
-export const ProductionURL = 'https://staking.polkadot.cloud'
+// Staking
+export const StakingDappName = 'Polkadot Cloud Staking'
+export const StakingProductionURL = 'https://staking.polkadot.cloud'
 export const PlatformDocsURL = 'https://docs.staking.polkadot.cloud'
+
+// Stablecoins
+export const StablecoinsDappName = 'Polkadot Cloud Stablecoins'
+
+// Platform
+export const PlatformName = 'Polkadot Cloud'
+export const PlatformURL = 'https://polkadot.cloud'
 export const PlatformPrivacyURL = 'https://polkadot.cloud/privacy'
 export const PlatformDisclaimerURL = 'https://polkadot.cloud/disclaimer'
-export const PlatformSupportEmail = 'staking@polkadot.cloud'
+export const PlatformSupportEmail = 'support@polkadot.cloud'
 export const PlatformGitHubURL =
 	'https://github.com/polkadot-cloud/polkadot-cloud-apps'
 export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -6,9 +6,6 @@ export const StakingDappName = 'Polkadot Cloud Staking'
 export const StakingProductionURL = 'https://staking.polkadot.cloud'
 export const PlatformDocsURL = 'https://docs.staking.polkadot.cloud'
 
-// Stablecoins
-export const StablecoinsDappName = 'Polkadot Cloud Stablecoins'
-
 // Platform
 export const PlatformName = 'Polkadot Cloud'
 export const PlatformURL = 'https://polkadot.cloud'

--- a/packages/consts/src/networks.ts
+++ b/packages/consts/src/networks.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { NetworkId, Networks, SystemChain } from 'types'
+import { RpcEndpointsByChain } from './rpc'
 
 // The default network to use when no network is specified
 export const DefaultNetwork: NetworkId = 'polkadot'
@@ -15,15 +16,7 @@ export const NetworkList: Networks = {
 		name: 'polkadot',
 		endpoints: {
 			getLightClient: async () => await import('@dedot/chain-specs/polkadot'),
-			rpc: {
-				'Automata 1RPC': 'wss://1rpc.io/dot',
-				// Dwellir: 'wss://polkadot-rpc.dwellir.com',
-				// IBP1: 'wss://rpc.ibp.network/polkadot',
-				// IBP2: 'wss://rpc.dotters.network/polkadot',
-				LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
-				OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-				Stakeworld: 'wss://dot-rpc.stakeworld.io',
-			},
+			rpc: RpcEndpointsByChain.polkadot,
 		},
 		unit: 'DOT',
 		units: 10,
@@ -45,15 +38,7 @@ export const NetworkList: Networks = {
 		name: 'kusama',
 		endpoints: {
 			getLightClient: async () => await import('@dedot/chain-specs/ksmcc3'),
-			rpc: {
-				'Automata 1RPC': 'wss://1rpc.io/ksm',
-				// Dwellir: 'wss://kusama-rpc.dwellir.com',
-				// IBP1: 'wss://rpc.ibp.network/kusama',
-				// IBP2: 'wss://rpc.dotters.network/kusama',
-				LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',
-				OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
-				Stakeworld: 'wss://ksm-rpc.stakeworld.io',
-			},
+			rpc: RpcEndpointsByChain.kusama,
 		},
 		unit: 'KSM',
 		units: 12,
@@ -75,14 +60,7 @@ export const NetworkList: Networks = {
 		name: 'westend',
 		endpoints: {
 			getLightClient: async () => await import('@dedot/chain-specs/westend2'),
-			rpc: {
-				// Dwellir: 'wss://westend-rpc.dwellir.com',
-				// IBP1: 'wss://rpc.ibp.network/westend',
-				// IBP2: 'wss://rpc.dotters.network/westend',
-				LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
-				OnFinality: 'wss://westend.api.onfinality.io/public-ws',
-				Stakeworld: 'wss://wnd-rpc.stakeworld.io',
-			},
+			rpc: RpcEndpointsByChain.westend,
 		},
 		unit: 'WND',
 		units: 12,
@@ -104,13 +82,7 @@ export const NetworkList: Networks = {
 		name: 'paseo',
 		endpoints: {
 			getLightClient: async () => await import('@dedot/chain-specs/paseo'),
-			rpc: {
-				IBP1: 'wss://rpc.ibp.network/paseo',
-				IBP2: 'wss://paseo.dotters.network',
-				Amforc: 'wss://paseo.rpc.amforc.com',
-				Dwellir: 'wss://paseo-rpc.dwellir.com',
-				StakeWorld: 'wss://pas-rpc.stakeworld.io',
-			},
+			rpc: RpcEndpointsByChain.paseo,
 		},
 		unit: 'PAS',
 		units: 10,
@@ -141,14 +113,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/polkadot_people'),
-			rpc: {
-				PolkadotPeople: 'wss://polkadot-people-rpc.polkadot.io',
-				LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
-				RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws',
-				// IBP1: 'wss://sys.ibp.network/people-polkadot',
-				// IBP2: 'wss://people-polkadot.dotters.network',
-				'Sys Dotters': 'wss://sys.dotters.network/people-polkadot',
-			},
+			rpc: RpcEndpointsByChain['people-polkadot'],
 		},
 		relayChain: 'polkadot',
 	},
@@ -161,13 +126,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/ksmcc3_people'),
-			rpc: {
-				Parity: 'wss://kusama-people-rpc.polkadot.io',
-				Stakeworld: 'wss://ksm-rpc.stakeworld.io/people',
-				// IBP1: 'wss://sys.ibp.network/people-kusama',
-				// IBP2: 'wss://people-kusama.dotters.network',
-				LuckyFriday: 'wss://rpc-people-kusama.luckyfriday.io',
-			},
+			rpc: RpcEndpointsByChain['people-kusama'],
 		},
 		relayChain: 'kusama',
 	},
@@ -180,10 +139,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/westend2_people'),
-			rpc: {
-				// IBP1: 'wss://sys.ibp.network/people-westend',
-				// IBP2: 'wss://people-westend.dotters.network',
-			},
+			rpc: RpcEndpointsByChain['people-westend'],
 		},
 		relayChain: 'westend',
 	},
@@ -196,15 +152,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/polkadot_asset_hub'),
-			rpc: {
-				DeServe: 'wss://asset-hub.polkadot.rpc.deserve.network',
-				// LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
-				// Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
-				StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
-				// Dwellir: 'wss://asset-hub-polkadot-rpc.dwellir.com',
-				// IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
-				// IBP2: 'wss://asset-hub-polkadot.dotters.network',
-			},
+			rpc: RpcEndpointsByChain.statemint,
 		},
 		relayChain: 'polkadot',
 	},
@@ -217,12 +165,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/ksmcc3_asset_hub'),
-			rpc: {
-				LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
-				Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',
-				// IBP1: 'wss://sys.ibp.network/asset-hub-kusama',
-				// IBP2: 'wss://asset-hub-kusama.dotters.network',
-			},
+			rpc: RpcEndpointsByChain.statemine,
 		},
 		relayChain: 'kusama',
 	},
@@ -235,13 +178,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/westend2_asset_hub'),
-			rpc: {
-				Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
-				// Dwellir: 'wss://asset-hub-westend-rpc.dwellir.com',
-				// IBP1: 'wss://sys.ibp.network/asset-hub-westend',
-				// IBP2: 'wss://asset-hub-westend.dotters.network',
-				'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io',
-			},
+			rpc: RpcEndpointsByChain.westmint,
 		},
 		relayChain: 'westend',
 	},
@@ -254,10 +191,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/paseo_people'),
-			rpc: {
-				IBP2: 'wss://people-paseo.dotters.network',
-				Amforc: 'wss://people-paseo.rpc.amforc.com',
-			},
+			rpc: RpcEndpointsByChain['people-paseo'],
 		},
 		relayChain: 'paseo',
 	},
@@ -270,13 +204,7 @@ export const SystemChainList: Record<string, SystemChain> = {
 		endpoints: {
 			getLightClient: async () =>
 				await import('@dedot/chain-specs/paseo_asset_hub'),
-			rpc: {
-				IBP1: 'wss://sys.ibp.network/asset-hub-paseo',
-				IBP2: 'wss://asset-hub-paseo.dotters.network',
-				Dwellir: 'wss://asset-hub-paseo-rpc.dwellir.com',
-				StakeWorld: 'wss://pas-rpc.stakeworld.io/assethub',
-				TurboFlakes: 'wss://sys.turboflakes.io/asset-hub-paseo',
-			},
+			rpc: RpcEndpointsByChain.paseomint,
 		},
 		relayChain: 'paseo',
 	},

--- a/packages/consts/src/rpc.ts
+++ b/packages/consts/src/rpc.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ChainId, RpcEndpoints } from 'types'
+
+export type RpcChainId = ChainId | 'hydration'
+
+export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
+	polkadot: {
+		'Automata 1RPC': 'wss://1rpc.io/dot',
+		// Dwellir: 'wss://polkadot-rpc.dwellir.com',
+		// IBP1: 'wss://rpc.ibp.network/polkadot',
+		// IBP2: 'wss://rpc.dotters.network/polkadot',
+		LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
+		OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
+		Stakeworld: 'wss://dot-rpc.stakeworld.io',
+	},
+	kusama: {
+		'Automata 1RPC': 'wss://1rpc.io/ksm',
+		// Dwellir: 'wss://kusama-rpc.dwellir.com',
+		// IBP1: 'wss://rpc.ibp.network/kusama',
+		// IBP2: 'wss://rpc.dotters.network/kusama',
+		LuckyFriday: 'wss://rpc-kusama.luckyfriday.io',
+		OnFinality: 'wss://kusama.api.onfinality.io/public-ws',
+		Stakeworld: 'wss://ksm-rpc.stakeworld.io',
+	},
+	westend: {
+		// Dwellir: 'wss://westend-rpc.dwellir.com',
+		// IBP1: 'wss://rpc.ibp.network/westend',
+		// IBP2: 'wss://rpc.dotters.network/westend',
+		LuckyFriday: 'wss://rpc-westend.luckyfriday.io',
+		OnFinality: 'wss://westend.api.onfinality.io/public-ws',
+		Stakeworld: 'wss://wnd-rpc.stakeworld.io',
+	},
+	paseo: {
+		IBP1: 'wss://rpc.ibp.network/paseo',
+		IBP2: 'wss://paseo.dotters.network',
+		Amforc: 'wss://paseo.rpc.amforc.com',
+		Dwellir: 'wss://paseo-rpc.dwellir.com',
+		StakeWorld: 'wss://pas-rpc.stakeworld.io',
+	},
+	'people-polkadot': {
+		PolkadotPeople: 'wss://polkadot-people-rpc.polkadot.io',
+		LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
+		RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws',
+		// IBP1: 'wss://sys.ibp.network/people-polkadot',
+		// IBP2: 'wss://people-polkadot.dotters.network',
+		'Sys Dotters': 'wss://sys.dotters.network/people-polkadot',
+	},
+	'people-kusama': {
+		Parity: 'wss://kusama-people-rpc.polkadot.io',
+		Stakeworld: 'wss://ksm-rpc.stakeworld.io/people',
+		// IBP1: 'wss://sys.ibp.network/people-kusama',
+		// IBP2: 'wss://people-kusama.dotters.network',
+		LuckyFriday: 'wss://rpc-people-kusama.luckyfriday.io',
+	},
+	'people-westend': {
+		// IBP1: 'wss://sys.ibp.network/people-westend',
+		// IBP2: 'wss://people-westend.dotters.network',
+	},
+	'people-paseo': {
+		IBP2: 'wss://people-paseo.dotters.network',
+		Amforc: 'wss://people-paseo.rpc.amforc.com',
+	},
+	statemint: {
+		DeServe: 'wss://asset-hub.polkadot.rpc.deserve.network',
+		// LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
+		// Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
+		StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
+		// Dwellir: 'wss://asset-hub-polkadot-rpc.dwellir.com',
+		// IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
+		// IBP2: 'wss://asset-hub-polkadot.dotters.network',
+	},
+	statemine: {
+		LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
+		Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',
+		// IBP1: 'wss://sys.ibp.network/asset-hub-kusama',
+		// IBP2: 'wss://asset-hub-kusama.dotters.network',
+	},
+	westmint: {
+		Parity: 'wss://westend-asset-hub-rpc.polkadot.io',
+		// Dwellir: 'wss://asset-hub-westend-rpc.dwellir.com',
+		// IBP1: 'wss://sys.ibp.network/asset-hub-westend',
+		// IBP2: 'wss://asset-hub-westend.dotters.network',
+		'Permanence DAO EU': 'wss://asset-hub-westend.rpc.permanence.io',
+	},
+	paseomint: {
+		IBP1: 'wss://sys.ibp.network/asset-hub-paseo',
+		IBP2: 'wss://asset-hub-paseo.dotters.network',
+		Dwellir: 'wss://asset-hub-paseo-rpc.dwellir.com',
+		StakeWorld: 'wss://pas-rpc.stakeworld.io/assethub',
+		TurboFlakes: 'wss://sys.turboflakes.io/asset-hub-paseo',
+	},
+	hydration: {
+		Dwellir: 'wss://hydration-rpc.n.dwellir.com',
+		Nice: 'wss://rpc.nice.hydration.cloud',
+	},
+}
+
+export const getRpcEndpointList = (chain: RpcChainId): string[] =>
+	Object.values(RpcEndpointsByChain[chain])

--- a/packages/ui-app/src/MainFooter/index.tsx
+++ b/packages/ui-app/src/MainFooter/index.tsx
@@ -7,8 +7,8 @@ import { Odometer } from '@w3ux/react-odometer'
 import CloudIconSVG from 'assets/icons/cloud.svg?react'
 import BigNumber from 'bignumber.js'
 import {
-	DappOrganisation,
 	PlatformDisclaimerURL,
+	PlatformName,
 	PlatformPrivacyURL,
 	PlatformURL,
 } from 'consts'
@@ -50,7 +50,7 @@ export const MainFooter = () => {
 					<section>
 						<p>
 							<a href={PlatformURL} target="_blank" rel="noreferrer">
-								{DappOrganisation}
+								{PlatformName}
 							</a>
 						</p>
 						<Status />


### PR DESCRIPTION
This PR refactors the shared `consts` package to better separate “platform” vs “staking app” constants, and centralizes RPC endpoint configuration behind a single `RpcEndpointsByChain` map to reduce duplication across network definitions.

**Changes:**
- Introduce `packages/consts/src/rpc.ts` and move RPC endpoint lists into `RpcEndpointsByChain`, referenced from `packages/consts/src/networks.ts`.
- Split/rename global constants into clearer platform vs staking constants (e.g., `PlatformName`, `StakingDappName`, `StakingProductionURL`) and update downstream imports/usages.
- Update platform support email address constant.
