### PR TITLE
feat(refactor): Share `lazyNamed` through `ui-overlay`

### DIFF
--- a/packages/app-staking/src/Overlays.tsx
+++ b/packages/app-staking/src/Overlays.tsx
@@ -1,32 +1,8 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { type ComponentType, lazy } from 'react'
 import { ErrorFallbackModal } from 'ui-app/ErrorBoundary'
-import { Overlay } from 'ui-overlay'
-
-type OverlayLoader<TModule = Record<string, unknown>> = () => Promise<TModule>
-
-const lazyNamed = <TModule extends Record<string, unknown>>(
-	load: OverlayLoader<TModule>,
-	exportName: string,
-) =>
-	lazy(async () => {
-		const module = await load()
-		const component = module[exportName]
-
-		if (!component) {
-			throw new Error(`Missing overlay export: ${exportName}`)
-		}
-
-		if (typeof component !== 'function') {
-			throw new Error(
-				`Export ${exportName} is not a component (expected function, got ${typeof component})`,
-			)
-		}
-
-		return { default: component as ComponentType }
-	})
+import { lazyNamed, Overlay, type OverlayLoader } from 'ui-overlay'
 
 const lazyOverlayComponents = <
 	T extends Record<string, OverlayLoader<Record<string, unknown>>>,

--- a/packages/ui-overlay/src/index.tsx
+++ b/packages/ui-overlay/src/index.tsx
@@ -3,6 +3,7 @@
 
 export * from './Close'
 export * from './CloseCanvas'
+export * from './lazyNamed'
 export * from './Overlay'
 export * from './Prompt'
 export * from './Provider'

--- a/packages/ui-overlay/src/lazyNamed.ts
+++ b/packages/ui-overlay/src/lazyNamed.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { type ComponentType, lazy } from 'react'
+
+export type OverlayLoader<TModule = Record<string, unknown>> =
+	() => Promise<TModule>
+
+export const lazyNamed = <TModule extends Record<string, unknown>>(
+	load: OverlayLoader<TModule>,
+	exportName: string,
+) =>
+	lazy(async () => {
+		const module = await load()
+		const component = module[exportName]
+
+		if (!component) {
+			throw new Error(`Missing overlay export: ${exportName}`)
+		}
+
+		if (typeof component !== 'function') {
+			throw new Error(
+				`Export ${exportName} is not a component (expected function, got ${typeof component})`,
+			)
+		}
+
+		return { default: component as ComponentType }
+	})


### PR DESCRIPTION
This PR refactors the `lazyNamed` helper (used to lazily load overlay components by named export) into the `ui-overlay` package so it can be shared across apps instead of being duplicated in `app-staking`.

**Changes:**
- Added `lazyNamed` and the `OverlayLoader` type to `packages/ui-overlay`.
- Re-exported `lazyNamed` from `ui-overlay`’s public entrypoint.
- Updated `app-staking` overlays setup to import and use the shared helper.
