### PR TITLE
feat: Add simple analytics vite plugin to apps, rm `SAEnabled` flag

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,36 +5,10 @@ on:
     branches: [main]
 
 jobs:
-  merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: gh-deploy
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.1.0
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Merge
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          from_branch: main
-          target_branch: gh-deploy
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     runs-on: ubuntu-latest
-    needs: merge
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: gh-deploy
       - uses: pnpm/action-setup@v6
         with:
           version: 11.1.0

--- a/packages/app-staking/vite.config.ts
+++ b/packages/app-staking/vite.config.ts
@@ -5,13 +5,14 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins } from 'vite-shared'
+import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
 
 // https://vitejs.dev/config/
 // - `BASE_URL`env variable is used in the codebase to refer to the supplied base.
 export default defineConfig({
 	plugins: [
 		...sharedFaviconPlugins(),
+		simpleAnalyticsPlugin(),
 		react(),
 		svgr(),
 		checker({

--- a/packages/app-swap/vite.config.ts
+++ b/packages/app-swap/vite.config.ts
@@ -5,11 +5,12 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins } from 'vite-shared'
+import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
 
 export default defineConfig({
 	plugins: [
 		...sharedFaviconPlugins(),
+		simpleAnalyticsPlugin(),
 		react(),
 		svgr(),
 		checker({

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -21,9 +21,6 @@ export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'
 export const AssetHubPolkadotSubscanURL = 'https://assethub-polkadot.subscan.io'
 export const ManualSigners = ['ledger', 'vault', 'wallet_connect']
 
-// Analytics
-export const SAEnabled = false
-
 // Element Thresholds
 export const SideMenuHiddenWidth = 250
 export const SideMenuMaximisedWidth = 145

--- a/packages/event-tracking/src/util.ts
+++ b/packages/event-tracking/src/util.ts
@@ -1,17 +1,15 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { SAEnabled } from 'consts'
+type SimpleAnalyticsWindow = Window & {
+	sa_event?: (event: string, attributes: unknown) => void
+}
 
 // Utility to register a simple event with SA
-export const onSaEvent = (e: string, a: unknown = {}) => {
-	if (!SAEnabled) return
+export const onSaEvent = (event: string, attributes: unknown = {}) => {
 	try {
-		// biome-ignore lint/suspicious/noExplicitAny: <need `sa_event` in `window`>
-		const w = window as any
-		if (w.sa_event) {
-			w.sa_event(e, a)
-		}
+		const { sa_event: sendEvent } = window as SimpleAnalyticsWindow
+		sendEvent?.(event, attributes)
 	} catch {
 		// SA not supported. Do nothing
 	}

--- a/packages/vite-shared/src/index.ts
+++ b/packages/vite-shared/src/index.ts
@@ -76,3 +76,40 @@ export const sharedFaviconPlugins = (): Plugin[] => [
 	serveSharedFavicons(),
 	buildSharedFavicons(),
 ]
+
+export const simpleAnalyticsPlugin = (): Plugin => ({
+	name: 'simple-analytics',
+	apply: (_, { command, mode }) => command === 'build' && mode === 'production',
+	transformIndexHtml() {
+		return [
+			{
+				tag: 'script',
+				children: `window.sa_event =
+  window.sa_event ||
+  ((...args) => {
+    if (window.sa_event.q) {
+      window.sa_event.q.push(args)
+    } else {
+      window.sa_event.q = [args]
+    }
+  })`,
+				injectTo: 'head',
+			},
+			{
+				tag: 'script',
+				attrs: {
+					async: true,
+					defer: true,
+					src: 'https://apisa.polkadot.cloud/latest.js',
+				},
+				injectTo: 'body',
+			},
+			{
+				tag: 'noscript',
+				children:
+					'<img src="https://apisa.polkadot.cloud/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" />',
+				injectTo: 'body',
+			},
+		]
+	},
+})

--- a/packages/vite-shared/src/index.ts
+++ b/packages/vite-shared/src/index.ts
@@ -98,8 +98,8 @@ export const simpleAnalyticsPlugin = (): Plugin => ({
 			{
 				tag: 'script',
 				attrs: {
-					async: true,
 					defer: true,
+					referrerpolicy: 'no-referrer-when-downgrade',
 					src: 'https://apisa.polkadot.cloud/latest.js',
 				},
 				injectTo: 'body',


### PR DESCRIPTION
This PR introduces a shared Vite plugin to inject Simple Analytics into production builds of the apps, and removes the previously hardcoded `SAEnabled` feature flag so event tracking can be controlled by whether the SA script is present.

**Changes:**
- Add a `simpleAnalyticsPlugin` to `vite-shared` that injects the SA stub + loader + noscript pixel on production builds.
- Remove the `SAEnabled` constant and simplify `onSaEvent` to send events when `window.sa_event` is available.
- Update app Vite configs to include the new shared analytics plugin and simplify the GitHub Pages workflow structure.
