### PR TITLE
feat: Support DOT transfers in `SendForm`

### DIFF
--- a/packages/app-stablecoins/src/Router.tsx
+++ b/packages/app-stablecoins/src/Router.tsx
@@ -44,6 +44,7 @@ export const Router = () => (
 							plugins: false,
 							docs: false,
 							syncAccounts: false,
+							sendModal: false,
 						}}
 					/>
 					<ErrorBoundary FallbackComponent={ErrorFallbackRoutes}>

--- a/packages/app-stablecoins/src/library/Balances/BalancesPopover/index.tsx
+++ b/packages/app-stablecoins/src/library/Balances/BalancesPopover/index.tsx
@@ -11,10 +11,11 @@ import {
 	StablecoinChains,
 	StablecoinSymbols,
 } from 'consts/stablecoins'
-import { useStablecoinBalances } from 'hooks'
+import { useStablecoinBalances, useTokenPrices } from 'hooks'
 import type { Dispatch, SetStateAction } from 'react'
 import { Fragment, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { StablecoinChainId } from 'types'
 import { PopoverTab } from 'ui-buttons'
 import { Loader } from 'ui-core/base'
 import {
@@ -40,6 +41,7 @@ export const BalancesPopover = ({
 }) => {
 	const { t } = useTranslation('stablecoins')
 	const { activeAddress } = useActiveAccount()
+	const { price: dotPrice } = useTokenPrices()
 	const {
 		getBalanceUnit,
 		getStablecoinShare,
@@ -48,6 +50,19 @@ export const BalancesPopover = ({
 	} = useStablecoinBalances(activeAddress)
 	const popoverRef = useRef<HTMLDivElement>(null)
 	const [activeTab, setActiveTab] = useState<'mix' | 'balances'>('balances')
+	const stablecoinTotal = getStablecoinTotal()
+	const dotTotal = StablecoinChains.reduce(
+		(total, chain) => total.plus(getBalanceUnit(chain, 'DOT')),
+		stablecoinTotal.multipliedBy(0),
+	)
+	const getDotTotal = (chain?: StablecoinChainId) =>
+		chain ? getBalanceUnit(chain, 'DOT') : dotTotal
+	const getTotalBalance = (chain?: StablecoinChainId) =>
+		(chain ? getStablecoinTotal({ chain }) : stablecoinTotal).plus(
+			getDotTotal(chain).multipliedBy(dotPrice),
+		)
+	const isTotalBalanceUnavailable = (chain?: StablecoinChainId) =>
+		!getDotTotal(chain).isZero() && dotPrice === 0
 	const stablecoinMix = StablecoinSymbols.map((symbol) => ({
 		share: getStablecoinShare({ symbol }),
 		symbol,
@@ -144,8 +159,10 @@ export const BalancesPopover = ({
 						value={
 							syncing ? (
 								<BalancePreloader height="1.5rem" width="7.5rem" />
+							) : isTotalBalanceUnavailable() ? (
+								<>&mdash;</>
 							) : (
-								`$${getStablecoinTotal().toFormat(2)}`
+								`$${getTotalBalance().toFormat(2)}`
 							)
 						}
 					/>
@@ -160,31 +177,31 @@ export const BalancesPopover = ({
 										<div>
 											{syncing ? (
 												<BalancePreloader width="7rem" />
+											) : isTotalBalanceUnavailable(chain) ? (
+												<h4>&mdash;</h4>
 											) : (
-												<h4>${getStablecoinTotal({ chain }).toFormat(2)}</h4>
+												<h4>${getTotalBalance(chain).toFormat(2)}</h4>
 											)}
 										</div>
 									</div>
 								</MenuItem>
-								{getStablecoinFeeAssets(chain)
-									.filter((symbol) => symbol !== 'DOT')
-									.map((symbol) => (
-										<MenuItem key={`${chain}-${symbol}`} padded>
+								{getStablecoinFeeAssets(chain).map((symbol) => (
+									<MenuItem key={`${chain}-${symbol}`} padded>
+										<div>
+											<img src={getFeeTokenIcon(symbol)} alt="" />
+										</div>
+										<div>
+											<h3>{symbol}</h3>
 											<div>
-												<img src={getFeeTokenIcon(symbol)} alt="" />
+												{syncing ? (
+													<BalancePreloader />
+												) : (
+													<h4>{getBalanceUnit(chain, symbol).toFormat(2)}</h4>
+												)}
 											</div>
-											<div>
-												<h3>{symbol}</h3>
-												<div>
-													{syncing ? (
-														<BalancePreloader />
-													) : (
-														<h4>{getBalanceUnit(chain, symbol).toFormat(2)}</h4>
-													)}
-												</div>
-											</div>
-										</MenuItem>
-									))}
+										</div>
+									</MenuItem>
+								))}
 							</Fragment>
 						))}
 					</ConnectItem.Container>

--- a/packages/app-stablecoins/src/pages/Send/components/SendForm.tsx
+++ b/packages/app-stablecoins/src/pages/Send/components/SendForm.tsx
@@ -23,7 +23,7 @@ export const SendForm = ({
 			<SendFormUi.Container>
 				<SendFormUi.Header
 					title={t('sendAssets')}
-					subtitle={t('transferStablecoinsDescription')}
+					subtitle={t('transferAssetsDescription')}
 				/>
 				<SendFormUi.Card>
 					<SendFormUi.Segment title={t('chain')} layer="top">

--- a/packages/app-stablecoins/src/pages/Send/hooks/types.ts
+++ b/packages/app-stablecoins/src/pages/Send/hooks/types.ts
@@ -7,10 +7,10 @@ import type { TxFeeEstimator, UseSubmitExtrinsic } from 'tx-submit/types'
 import type {
 	FeeAssetSymbol,
 	ImportedAccount,
+	SendAssetSymbol,
 	ServiceInterface,
 	StablecoinBalance,
 	StablecoinChainId,
-	StablecoinSymbol,
 	TxFeeDisplay,
 } from 'types'
 import type { DropdownOption } from 'ui-app/Dropdown'
@@ -28,26 +28,26 @@ export type SendSelectionState = {
 	amount: string
 	chain: StablecoinChainId
 	feeAsset: FeeAssetSymbol
-	token: StablecoinSymbol
+	token: SendAssetSymbol
 }
 
 export type SendSelectionAction =
 	| { type: 'setAmount'; amount: string }
 	| { type: 'selectChain'; chain: StablecoinChainId }
 	| { type: 'selectFeeAsset'; feeAsset: FeeAssetSymbol }
-	| { type: 'selectToken'; token: StablecoinSymbol }
+	| { type: 'selectToken'; token: SendAssetSymbol }
 
 export type SendSelection = SendSelectionState & {
 	availableFeeAssetOptions: DropdownOption<FeeAssetSymbol>[]
 	chainOptions: DropdownOption<StablecoinChainId>[]
 	selectedChain: DropdownOption<StablecoinChainId>
 	selectedFeeAsset: DropdownOption<FeeAssetSymbol>
-	selectedToken: DropdownOption<StablecoinSymbol>
+	selectedToken: DropdownOption<SendAssetSymbol>
 	setAmount: (amount: string) => void
 	setSelectedChain: (option: DropdownOption<StablecoinChainId>) => void
 	setSelectedFeeAsset: (option: DropdownOption<FeeAssetSymbol>) => void
-	setSelectedToken: (option: DropdownOption<StablecoinSymbol>) => void
-	tokenOptions: DropdownOption<StablecoinSymbol>[]
+	setSelectedToken: (option: DropdownOption<SendAssetSymbol>) => void
+	tokenOptions: DropdownOption<SendAssetSymbol>[]
 }
 
 export type FeeCurrencyStatus = 'error' | 'idle' | 'loading' | 'ready'
@@ -92,7 +92,7 @@ export type UseSendTransactionProps = {
 	feeAsset: FeeAssetSymbol
 	fromAccount: ImportedAccount | null
 	toAccount: ImportedAccount | null
-	token: StablecoinSymbol
+	token: SendAssetSymbol
 }
 
 export type SendTransaction = {

--- a/packages/app-stablecoins/src/pages/Send/hooks/useSendSelection.ts
+++ b/packages/app-stablecoins/src/pages/Send/hooks/useSendSelection.ts
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import {
+	isAssetSendSupported,
 	isStablecoinFeeAssetSupported,
-	isStablecoinSendAssetSupported,
 } from 'consts/stablecoins'
 import { useMemo, useReducer } from 'react'
 import {
+	assetOptions,
 	chainOptions,
 	feeAssetOptions,
 	findOption,
 	getFeeAssetOptions,
 	getTokenOptions,
-	stablecoinOptions,
 } from '../options'
 import type {
 	SendSelection,
@@ -36,7 +36,7 @@ const reducer = (
 		case 'setAmount':
 			return { ...state, amount: action.amount }
 		case 'selectChain': {
-			const token = isStablecoinSendAssetSupported(action.chain, state.token)
+			const token = isAssetSendSupported(action.chain, state.token)
 				? state.token
 				: getTokenOptions(action.chain)[0]?.value || state.token
 			const feeAsset = isStablecoinFeeAssetSupported(
@@ -72,7 +72,7 @@ export const useSendSelection = (): SendSelection => {
 		chainOptions,
 		selectedChain: findOption(chainOptions, state.chain),
 		selectedFeeAsset: findOption(feeAssetOptions, state.feeAsset),
-		selectedToken: findOption(stablecoinOptions, state.token),
+		selectedToken: findOption(assetOptions, state.token),
 		setAmount: (amount: string) => dispatch({ type: 'setAmount', amount }),
 		setSelectedChain: (option) =>
 			dispatch({ type: 'selectChain', chain: option.value }),

--- a/packages/app-stablecoins/src/pages/Send/hooks/useSendTransaction.ts
+++ b/packages/app-stablecoins/src/pages/Send/hooks/useSendTransaction.ts
@@ -3,7 +3,7 @@
 
 import {
 	getStablecoinAssetConfig,
-	isStablecoinSendAssetSupported,
+	isAssetSendSupported,
 } from 'consts/stablecoins'
 import { useApi, useStablecoinBalances, useTxMeta } from 'hooks'
 import { useEffect, useMemo, useState } from 'react'
@@ -77,7 +77,7 @@ export const useSendTransaction = ({
 	const transferKey =
 		toAccount?.address &&
 		amountPlanck > 0n &&
-		isStablecoinSendAssetSupported(chain, token)
+		isAssetSendSupported(chain, token)
 			? `${chain}:${token}:${toAccount.address}:${amountPlanck}`
 			: null
 

--- a/packages/app-stablecoins/src/pages/Send/options.ts
+++ b/packages/app-stablecoins/src/pages/Send/options.ts
@@ -5,16 +5,16 @@ import {
 	FeeAssetSymbols,
 	getFeeTokenIcon,
 	getStablecoinChainLabel,
+	isAssetSendSupported,
 	isStablecoinFeeAssetSupported,
-	isStablecoinSendAssetSupported,
+	SendAssetSymbols,
 	StablecoinChains,
-	StablecoinSymbols,
 } from 'consts/stablecoins'
-import type { FeeAssetSymbol, StablecoinChainId, StablecoinSymbol } from 'types'
+import type { FeeAssetSymbol, SendAssetSymbol, StablecoinChainId } from 'types'
 import type { DropdownOption } from 'ui-app/Dropdown'
 
-export const stablecoinOptions: DropdownOption<StablecoinSymbol>[] =
-	StablecoinSymbols.map((symbol) => ({
+export const assetOptions: DropdownOption<SendAssetSymbol>[] =
+	SendAssetSymbols.map((symbol) => ({
 		value: symbol,
 		label: symbol,
 		icon: getFeeTokenIcon(symbol),
@@ -34,9 +34,7 @@ export const chainOptions: DropdownOption<StablecoinChainId>[] =
 	}))
 
 export const getTokenOptions = (chain: StablecoinChainId) =>
-	stablecoinOptions.filter((option) =>
-		isStablecoinSendAssetSupported(chain, option.value),
-	)
+	assetOptions.filter((option) => isAssetSendSupported(chain, option.value))
 
 export const getFeeAssetOptions = (chain: StablecoinChainId) =>
 	feeAssetOptions.filter((option) =>

--- a/packages/app-stablecoins/src/pages/Send/utils.ts
+++ b/packages/app-stablecoins/src/pages/Send/utils.ts
@@ -44,7 +44,11 @@ export const maxSendableBalance = (
 
 	const feeFromSameAsset =
 		feeBalance?.chain === balance.chain && feeBalance.symbol === balance.symbol
-	const reserved = balance.existentialDeposit + (feeFromSameAsset ? fee : 0n)
+	const balanceFloor =
+		balance.frozen > balance.existentialDeposit
+			? balance.frozen
+			: balance.existentialDeposit
+	const reserved = balanceFloor + (feeFromSameAsset ? fee : 0n)
 	const max = balance.free - reserved
 	return max > 0n ? max : 0n
 }

--- a/packages/consts/src/stablecoins.ts
+++ b/packages/consts/src/stablecoins.ts
@@ -9,6 +9,7 @@ import type {
 	AssetMetadata,
 	ChainAssetConfigs,
 	FeeAssetSymbol,
+	SendAssetSymbol,
 	StablecoinChainConfig,
 	StablecoinChainId,
 	StablecoinSymbol,
@@ -38,6 +39,9 @@ export const FeeAssetSymbols = Object.keys(FeeTokenMetadata) as FeeAssetSymbol[]
 export const StablecoinSymbols = FeeAssetSymbols.filter(
 	(symbol): symbol is StablecoinSymbol => symbol !== 'DOT',
 )
+
+// All assets that can be sent from the Asset Send form.
+export const SendAssetSymbols: SendAssetSymbol[] = [...StablecoinSymbols, 'DOT']
 
 // Merges shared fee-token metadata into chain-specific asset configuration.
 const withFeeTokenMetadata = (
@@ -123,10 +127,10 @@ export const getStablecoinFeeAssets = (
 ): FeeAssetSymbol[] =>
 	Object.keys(StablecoinConfigs[chain].assets) as FeeAssetSymbol[]
 
-// Checks whether a stablecoin can be sent on a chain.
-export const isStablecoinSendAssetSupported = (
+// Checks whether an asset can be sent on a chain.
+export const isAssetSendSupported = (
 	chain: StablecoinChainId,
-	symbol: StablecoinSymbol,
+	symbol: SendAssetSymbol,
 ) => !!getStablecoinAssetConfig(chain, symbol)
 
 // Checks whether an asset can pay transaction fees on a chain.

--- a/packages/dedot-api/src/stablecoins/assetHub.ts
+++ b/packages/dedot-api/src/stablecoins/assetHub.ts
@@ -74,6 +74,10 @@ export const createAssetHubStablecoinAdapter = (
 		}
 	},
 	transfer: async ({ symbol, recipient, amount }) => {
+		if (symbol === 'DOT') {
+			return asTx(api.tx.balances.transferKeepAlive(recipient, amount))
+		}
+
 		const config = getStablecoinAssetConfig('statemint', symbol)
 		if (config?.assetId === undefined) {
 			return undefined

--- a/packages/dedot-api/src/stablecoins/shared.ts
+++ b/packages/dedot-api/src/stablecoins/shared.ts
@@ -5,10 +5,10 @@ import { getStablecoinAssetConfig } from 'consts/stablecoins'
 import type { SubmittableExtrinsic } from 'dedot'
 import type { PayloadOptions } from 'dedot/types'
 import type {
+	AssetTransferInput,
 	FeeAssetSymbol,
 	StablecoinBalance,
 	StablecoinFeeEstimateInput,
-	StablecoinTransferInput,
 } from 'types'
 
 // Minimal free/frozen balance shape shared by all stablecoin balance sources.
@@ -25,7 +25,7 @@ export type StablecoinAdapter = {
 		symbol: FeeAssetSymbol,
 	) => Promise<StablecoinBalance | undefined>
 	transfer: (
-		input: StablecoinTransferInput,
+		input: AssetTransferInput,
 	) => Promise<SubmittableExtrinsic | undefined>
 	paymentOptions: (symbol: FeeAssetSymbol) => PayloadOptions | undefined
 	estimateFee: (input: StablecoinFeeEstimateInput) => Promise<bigint>

--- a/packages/locales/src/resources/de/stablecoins.json
+++ b/packages/locales/src/resources/de/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Stablecoin-Mix",
 		"syncingBalances": "Guthaben werden synchronisiert",
 		"total": "Gesamt",
-		"transferStablecoinsDescription": "Stablecoins an eine andere Adresse im selben Netzwerk übertragen."
+		"transferAssetsDescription": "Assets an eine andere Adresse im selben Netzwerk übertragen."
 	}
 }

--- a/packages/locales/src/resources/en/stablecoins.json
+++ b/packages/locales/src/resources/en/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Stablecoin Mix",
 		"syncingBalances": "Syncing balances",
 		"total": "Total",
-		"transferStablecoinsDescription": "Transfer stablecoins to another address on the same network."
+		"transferAssetsDescription": "Transfer assets to another address on the same network."
 	}
 }

--- a/packages/locales/src/resources/es/stablecoins.json
+++ b/packages/locales/src/resources/es/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Composición de stablecoins",
 		"syncingBalances": "Sincronizando saldos",
 		"total": "Total",
-		"transferStablecoinsDescription": "Transfiere stablecoins a otra dirección en la misma red."
+		"transferAssetsDescription": "Transfiere activos a otra dirección en la misma red."
 	}
 }

--- a/packages/locales/src/resources/fr/stablecoins.json
+++ b/packages/locales/src/resources/fr/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Répartition des stablecoins",
 		"syncingBalances": "Synchronisation des soldes",
 		"total": "Total",
-		"transferStablecoinsDescription": "Transférez des stablecoins vers une autre adresse sur le même réseau."
+		"transferAssetsDescription": "Transférez des actifs vers une autre adresse sur le même réseau."
 	}
 }

--- a/packages/locales/src/resources/ko/stablecoins.json
+++ b/packages/locales/src/resources/ko/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "스테이블코인 구성",
 		"syncingBalances": "잔액 동기화 중",
 		"total": "합계",
-		"transferStablecoinsDescription": "동일 네트워크의 다른 주소로 스테이블코인을 전송하세요."
+		"transferAssetsDescription": "동일 네트워크의 다른 주소로 자산을 전송하세요."
 	}
 }

--- a/packages/locales/src/resources/pt/stablecoins.json
+++ b/packages/locales/src/resources/pt/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Composição de stablecoins",
 		"syncingBalances": "Sincronizando saldos",
 		"total": "Total",
-		"transferStablecoinsDescription": "Transfira stablecoins para outro endereço na mesma rede."
+		"transferAssetsDescription": "Transfira ativos para outro endereço na mesma rede."
 	}
 }

--- a/packages/locales/src/resources/tr/stablecoins.json
+++ b/packages/locales/src/resources/tr/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "Stablecoin Dağılımı",
 		"syncingBalances": "Bakiyeler eşitleniyor",
 		"total": "Toplam",
-		"transferStablecoinsDescription": "Stablecoin'leri aynı ağdaki başka bir adrese aktarın."
+		"transferAssetsDescription": "Varlıkları aynı ağdaki başka bir adrese aktarın."
 	}
 }

--- a/packages/locales/src/resources/zh/stablecoins.json
+++ b/packages/locales/src/resources/zh/stablecoins.json
@@ -20,6 +20,6 @@
 		"stablecoinMix": "稳定币配比",
 		"syncingBalances": "正在同步余额",
 		"total": "总计",
-		"transferStablecoinsDescription": "将稳定币转账到同一网络中的其他地址。"
+		"transferAssetsDescription": "将资产转账到同一网络中的其他地址。"
 	}
 }

--- a/packages/tests/src/assetSend.test.ts
+++ b/packages/tests/src/assetSend.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { StablecoinBalance } from 'types'
+import { describe, expect, test } from 'vitest'
+import { maxSendableBalance } from '../../app-stablecoins/src/pages/Send/utils'
+
+const dotBalance: StablecoinBalance = {
+	chain: 'statemint',
+	symbol: 'DOT',
+	free: 1_000n,
+	frozen: 0n,
+	existentialDeposit: 100n,
+	decimals: 10,
+}
+
+describe('Asset Send maximum balance', () => {
+	test('deducts the transaction fee when DOT pays for a DOT transfer', () => {
+		expect(maxSendableBalance(dotBalance, dotBalance, 25n)).toBe(875n)
+	})
+
+	test('does not deduct a fee paid from a different asset', () => {
+		const feeBalance: StablecoinBalance = {
+			...dotBalance,
+			symbol: 'USDC',
+		}
+
+		expect(maxSendableBalance(dotBalance, feeBalance, 25n)).toBe(900n)
+	})
+
+	test('keeps frozen funds out of the available amount', () => {
+		const frozenBalance = { ...dotBalance, frozen: 400n }
+
+		expect(maxSendableBalance(frozenBalance, frozenBalance, 25n)).toBe(575n)
+	})
+
+	test('never returns a negative maximum', () => {
+		expect(maxSendableBalance(dotBalance, dotBalance, 1_000n)).toBe(0n)
+	})
+})

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -19,11 +19,11 @@ import type { IdentityOf, SuperOf } from './identity'
 import type { NominatorsMultiQuery } from './nominate'
 import type { BondedPoolQuery, ClaimPermission, PoolRoles } from './pools'
 import type {
+	AssetTransferInput,
 	FeeAssetSymbol,
 	StablecoinBalance,
 	StablecoinChainId,
 	StablecoinFeeEstimateInput,
-	StablecoinTransferInput,
 } from './stablecoins'
 import type {
 	ErasStakersOverviewEntries,
@@ -45,7 +45,7 @@ export interface ServiceInterface {
 		}
 		tx: {
 			transfer: (
-				input: StablecoinTransferInput,
+				input: AssetTransferInput,
 			) => Promise<SubmittableExtrinsic | undefined>
 			setHydrationFeeCurrency: (
 				symbol: FeeAssetSymbol,

--- a/packages/types/src/stablecoins.ts
+++ b/packages/types/src/stablecoins.ts
@@ -10,6 +10,8 @@ export type StablecoinSymbol = 'USDC' | 'USDT' | 'HOLLAR'
 
 export type FeeAssetSymbol = 'DOT' | StablecoinSymbol
 
+export type SendAssetSymbol = FeeAssetSymbol
+
 export type AssetMetadata = Pick<StablecoinAssetConfig, 'color' | 'decimals'>
 
 export type ChainAssetConfigs = Partial<
@@ -38,12 +40,15 @@ export type StablecoinBalance = {
 	decimals: number
 }
 
-export type StablecoinTransferInput = {
+export type AssetTransferInput = {
 	chain: StablecoinChainId
-	symbol: StablecoinSymbol
+	symbol: SendAssetSymbol
 	recipient: string
 	amount: bigint
 }
+
+// Retained for consumers of the original stablecoin service API.
+export type StablecoinTransferInput = AssetTransferInput
 
 export type StablecoinFeePayment = {
 	chain: StablecoinChainId

--- a/packages/ui-app/src/Headers/Account.tsx
+++ b/packages/ui-app/src/Headers/Account.tsx
@@ -11,8 +11,12 @@ import { Popover } from 'ui-core/popover'
 import { useOverlay } from 'ui-overlay'
 import { AccountPopover } from './Popovers/AccountPopover'
 import type { ToggleConnectProps } from './Popovers/types'
+import type { MenuPopoverFeatureFlags } from './types'
 
-export const Account = ({ setOpenConnect }: ToggleConnectProps) => {
+export const Account = ({
+	setOpenConnect,
+	sendModal = true,
+}: ToggleConnectProps & Pick<MenuPopoverFeatureFlags, 'sendModal'>) => {
 	const { t } = useTranslation('app')
 	const { themeElementRef } = useTheme()
 	const { activeProxy } = useActiveProxy()
@@ -39,7 +43,7 @@ export const Account = ({ setOpenConnect }: ToggleConnectProps) => {
 		<Popover
 			open={open}
 			portalContainer={themeElementRef.current || undefined}
-			content={<AccountPopover setOpen={setOpen} />}
+			content={<AccountPopover setOpen={setOpen} sendModal={sendModal} />}
 			onTriggerClick={() => {
 				if (!totalImportedAccounts) {
 					return

--- a/packages/ui-app/src/Headers/Popovers/AccountPopover/index.tsx
+++ b/packages/ui-app/src/Headers/Popovers/AccountPopover/index.tsx
@@ -25,8 +25,10 @@ import classes from './index.module.scss'
 
 export const AccountPopover = ({
 	setOpen,
+	sendModal,
 }: {
 	setOpen: Dispatch<SetStateAction<boolean>>
+	sendModal: boolean
 }) => {
 	const { t } = useTranslation()
 	const { network } = useNetwork()
@@ -60,23 +62,25 @@ export const AccountPopover = ({
 				/>
 			)}
 
-			<MenuItemButton
-				style={{ border: 'none' }}
-				onClick={() => {
-					setOpen(false)
-					openModal({ key: 'Transfer', size: 'sm' })
-				}}
-			>
-				<div>
-					<FontAwesomeIcon icon={faPaperPlane} transform="shrink-2" />
-				</div>
-				<div>
-					<h3>{t('send', { ns: 'app' })}</h3>
+			{sendModal && (
+				<MenuItemButton
+					style={{ border: 'none' }}
+					onClick={() => {
+						setOpen(false)
+						openModal({ key: 'Transfer', size: 'sm' })
+					}}
+				>
 					<div>
-						<FontAwesomeIcon icon={faChevronRight} transform="shrink-3" />
+						<FontAwesomeIcon icon={faPaperPlane} transform="shrink-2" />
 					</div>
-				</div>
-			</MenuItemButton>
+					<div>
+						<h3>{t('send', { ns: 'app' })}</h3>
+						<div>
+							<FontAwesomeIcon icon={faChevronRight} transform="shrink-3" />
+						</div>
+					</div>
+				</MenuItemButton>
+			)}
 
 			<ConnectItem.Container>
 				<h4>Account Details</h4>

--- a/packages/ui-app/src/Headers/index.tsx
+++ b/packages/ui-app/src/Headers/index.tsx
@@ -31,7 +31,11 @@ export const Headers = ({
 				{Object.entries(NodesLeft || {}).map(([key, Component]) => (
 					<Component key={key} />
 				))}
-				<Account openConnect={openConnect} setOpenConnect={setOpenConnect} />
+				<Account
+					openConnect={openConnect}
+					setOpenConnect={setOpenConnect}
+					sendModal={menuPopoverFeatures?.sendModal}
+				/>
 				{Object.entries(NodesRight || {}).map(([key, Component]) => (
 					<Component key={key} />
 				))}

--- a/packages/ui-app/src/Headers/types.ts
+++ b/packages/ui-app/src/Headers/types.ts
@@ -10,6 +10,7 @@ export interface MenuPopoverFeatureFlags {
 	plugins?: boolean
 	docs?: boolean
 	syncAccounts?: boolean
+	sendModal?: boolean
 }
 
 export interface HeadersProps {


### PR DESCRIPTION
This PR extends the existing “stablecoins send” flow to support sending native DOT alongside stablecoins, updating the related type surface, options/filtering logic, and UI copy so the Send form and balance displays are asset-agnostic.

**Changes:**
- Expand sendable-asset support to include `DOT` (types, constants, option filtering, and adapter transfer handling).
- Update Send form UX/text from “stablecoins” to “assets”, and adjust maximum-sendable logic to respect frozen funds.
- Add a Vitest test suite covering `maxSendableBalance` behavior (fee deduction, frozen funds, non-negative cap).
