### PR TITLE
fix(tx-submit): report on-chain dispatch errors as failed transactions

### DIFF
--- a/packages/global-bus/src/txSubmit/error.ts
+++ b/packages/global-bus/src/txSubmit/error.ts
@@ -1,6 +1,39 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { DispatchError } from 'dedot/codecs'
+
+// Minimal registry surface needed to decode module dispatch errors, satisfied
+// by a dedot client's `registry`.
+export interface DispatchErrorRegistry {
+	findErrorMeta(
+		error: DispatchError,
+	): { pallet: string; name: string; docs: string[] } | undefined
+}
+
+// Convert an on-chain DispatchError into a human-readable message. `Module`
+// errors are decoded via the registry into `Pallet.Error` plus their metadata
+// docs; other variants (BadOrigin, Token, Arithmetic, …) fall back to the
+// variant name (with a nested value where one is present).
+export const getDispatchErrorMessage = (
+	dispatchError: DispatchError,
+	registry?: DispatchErrorRegistry,
+): string => {
+	if (dispatchError.type === 'Module') {
+		const meta = registry?.findErrorMeta(dispatchError)
+		if (meta) {
+			const docs = meta.docs.join(' ').trim()
+			return docs
+				? `${meta.pallet}.${meta.name}: ${docs}`
+				: `${meta.pallet}.${meta.name}`
+		}
+	}
+	const value = (dispatchError as { value?: unknown }).value
+	return typeof value === 'string'
+		? `${dispatchError.type}.${value}`
+		: dispatchError.type
+}
+
 // Enhanced technical error classification
 export const getErrorKeyFromMessage = (errorMessage: string): string => {
 	const msgLower = errorMessage.toLowerCase()

--- a/packages/global-bus/src/txSubmit/submit.ts
+++ b/packages/global-bus/src/txSubmit/submit.ts
@@ -3,10 +3,14 @@
 
 import type { SubmittableExtrinsic } from 'dedot'
 import type { ExtrinsicSignatureV4 } from 'dedot/codecs'
-import type { InjectedSigner, TxStatus } from 'dedot/types'
+import type { InjectedSigner, ISubmittableResult } from 'dedot/types'
 import { onTransactionSubmittedEvent } from 'event-tracking'
 import type { TxStatusHandlers } from 'types'
-import { getErrorKeyFromMessage } from './error'
+import {
+	type DispatchErrorRegistry,
+	getDispatchErrorMessage,
+	getErrorKeyFromMessage,
+} from './error'
 import { deleteTx, setUidPending, setUidSubmitted, subs } from './index'
 
 export const addSignAndSend = async (
@@ -26,8 +30,8 @@ export const addSignAndSend = async (
 		subs[uid] = await tx.signAndSend(
 			from,
 			{ signer, nonce },
-			async ({ status }) => {
-				handleResult(uid, status, onRest)
+			async (result) => {
+				handleResult(uid, result, onRest, tx.client.registry)
 			},
 		)
 	} catch (e) {
@@ -50,8 +54,8 @@ export const addSend = async (
 		// Transaction submitted - register tx event
 		onTransactionSubmittedEvent(network, getTxLabel(tx))
 
-		subs[uid] = await tx.send(async ({ status }) => {
-			handleResult(uid, status, onRest)
+		subs[uid] = await tx.send(async (result) => {
+			handleResult(uid, result, onRest, tx.client.registry)
 		})
 	} catch (e) {
 		handleError(String(e), onError)
@@ -62,7 +66,7 @@ export const addSend = async (
 
 export const handleResult = (
 	uid: number,
-	status: TxStatus,
+	result: ISubmittableResult,
 	{
 		onReady,
 		onInBlock,
@@ -74,7 +78,23 @@ export const handleResult = (
 		onFinalized: () => void
 		onFailed: (err: Error) => void
 	},
+	registry?: DispatchErrorRegistry,
 ) => {
+	const { status, dispatchError } = result
+
+	// A transaction can be included in a block and finalized while its extrinsic
+	// reverted on-chain (e.g. staking.InsufficientBond, nominationPools.PoolNotFound).
+	// `status` only reflects inclusion, so a dispatch error must be surfaced as a
+	// failure instead of being routed to the success handlers.
+	if (
+		dispatchError &&
+		(status.type === 'BestChainBlockIncluded' || status.type === 'Finalized')
+	) {
+		onFailed(new Error(getDispatchErrorMessage(dispatchError, registry)))
+		deleteTx(uid)
+		return
+	}
+
 	if (status.type === 'Broadcasting') {
 		setUidPending(uid, true)
 		onReady()


### PR DESCRIPTION
## Summary
A transaction that is **included and finalized** can still have **failed** on-chain, the extrinsic reverts with a `dispatchError` (e.g. `staking.InsufficientBond`, `nominationPools.PoolNotFound`, pool full, commission-exceeds-max). The submit handler only inspected `status.type`, which reflects *inclusion*, not *success*, so every finalized-but-reverted transaction ran the **success** path and the user was told a fund-moving action worked when nothing happened.

`onFailed` was reachable only for `status.type === 'Invalid'` (mempool rejection). A reverted extrinsic sailed through `BestChainBlockIncluded → onInBlock()` and `Finalized → onFinalized()`.

## Fix
dedot surfaces the failure on the result object: `ISubmittableResult.dispatchError` (populated from the extrinsic's `system.ExtrinsicFailed` event). The callbacks previously destructured only `{ status }`, discarding it.

- `submit.ts` both callbacks now pass the **full result** (and the client registry) to `handleResult`.
- `handleResult` when a `dispatchError` is present on `BestChainBlockIncluded`/`Finalized`, it routes to `onFailed(...)` and cleans up, instead of the success handlers.
- `error.ts` new `getDispatchErrorMessage()` decodes the error: `Module` errors become `Pallet.Error` + metadata docs via `registry.findErrorMeta()`; other variants (`BadOrigin`, `Token`, `Arithmetic`, …) fall back to the variant name. This message flows into the existing `onFailed` classifier in `useSubmitExtrinsic`, so users get a meaningful reason (e.g. balance/reserve messaging) rather than a false success.

## Files
- `packages/global-bus/src/txSubmit/submit.ts`
- `packages/global-bus/src/txSubmit/error.ts`

## Behaviour
- **Successful tx** unchanged (`dispatchError` is undefined; `onInBlock`/`onFinalized` fire as before).
- **Reverted tx** now shows a failure notification with the decoded reason and stops, instead of a success toast.