### PR TITLE
faet: add `app-stablecoins` skeleton [3]

### DIFF
--- a/packages/ui-app/src/Dropdown/index.module.scss
+++ b/packages/ui-app/src/Dropdown/index.module.scss
@@ -1,0 +1,99 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.wrapper {
+	position: relative;
+	flex-shrink: 0;
+}
+
+.trigger,
+.option {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	width: 100%;
+}
+
+.trigger {
+	background-color: var(--gray-100);
+	border-radius: 0.75rem;
+	box-shadow: var(--shadow-alt);
+	border: 1px solid var(--shade-200);
+
+	&:hover {
+		border-color: var(--gray-500);
+	}
+}
+
+.triggerCompact {
+	padding: 0.5rem 1rem;
+}
+
+.triggerFull {
+	padding: 0.85rem 1rem;
+}
+
+.value {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	min-width: 0;
+}
+
+.icon {
+	width: 1.5rem;
+	height: 1.5rem;
+	flex-shrink: 0;
+}
+
+.selectedLabel {
+	font-weight: 700;
+	font-size: 1.25rem;
+}
+
+.chevron {
+	color: var(--gray-600);
+	font-size: 1.25rem;
+	line-height: 1.8rem;
+}
+
+.menu {
+	position: absolute;
+	top: calc(100% + 0.35rem);
+	right: 0;
+	z-index: 20;
+	min-width: 100%;
+	background-color: var(--gray-100);
+	border: 1px solid var(--shade-200);
+	border-radius: 0.75rem;
+	box-shadow: var(--shadow-alt);
+	overflow: hidden;
+}
+
+.menuTopLayer {
+	z-index: 80;
+}
+
+.option {
+	color: var(--gray-900);
+	padding: 0.75rem 1rem;
+	text-align: left;
+	white-space: nowrap;
+
+	&:hover {
+		background-color: var(--gray-200);
+		color: var(--gray-1000);
+	}
+}
+
+.optionActive {
+	background-color: var(--gray-200);
+	color: var(--gray-1000);
+	font-weight: 700;
+}
+
+.check {
+	color: var(--status-success);
+	font-size: 0.95rem;
+}

--- a/packages/ui-app/src/Dropdown/index.tsx
+++ b/packages/ui-app/src/Dropdown/index.tsx
@@ -82,8 +82,6 @@ export const Dropdown = <T extends string>({
 								className={`${classes.option} ${
 									selectedOption ? classes.optionActive : ''
 								}`}
-								role="option"
-								aria-selected={selectedOption}
 								onClick={() => {
 									onSelect(option)
 									setIsOpen(false)

--- a/packages/ui-app/src/Dropdown/index.tsx
+++ b/packages/ui-app/src/Dropdown/index.tsx
@@ -1,0 +1,113 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faCheck, faChevronDown } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useEffect, useRef, useState } from 'react'
+import classes from './index.module.scss'
+import type { DropdownProps } from './types'
+
+export type { DropdownOption, DropdownProps } from './types'
+
+export const Dropdown = <T extends string>({
+	options,
+	selected,
+	onSelect,
+	variant = 'compact',
+}: DropdownProps<T>) => {
+	const [isOpen, setIsOpen] = useState(false)
+	const ref = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		if (!isOpen) {
+			return
+		}
+
+		const handlePointerDown = (event: PointerEvent) => {
+			if (!ref.current?.contains(event.target as Node)) {
+				setIsOpen(false)
+			}
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				setIsOpen(false)
+			}
+		}
+
+		document.addEventListener('pointerdown', handlePointerDown)
+		document.addEventListener('keydown', handleKeyDown)
+
+		return () => {
+			document.removeEventListener('pointerdown', handlePointerDown)
+			document.removeEventListener('keydown', handleKeyDown)
+		}
+	}, [isOpen])
+
+	return (
+		<div className={classes.wrapper} ref={ref}>
+			<button
+				type="button"
+				className={`${classes.trigger} ${
+					variant === 'full' ? classes.triggerFull : classes.triggerCompact
+				}`}
+				aria-expanded={isOpen}
+				onClick={() => setIsOpen((open) => !open)}
+			>
+				<span className={classes.value}>
+					{selected.icon && (
+						<img
+							src={selected.icon}
+							alt={selected.label}
+							className={classes.icon}
+						/>
+					)}
+					<span className={classes.selectedLabel}>{selected.label}</span>
+				</span>
+				<FontAwesomeIcon icon={faChevronDown} className={classes.chevron} />
+			</button>
+
+			{isOpen && (
+				<div
+					className={`${classes.menu} ${
+						variant === 'full' ? classes.menuTopLayer : ''
+					}`}
+					role="listbox"
+				>
+					{options.map((option) => {
+						const selectedOption = option.value === selected.value
+
+						return (
+							<button
+								type="button"
+								key={option.value}
+								className={`${classes.option} ${
+									selectedOption ? classes.optionActive : ''
+								}`}
+								role="option"
+								aria-selected={selectedOption}
+								onClick={() => {
+									onSelect(option)
+									setIsOpen(false)
+								}}
+							>
+								<span className={classes.value}>
+									{option.icon && (
+										<img
+											src={option.icon}
+											alt={option.label}
+											className={classes.icon}
+										/>
+									)}
+									<span>{option.label}</span>
+								</span>
+								{selectedOption && (
+									<FontAwesomeIcon icon={faCheck} className={classes.check} />
+								)}
+							</button>
+						)
+					})}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/packages/ui-app/src/Dropdown/index.tsx
+++ b/packages/ui-app/src/Dropdown/index.tsx
@@ -71,7 +71,6 @@ export const Dropdown = <T extends string>({
 					className={`${classes.menu} ${
 						variant === 'full' ? classes.menuTopLayer : ''
 					}`}
-					role="listbox"
 				>
 					{options.map((option) => {
 						const selectedOption = option.value === selected.value

--- a/packages/ui-app/src/Dropdown/types.ts
+++ b/packages/ui-app/src/Dropdown/types.ts
@@ -1,0 +1,15 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export type DropdownOption<T extends string = string> = {
+	value: T
+	label: string
+	icon?: string
+}
+
+export type DropdownProps<T extends string> = {
+	options: DropdownOption<T>[]
+	selected: DropdownOption<T>
+	onSelect: (option: DropdownOption<T>) => void
+	variant?: 'compact' | 'full'
+}

--- a/packages/ui-core/src/input/SendForm/Action/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Action/index.module.scss
@@ -1,7 +1,6 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-export * from './AccountInput'
-export * from './SendForm'
-export * from './Switch'
-export * from './TokenInput'
+.action {
+	padding: 0.5rem;
+}

--- a/packages/ui-core/src/input/SendForm/Action/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Action/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ComponentBase } from 'types'
+import classes from './index.module.scss'
+
+export const Action = ({ children, style }: ComponentBase) => (
+	<div className={classes.action} style={style}>
+		{children}
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/Card/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Card/index.module.scss
@@ -1,0 +1,11 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.card {
+	background-color: var(--gray-100);
+	border-radius: 1.5rem;
+	padding: 0.5rem;
+	box-shadow: var(--shadow-alt);
+	border: 1px solid var(--shade-200);
+	position: relative;
+}

--- a/packages/ui-core/src/input/SendForm/Card/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Card/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ComponentBase } from 'types'
+import classes from './index.module.scss'
+
+export const Card = ({ children, style }: ComponentBase) => (
+	<div className={classes.card} style={style}>
+		{children}
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/Container/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Container/index.module.scss
@@ -1,7 +1,8 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-export * from './AccountInput'
-export * from './SendForm'
-export * from './Switch'
-export * from './TokenInput'
+.container {
+	max-width: 600px;
+	margin: 0 auto;
+	width: 100%;
+}

--- a/packages/ui-core/src/input/SendForm/Container/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Container/index.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ComponentBase } from 'types'
+import classes from './index.module.scss'
+
+export const Container = ({ children, style }: ComponentBase) => (
+	<div className={classes.container} style={style}>
+		{children}
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/DirectionIndicator/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/DirectionIndicator/index.module.scss
@@ -1,0 +1,29 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.directionIndicator {
+	display: flex;
+	justify-content: center;
+	height: 0;
+	position: relative;
+	z-index: 8;
+	pointer-events: none;
+}
+
+.directionButton {
+	width: 2rem;
+	height: 2rem;
+	background-color: var(--gray-100);
+	border-radius: 9999px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--gray-600);
+	transform: translateY(-50%);
+	pointer-events: auto;
+}
+
+.directionIcon {
+	font-size: 1.25rem;
+	line-height: 1.8rem;
+}

--- a/packages/ui-core/src/input/SendForm/DirectionIndicator/index.tsx
+++ b/packages/ui-core/src/input/SendForm/DirectionIndicator/index.tsx
@@ -1,0 +1,14 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import classes from './index.module.scss'
+
+export const DirectionIndicator = () => (
+	<div className={classes.directionIndicator}>
+		<div className={classes.directionButton}>
+			<FontAwesomeIcon icon={faArrowDown} className={classes.directionIcon} />
+		</div>
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/Header/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Header/index.module.scss
@@ -1,0 +1,20 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.header {
+	margin-top: 5.5rem;
+	margin-bottom: 1.5rem;
+}
+
+.title {
+	font-family: "DM Serif Display", serif;
+	font-size: 2.5rem;
+	line-height: 2.8rem;
+}
+
+.subtitle {
+	font-size: 1.25rem;
+	line-height: 1.8rem;
+	color: var(--gray-700);
+	margin-top: 0.75rem;
+}

--- a/packages/ui-core/src/input/SendForm/Header/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Header/index.tsx
@@ -1,0 +1,16 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import classes from './index.module.scss'
+
+export type SendFormHeaderProps = {
+	title: string
+	subtitle: string
+}
+
+export const Header = ({ title, subtitle }: SendFormHeaderProps) => (
+	<header className={classes.header}>
+		<h1 className={classes.title}>{title}</h1>
+		<p className={classes.subtitle}>{subtitle}</p>
+	</header>
+)

--- a/packages/ui-core/src/input/SendForm/Label/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Label/index.module.scss
@@ -1,0 +1,15 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.label {
+	font-size: 1.1rem;
+	line-height: 1.4rem;
+	font-weight: 500;
+	color: var(--gray-700);
+}
+
+.value {
+	font-family: var(--font-family-mono);
+	color: var(--gray-1000);
+	font-weight: 700;
+}

--- a/packages/ui-core/src/input/SendForm/Label/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Label/index.tsx
@@ -1,0 +1,16 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ReactNode } from 'react'
+import classes from './index.module.scss'
+
+export type SendFormLabelProps = {
+	label: string
+	children: ReactNode
+}
+
+export const Label = ({ label, children }: SendFormLabelProps) => (
+	<span className={classes.label}>
+		{label}: <span className={classes.value}>{children}</span>
+	</span>
+)

--- a/packages/ui-core/src/input/SendForm/Notes/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Notes/index.module.scss
@@ -1,0 +1,35 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.notes {
+	padding: 1.25rem;
+
+	> * + * {
+		margin-top: 0.75rem;
+	}
+}
+
+.note {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 1.1rem;
+	line-height: 1.4rem;
+}
+
+.label {
+	color: var(--gray-700);
+	font-weight: 500;
+}
+
+.value {
+	font-weight: 500;
+}
+
+.defaultValue {
+	font-family: var(--font-family-mono);
+}
+
+.successValue {
+	color: var(--status-success);
+}

--- a/packages/ui-core/src/input/SendForm/Notes/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Notes/index.tsx
@@ -1,0 +1,38 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import classNames from 'classnames'
+import type { ReactNode } from 'react'
+import classes from './index.module.scss'
+
+export type SendFormNotesProps = {
+	children: ReactNode
+}
+
+export type SendFormNoteProps = {
+	label: string
+	children: ReactNode
+	variant?: 'default' | 'success'
+}
+
+export const Notes = ({ children }: SendFormNotesProps) => (
+	<div className={classes.notes}>{children}</div>
+)
+
+export const Note = ({
+	label,
+	children,
+	variant = 'default',
+}: SendFormNoteProps) => (
+	<div className={classes.note}>
+		<span className={classes.label}>{label}</span>
+		<span
+			className={classNames(classes.value, {
+				[classes.defaultValue]: variant === 'default',
+				[classes.successValue]: variant === 'success',
+			})}
+		>
+			{children}
+		</span>
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/Segment/index.module.scss
+++ b/packages/ui-core/src/input/SendForm/Segment/index.module.scss
@@ -1,0 +1,51 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.segment {
+	background-color: var(--gray-200);
+	border-radius: 1rem;
+	padding: 1.25rem;
+	margin-bottom: 0.25rem;
+	transition: background-color var(--transition-duration) ease;
+
+	&:hover {
+		background-color: var(--gray-300);
+	}
+}
+
+.raisedLayer {
+	position: relative;
+	z-index: 1;
+}
+
+.topLayer {
+	position: relative;
+	z-index: 6;
+}
+
+.titleRow {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 1rem;
+}
+
+.title {
+	font-size: 1.1rem;
+	line-height: 1.4rem;
+	font-weight: 700;
+	color: var(--gray-700);
+	text-transform: uppercase;
+}
+
+.responsiveTitleRow {
+	margin-bottom: 0.75rem;
+}
+
+@media (width <= 560px) {
+	.responsiveTitleRow {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+}

--- a/packages/ui-core/src/input/SendForm/Segment/index.tsx
+++ b/packages/ui-core/src/input/SendForm/Segment/index.tsx
@@ -1,0 +1,39 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import classNames from 'classnames'
+import type { ReactNode } from 'react'
+import classes from './index.module.scss'
+
+export type SendFormSegmentProps = {
+	title: string
+	children: ReactNode
+	headerContent?: ReactNode
+	layer?: 'default' | 'raised' | 'top'
+	responsiveHeader?: boolean
+}
+
+export const Segment = ({
+	title,
+	children,
+	headerContent,
+	layer = 'default',
+	responsiveHeader = false,
+}: SendFormSegmentProps) => (
+	<div
+		className={classNames(classes.segment, {
+			[classes.raisedLayer]: layer === 'raised',
+			[classes.topLayer]: layer === 'top',
+		})}
+	>
+		<div
+			className={classNames(classes.titleRow, {
+				[classes.responsiveTitleRow]: responsiveHeader,
+			})}
+		>
+			<span className={classes.title}>{title}</span>
+			{headerContent}
+		</div>
+		{children}
+	</div>
+)

--- a/packages/ui-core/src/input/SendForm/index.tsx
+++ b/packages/ui-core/src/input/SendForm/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Action } from './Action'
+import { Card } from './Card'
+import { Container } from './Container'
+import { DirectionIndicator } from './DirectionIndicator'
+import { Header } from './Header'
+import { Label } from './Label'
+import { Note, Notes } from './Notes'
+import { Segment } from './Segment'
+
+export const SendForm = {
+	Action,
+	Card,
+	Container,
+	DirectionIndicator,
+	Header,
+	Label,
+	Note,
+	Notes,
+	Segment,
+}

--- a/packages/ui-core/src/popover/MenuItem/index.module.scss
+++ b/packages/ui-core/src/popover/MenuItem/index.module.scss
@@ -4,6 +4,7 @@
 @use "ui-styles/theme/variables" as *;
 
 $button-padding: 1.3rem 1rem 1.2rem 1rem;
+$button-padding-sm: 1rem;
 
 .menuItem {
 	border-bottom: 1px solid var(--gray-500);
@@ -20,6 +21,10 @@ $button-padding: 1.3rem 1rem 1.2rem 1rem;
 		border-bottom-left-radius: $popover-border-radius;
 		border-bottom-right-radius: $popover-border-radius;
 		border: none;
+	}
+
+	&.padded {
+		padding: $button-padding-sm;
 	}
 
 	> div,

--- a/packages/ui-core/src/popover/MenuItem/index.tsx
+++ b/packages/ui-core/src/popover/MenuItem/index.tsx
@@ -6,8 +6,16 @@ import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react'
 import type { ComponentBaseWithClassName } from 'types'
 import classes from './index.module.scss'
 
-export const MenuItem = ({ children }: { children: ReactNode }) => {
-	const allClasses = classNames(classes.menuItem)
+export const MenuItem = ({
+	children,
+	padded,
+}: {
+	children: ReactNode
+	padded?: boolean
+}) => {
+	const allClasses = classNames(classes.menuItem, {
+		[classes.padded]: padded,
+	})
 
 	return <div className={allClasses}>{children}</div>
 }


### PR DESCRIPTION
This PR expands the shared UI library with new building blocks to support an upcoming “stablecoins” app flow, adding a `SendForm` component set in `ui-core` and introducing a reusable `Dropdown` in `ui-app`, plus a small enhancement to the popover `MenuItem`.

**Changes:**
- Add a new `SendForm` component namespace (Header/Card/Segment/Notes/etc.) and export it from `ui-core` inputs.
- Add a new `Dropdown` component and supporting types in `ui-app`.
- Extend `MenuItem` with an optional `padded` presentation variant.