### PR TITLE
feat(refactor): Support custom transaction fee display

### DIFF
--- a/packages/types/src/tx.ts
+++ b/packages/types/src/tx.ts
@@ -14,6 +14,11 @@ export type TxSubmissionItem = {
 	pending: boolean
 }
 
+export type TxFeeDisplay = {
+	unit: string
+	units: number
+}
+
 export interface TxStatusHandlers {
 	onReady: () => void
 	onInBlock: () => void
@@ -38,6 +43,7 @@ export type SubmitTxProps = SubmitProps &
 		txInitiated: boolean
 		proxyAccount: ActiveProxy | null
 		stacked?: boolean
+		feeDisplay?: TxFeeDisplay
 	}
 
 export interface SubmitProps {

--- a/packages/ui-app/src/EstimatedTxFee/index.tsx
+++ b/packages/ui-app/src/EstimatedTxFee/index.tsx
@@ -2,18 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { getStakingChainData } from 'consts/util'
-import { useNetwork } from 'hooks/useNetwork'
 import { useTxMeta } from 'hooks/useTxMeta'
 import { useTranslation } from 'react-i18next'
 import { planckToUnitBn } from 'utils'
 import type { EstimatedTxFeeProps } from './types'
 
-export const EstimatedTxFee = ({ uid }: EstimatedTxFeeProps) => {
+export const EstimatedTxFee = ({ uid, feeDisplay }: EstimatedTxFeeProps) => {
 	const { t } = useTranslation('app')
-	const { network } = useNetwork()
 	const { getTxSubmission } = useTxMeta()
-	const { unit, units } = getStakingChainData(network)
+	const { unit, units } = feeDisplay
 
 	const txSubmission = getTxSubmission(uid)
 	const fee = txSubmission?.fee || 0n

--- a/packages/ui-app/src/EstimatedTxFee/types.ts
+++ b/packages/ui-app/src/EstimatedTxFee/types.ts
@@ -1,6 +1,9 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { TxFeeDisplay } from 'types'
+
 export interface EstimatedTxFeeProps {
 	uid?: number
+	feeDisplay: TxFeeDisplay
 }

--- a/packages/ui-app/src/SubmitTx/Signers/Extension.tsx
+++ b/packages/ui-app/src/SubmitTx/Signers/Extension.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { DisplayFor } from 'types'
+import type { DisplayFor, TxFeeDisplay } from 'types'
 import { ButtonSubmitWithFee } from 'ui-buttons'
 import { EstimatedTxFee } from '../../EstimatedTxFee'
 import { SubmitButtonWrapper } from '../../Tx'
@@ -14,6 +14,7 @@ interface ExtensionProps {
 	valid: boolean
 	submitted: boolean
 	notEnoughFunds: boolean
+	feeDisplay: TxFeeDisplay
 }
 
 export const Extension = ({
@@ -23,6 +24,7 @@ export const Extension = ({
 	valid,
 	submitted,
 	notEnoughFunds,
+	feeDisplay,
 }: ExtensionProps) => {
 	// Disable while submitting or when the account cannot cover the tx fee,
 	// matching the Vault and Ledger signers
@@ -35,7 +37,7 @@ export const Extension = ({
 				onSubmit={onSubmit}
 				disabled={buttonDisabled}
 				pulse={!buttonDisabled}
-				fee={<EstimatedTxFee uid={uid} />}
+				fee={<EstimatedTxFee uid={uid} feeDisplay={feeDisplay} />}
 			/>
 		</SubmitButtonWrapper>
 	)

--- a/packages/ui-app/src/SubmitTx/Signers/Ledger.tsx
+++ b/packages/ui-app/src/SubmitTx/Signers/Ledger.tsx
@@ -10,7 +10,7 @@ import {
 } from '@polkadot-cloud/connect-ledger'
 import { useHelp } from 'hooks/useHelp'
 import { useTranslation } from 'react-i18next'
-import type { ActiveAccount, DisplayFor } from 'types'
+import type { ActiveAccount, DisplayFor, TxFeeDisplay } from 'types'
 import { ButtonHelp, ButtonSubmitWithFee } from 'ui-buttons'
 import { useOverlay } from 'ui-overlay'
 import { EstimatedTxFee } from '../../EstimatedTxFee'
@@ -25,6 +25,7 @@ interface LedgerProps {
 	submitAccount: ActiveAccount
 	onSubmit: () => void
 	notEnoughFunds: boolean
+	feeDisplay: TxFeeDisplay
 }
 
 interface LedgerPromptProps {
@@ -39,6 +40,7 @@ export const LedgerSubmit = ({
 	submitAccount,
 	onSubmit,
 	notEnoughFunds,
+	feeDisplay,
 }: LedgerProps) => {
 	const { t } = useTranslation('app')
 	const { setModalResize } = useOverlay().modal
@@ -69,7 +71,7 @@ export const LedgerSubmit = ({
 				onSubmit={buttonOnClick}
 				disabled={buttonDisabled}
 				pulse={buttonPulse}
-				fee={<EstimatedTxFee uid={uid} />}
+				fee={<EstimatedTxFee uid={uid} feeDisplay={feeDisplay} />}
 			/>
 		</SubmitButtonWrapper>
 	)

--- a/packages/ui-app/src/SubmitTx/Signers/Vault.tsx
+++ b/packages/ui-app/src/SubmitTx/Signers/Vault.tsx
@@ -5,7 +5,7 @@ import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { deriveVaultButtonState } from '@polkadot-cloud/connect-vault'
 import { useTranslation } from 'react-i18next'
-import type { DisplayFor } from 'types'
+import type { DisplayFor, TxFeeDisplay } from 'types'
 import { ButtonSubmitWithFee } from 'ui-buttons'
 import { EstimatedTxFee } from '../../EstimatedTxFee'
 import { SubmitButtonWrapper } from '../../Tx'
@@ -19,6 +19,7 @@ interface VaultProps {
 	onSubmit: () => void
 	notEnoughFunds: boolean
 	promptStatus: number
+	feeDisplay: TxFeeDisplay
 }
 
 export const VaultSubmit = ({
@@ -30,6 +31,7 @@ export const VaultSubmit = ({
 	onSubmit,
 	notEnoughFunds,
 	promptStatus,
+	feeDisplay,
 }: VaultProps) => {
 	const { t } = useTranslation('app')
 
@@ -56,7 +58,7 @@ export const VaultSubmit = ({
 				onSubmit={onSubmit}
 				disabled={finalDisabled}
 				pulse={finalPulse}
-				fee={<EstimatedTxFee uid={uid} />}
+				fee={<EstimatedTxFee uid={uid} feeDisplay={feeDisplay} />}
 			/>
 		</SubmitButtonWrapper>
 	)

--- a/packages/ui-app/src/SubmitTx/index.tsx
+++ b/packages/ui-app/src/SubmitTx/index.tsx
@@ -8,7 +8,7 @@ import { useNetwork } from 'hooks/useNetwork'
 import { useTxMeta } from 'hooks/useTxMeta'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { SubmitTxProps } from 'types'
+import type { SubmitTxProps, TxFeeDisplay } from 'types'
 import { useOverlay, usePrompt } from 'ui-overlay'
 import { Tx } from '../Tx'
 import { Extension } from './Signers/Extension'
@@ -28,6 +28,7 @@ export const SubmitTx = (props: SubmitTxProps) => {
 		onResize,
 		transparent,
 		stacked,
+		feeDisplay,
 	} = props
 
 	const { t } = useTranslation()
@@ -37,7 +38,8 @@ export const SubmitTx = (props: SubmitTxProps) => {
 	const { setModalResize } = useOverlay().modal
 	const { requiresManualSign, getAccount } = useImportedAccounts()
 
-	const { unit } = getStakingChainData(network)
+	const { unit, units } = getStakingChainData(network)
+	const activeFeeDisplay: TxFeeDisplay = feeDisplay ?? { unit, units }
 	const txSubmission = getTxSubmission(uid)
 	const from = txSubmission?.from || null
 	const fee = txSubmission?.fee || 0n
@@ -83,6 +85,7 @@ export const SubmitTx = (props: SubmitTxProps) => {
 					onSubmit={onSubmit}
 					notEnoughFunds={notEnoughFunds}
 					promptStatus={promptStatus}
+					feeDisplay={activeFeeDisplay}
 				/>
 			)
 			PromptComponent = <VaultPrompt valid={valid} />
@@ -98,6 +101,7 @@ export const SubmitTx = (props: SubmitTxProps) => {
 					submitAccount={submitAccount}
 					onSubmit={onSubmit}
 					notEnoughFunds={notEnoughFunds}
+					feeDisplay={activeFeeDisplay}
 				/>
 			)
 			PromptComponent = <LedgerPrompt valid={valid} />
@@ -113,6 +117,7 @@ export const SubmitTx = (props: SubmitTxProps) => {
 				valid={valid}
 				submitted={submitted}
 				notEnoughFunds={notEnoughFunds}
+				feeDisplay={activeFeeDisplay}
 			/>
 		)
 		PromptComponent = undefined
@@ -122,7 +127,9 @@ export const SubmitTx = (props: SubmitTxProps) => {
 		<Tx
 			{...props}
 			notEnoughFunds={notEnoughFunds}
-			dangerMessage={`${t('notEnough', { ns: 'app' })} ${unit}`}
+			dangerMessage={`${t('notEnough', { ns: 'app' })} ${
+				activeFeeDisplay.unit
+			}`}
 			margin={!noMargin}
 			SubmitComponent={SubmitComponent}
 			PromptComponent={PromptComponent}


### PR DESCRIPTION
Introduces a `TxFeeDisplay` type and threads it through the transaction submission flow so fee-related UI (estimated fee and “not enough funds” messaging) can display using a caller-provided unit/decimals configuration instead of always deriving it from the active network.

**Changes:**
- Add `TxFeeDisplay` to the shared `types` package and extend `SubmitTxProps` with an optional `feeDisplay`.
- Update `SubmitTx` to compute an `activeFeeDisplay` (custom override or network default) and pass it into signer submit components.
- Refactor `EstimatedTxFee` to take `feeDisplay` via props and remove its direct dependency on network lookups.
