### PR TITLE
feat(refactor): Abstract advanced menu, add `enableAdvancedMenu` prop

### DIFF
--- a/packages/app-staking/src/Router.tsx
+++ b/packages/app-staking/src/Router.tsx
@@ -126,7 +126,7 @@ const RouterInner = () => {
 					<Menu />
 					<Tooltip />
 					<Prompt />
-					<SideMenu />
+					<SideMenu enableAdvancedMenu={true} />
 					<Page.Main ref={mainInterfaceRef}>
 						<HelmetProvider>
 							<Headers Nodes={{ sync: Sync }} />

--- a/packages/app-staking/src/library/SideMenu/index.tsx
+++ b/packages/app-staking/src/library/SideMenu/index.tsx
@@ -25,7 +25,11 @@ const DefaultMenuBarItems: DefaultMenuBarItem[] = [
 	{ key: 'pools', faIcon: faPeopleLine, iconTransform: 'grow-3' },
 ]
 
-export const SideMenu = () => {
+export const SideMenu = ({
+	enableAdvancedMenu,
+}: {
+	enableAdvancedMenu: boolean
+}) => {
 	const { pathname } = useLocation()
 	const { getActivePageForCategory } = useActivePageForCategory()
 	const { categoryKey } = usePageFromHash({
@@ -63,6 +67,7 @@ export const SideMenu = () => {
 				pagesConfig={PagesConfig}
 				renderMain={renderMain}
 				title="Cloud"
+				enableAdvancedMenu={enableAdvancedMenu}
 			/>
 			<FloatingMenu renderMain={renderMain} title="Stake" />
 		</>

--- a/packages/ui-app/src/SideMenu/AdvancedMenu.tsx
+++ b/packages/ui-app/src/SideMenu/AdvancedMenu.tsx
@@ -1,0 +1,85 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faRightFromBracket } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import CloudSVG from 'assets/icons/cloud.svg?react'
+import { useTheme } from 'hooks/useTheme'
+import { useUi } from 'hooks/useUi'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import type { PageCategory } from 'types'
+import { Separator, Tooltip } from 'ui-core/base'
+import type { BaseMenuProps } from './types'
+import {
+	BarButton,
+	BarFooterWrapper,
+	BarIconsWrapper,
+	BarLogoWrapper,
+} from './Wrapper'
+
+export const AdvancedMenu = ({
+	barItems,
+	getActivePageForCategory,
+	localCategory,
+}: BaseMenuProps) => {
+	const { t } = useTranslation('app')
+	const { setAdvancedMode } = useUi()
+	const navigate = useNavigate()
+	const { themeElementRef } = useTheme()
+
+	// Navigate to the last active page for a category
+	const navigateToCategory = (category: PageCategory['key']) => {
+		navigate(getActivePageForCategory(category))
+	}
+
+	return (
+		<>
+			<BarLogoWrapper>
+				<CloudSVG />
+			</BarLogoWrapper>
+			<BarIconsWrapper>
+				{barItems.map(({ faIcon, iconTransform, key }, index) => (
+					<section key={key}>
+						<Tooltip
+							text={t(key)}
+							side="right"
+							container={themeElementRef.current || undefined}
+							delayDuration={index === 0 ? 100 : 0}
+							fadeIn
+						>
+							<BarButton
+								type="button"
+								onClick={() => {
+									navigateToCategory(key)
+								}}
+								className={localCategory === key ? 'active' : ''}
+							>
+								<FontAwesomeIcon icon={faIcon} transform={iconTransform} />
+							</BarButton>
+						</Tooltip>
+					</section>
+				))}
+			</BarIconsWrapper>
+			<BarFooterWrapper>
+				<Separator style={{ opacity: 0.25 }} />
+				<Tooltip
+					text={t('exitAdvancedMode')}
+					side="right"
+					container={themeElementRef.current || undefined}
+					delayDuration={0}
+					fadeIn
+				>
+					<BarButton
+						type="button"
+						onClick={() => {
+							setAdvancedMode(false)
+						}}
+					>
+						<FontAwesomeIcon icon={faRightFromBracket} />
+					</BarButton>
+				</Tooltip>
+			</BarFooterWrapper>
+		</>
+	)
+}

--- a/packages/ui-app/src/SideMenu/DefaultMenu.tsx
+++ b/packages/ui-app/src/SideMenu/DefaultMenu.tsx
@@ -25,6 +25,7 @@ export const DefaultMenu = ({
 	pagesConfig,
 	renderMain,
 	title,
+	enableAdvancedMenu,
 }: DefaultMenuProps) => {
 	const { t } = useTranslation('app')
 	const { themeElementRef } = useTheme()
@@ -36,13 +37,15 @@ export const DefaultMenu = ({
 
 	const transparent = modalStatus === 'open' || canvasStatus === 'open'
 
+	const showAdvancedMenu = enableAdvancedMenu && advancedMode
+
 	return (
 		<Page.Side.Default
 			open={false}
 			minimised={sideMenuMinimised}
 			transparent={transparent}
 			bar={
-				!advancedMode ? undefined : (
+				!showAdvancedMenu ? undefined : (
 					<AdvancedMenu
 						barItems={barItems}
 						getActivePageForCategory={getActivePageForCategory}
@@ -51,10 +54,13 @@ export const DefaultMenu = ({
 				)
 			}
 			nav={
-				!advancedMode ? (
+				!showAdvancedMenu ? (
 					<NavSimple renderMain={renderMain} title={title} />
 				) : (
-					<Wrapper $minimised={sideMenuMinimised} $advancedMode={advancedMode}>
+					<Wrapper
+						$minimised={sideMenuMinimised}
+						$advancedMode={showAdvancedMenu}
+					>
 						<section>
 							<Popover
 								open={openCategories}

--- a/packages/ui-app/src/SideMenu/DefaultMenu.tsx
+++ b/packages/ui-app/src/SideMenu/DefaultMenu.tsx
@@ -1,34 +1,21 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import {
-	faChevronDown,
-	faRightFromBracket,
-	faTimes,
-} from '@fortawesome/free-solid-svg-icons'
+import { faChevronDown, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import CloudSVG from 'assets/icons/cloud.svg?react'
 import { useTheme } from 'hooks/useTheme'
 import { useUi } from 'hooks/useUi'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-import type { PageCategory } from 'types'
-import { Page, Separator, Tooltip } from 'ui-core/base'
+import { Page } from 'ui-core/base'
 import { Popover } from 'ui-core/popover'
 import { useOverlay } from 'ui-overlay'
 import { getCategoryId } from 'utils'
+import { AdvancedMenu } from './AdvancedMenu'
 import { CategoriesPopover } from './Categories'
 import { NavSimple } from './NavSimple'
 import type { DefaultMenuProps } from './types'
-import {
-	BarButton,
-	BarFooterWrapper,
-	BarIconsWrapper,
-	BarLogoWrapper,
-	CategoryHeader,
-	Wrapper,
-} from './Wrapper'
+import { CategoryHeader, Wrapper } from './Wrapper'
 
 export const DefaultMenu = ({
 	barItems,
@@ -40,20 +27,14 @@ export const DefaultMenu = ({
 	title,
 }: DefaultMenuProps) => {
 	const { t } = useTranslation('app')
-	const { advancedMode, setAdvancedMode, sideMenuMinimised } = useUi()
-	const navigate = useNavigate()
 	const { themeElementRef } = useTheme()
+	const { advancedMode, sideMenuMinimised } = useUi()
 	const { status: modalStatus } = useOverlay().modal
 	const { status: canvasStatus } = useOverlay().canvas
 
 	const [openCategories, setOpenCategories] = useState<boolean>(false)
 
 	const transparent = modalStatus === 'open' || canvasStatus === 'open'
-
-	// Navigate to the last active page for a category
-	const navigateToCategory = (category: PageCategory['key']) => {
-		navigate(getActivePageForCategory(category))
-	}
 
 	return (
 		<Page.Side.Default
@@ -62,56 +43,11 @@ export const DefaultMenu = ({
 			transparent={transparent}
 			bar={
 				!advancedMode ? undefined : (
-					<>
-						<BarLogoWrapper>
-							<CloudSVG />
-						</BarLogoWrapper>
-						<BarIconsWrapper>
-							{barItems.map(({ faIcon, iconTransform, key }, index) => (
-								<section key={key}>
-									<Tooltip
-										text={t(key)}
-										side="right"
-										container={themeElementRef.current || undefined}
-										delayDuration={index === 0 ? 100 : 0}
-										fadeIn
-									>
-										<BarButton
-											type="button"
-											onClick={() => {
-												navigateToCategory(key)
-											}}
-											className={localCategory === key ? 'active' : ''}
-										>
-											<FontAwesomeIcon
-												icon={faIcon}
-												transform={iconTransform}
-											/>
-										</BarButton>
-									</Tooltip>
-								</section>
-							))}
-						</BarIconsWrapper>
-						<BarFooterWrapper>
-							<Separator style={{ opacity: 0.25 }} />
-							<Tooltip
-								text={t('exitAdvancedMode')}
-								side="right"
-								container={themeElementRef.current || undefined}
-								delayDuration={0}
-								fadeIn
-							>
-								<BarButton
-									type="button"
-									onClick={() => {
-										setAdvancedMode(false)
-									}}
-								>
-									<FontAwesomeIcon icon={faRightFromBracket} />
-								</BarButton>
-							</Tooltip>
-						</BarFooterWrapper>
-					</>
+					<AdvancedMenu
+						barItems={barItems}
+						getActivePageForCategory={getActivePageForCategory}
+						localCategory={localCategory}
+					/>
 				)
 			}
 			nav={

--- a/packages/ui-app/src/SideMenu/types.ts
+++ b/packages/ui-app/src/SideMenu/types.ts
@@ -33,6 +33,7 @@ export interface DefaultMenuProps extends BaseMenuProps {
 	pagesConfig: PagesConfigItems
 	renderMain: RenderSideMenuMain
 	title: string
+	enableAdvancedMenu: boolean
 }
 
 export interface FloatingMenuProps {

--- a/packages/ui-app/src/SideMenu/types.ts
+++ b/packages/ui-app/src/SideMenu/types.ts
@@ -23,10 +23,12 @@ export interface DefaultMenuBarItem {
 	key: PageCategory['key']
 }
 
-export interface DefaultMenuProps {
+export interface BaseMenuProps {
 	barItems: DefaultMenuBarItem[]
 	getActivePageForCategory: (category: PageCategory['key']) => string
 	localCategory: PageCategory['key']
+}
+export interface DefaultMenuProps extends BaseMenuProps {
 	pageCategories: PageCategoryItems
 	pagesConfig: PagesConfigItems
 	renderMain: RenderSideMenuMain


### PR DESCRIPTION
Refactors the SideMenu implementation by extracting the “advanced” bar UI into a dedicated component and introducing an `enableAdvancedMenu` flag to explicitly control whether the advanced menu renders (in addition to the existing `advancedMode` UI state).

**Changes:**
- Introduced `BaseMenuProps` and added `enableAdvancedMenu: boolean` to `DefaultMenuProps`.
- Extracted the advanced sidebar bar UI into a new `AdvancedMenu` component and wired it into `DefaultMenu` behind `enableAdvancedMenu && advancedMode`.
- Updated the staking app’s `SideMenu` and router to pass the new `enableAdvancedMenu` prop through.
