### PR TITLE
feat(refactor): Add `network` to transaction UIDs

### DIFF
--- a/packages/global-bus/src/txSubmit/index.ts
+++ b/packages/global-bus/src/txSubmit/index.ts
@@ -12,7 +12,15 @@ export let subs: Record<number, Unsub> = {}
 export const getUid = (id: number) =>
 	_uids.getValue().find((item) => item.uid === id)
 
-export const addUid = ({ from, tag }: { from: MaybeAddress; tag?: string }) => {
+export const addUid = ({
+	network,
+	from,
+	tag,
+}: {
+	network: string
+	from: MaybeAddress
+	tag?: string
+}) => {
 	let newUids = [..._uids.getValue()]
 	// Ensure uid is unique
 	const newUid = newUids.length + 1
@@ -22,6 +30,7 @@ export const addUid = ({ from, tag }: { from: MaybeAddress; tag?: string }) => {
 	}
 	newUids.push({
 		uid: newUid,
+		network,
 		submitted: false,
 		pending: false,
 		from,

--- a/packages/tx-submit/src/useSubmitExtrinsic/index.tsx
+++ b/packages/tx-submit/src/useSubmitExtrinsic/index.tsx
@@ -398,7 +398,11 @@ export const useSubmitExtrinsic = ({
 	useEffect(() => {
 		// Add a new uid for this transaction
 		if (uid === 0) {
-			const newUid = addUid({ from: submitAccount?.address || null, tag })
+			const newUid = addUid({
+				network,
+				from: submitAccount?.address || null,
+				tag,
+			})
 			setUid(newUid)
 		}
 	}, [])

--- a/packages/types/src/tx.ts
+++ b/packages/types/src/tx.ts
@@ -7,6 +7,7 @@ import type { DisplayFor } from './overlay'
 
 export type TxSubmissionItem = {
 	uid: number
+	network: string
 	tag?: string
 	fee: bigint
 	from: MaybeAddress


### PR DESCRIPTION
This PR extends transaction-submission metadata so each tracked transaction UID is associated with a specific network, enabling network-aware handling of transaction submissions across the app.

**Changes:**
- Add `network` to the `TxSubmissionItem` type.
- Pass `network` when creating new transaction UIDs in `useSubmitExtrinsic`.
- Extend `addUid` to accept and store the `network` value in the global tx submission store.
