### PR TITLE
feat: Add validator self stake reward in `NetworkStats`

### DIFF
--- a/packages/app-staking/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/packages/app-staking/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -17,10 +17,14 @@ export const Announcements = ({ items }: { items: AnnouncementItem[] }) => {
 	const { t } = useTranslation('pages')
 	const { network } = useNetwork()
 	const { bondedPools } = useBondedPools()
-	const { totalStaked, lastReward } = useStakingMetrics()
+	const { totalStaked, lastReward, lastValidatorIncentiveBudget } =
+		useStakingMetrics()
 
 	const { unit, units } = getStakingChainData(network)
 	const lastRewardUnit = new BigNumber(planckToUnit(lastReward || 0, units))
+	const lastValidatorIncentiveBudgetUnit = new BigNumber(
+		planckToUnit(lastValidatorIncentiveBudget || 0, units),
+	)
 
 	let totalPoolPoints = new BigNumber(0)
 	bondedPools.forEach((b: BondedPool) => {
@@ -87,6 +91,20 @@ export const Announcements = ({ items }: { items: AnnouncementItem[] }) => {
 		)
 	} else {
 		announcements.push(null)
+	}
+
+	// Last era validator self stake payout
+	if (lastValidatorIncentiveBudgetUnit.isGreaterThan(0)) {
+		const lastValidatorIncentiveBudgetValue = lastValidatorIncentiveBudgetUnit
+			.integerValue()
+			.toFormat()
+		if (lastValidatorIncentiveBudgetValue !== '0') {
+			announcements.push({
+				value: `${lastValidatorIncentiveBudgetValue} ${unit}`,
+				label: t('lastValidatorSelfStakePayout'),
+				category: t('participation'),
+			})
+		}
 	}
 
 	announcements.sort(sortWithNull(true))

--- a/packages/app-staking/src/pages/Overview/NetworkSats/Announcements.tsx
+++ b/packages/app-staking/src/pages/Overview/NetworkSats/Announcements.tsx
@@ -21,9 +21,9 @@ export const Announcements = ({ items }: { items: AnnouncementItem[] }) => {
 		useStakingMetrics()
 
 	const { unit, units } = getStakingChainData(network)
-	const lastRewardUnit = new BigNumber(planckToUnit(lastReward || 0, units))
+	const lastRewardUnit = new BigNumber(planckToUnit(lastReward ?? 0n, units))
 	const lastValidatorIncentiveBudgetUnit = new BigNumber(
-		planckToUnit(lastValidatorIncentiveBudget || 0, units),
+		planckToUnit(lastValidatorIncentiveBudget ?? 0n, units),
 	)
 
 	let totalPoolPoints = new BigNumber(0)

--- a/packages/dedot-api/src/subscribe/stakingMetrics.ts
+++ b/packages/dedot-api/src/subscribe/stakingMetrics.ts
@@ -6,11 +6,13 @@ import type { Unsub } from 'dedot/types'
 import { defaultStakingMetrics, setStakingMetrics } from 'global-bus'
 import type { StakingMetrics } from 'types'
 import type { StakingChain } from '../types'
+import { hasStorageItem } from '../util'
 
 export class StakingMetricsQuery<T extends StakingChain> {
 	stakingMetrics: StakingMetrics = defaultStakingMetrics
 
 	#unsubs: Unsub[] = []
+	#disposed = false
 
 	constructor(
 		public api: DedotClient<T>,
@@ -82,6 +84,9 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				totalStaked,
 				counterForNominators,
 			]) => {
+				if (this.#disposed) {
+					return
+				}
 				this.stakingMetrics = {
 					...this.stakingMetrics,
 					totalIssuance,
@@ -99,15 +104,17 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				setStakingMetrics(this.stakingMetrics)
 			},
 		)
-		this.#unsubs.push(unsub)
+		if (!this.#trackUnsub(unsub)) {
+			return
+		}
 
 		// Check if the chain has the `erasValidatorIncentiveBudget` storage item before subscribing to
 		// it
-		const hasValidatorIncentiveBudget = this.api.registry.metadata.pallets
-			.find(({ name }) => name === 'Staking')
-			?.storage?.entries.some(
-				({ name }) => name === 'ErasValidatorIncentiveBudget',
-			)
+		const hasValidatorIncentiveBudget = hasStorageItem(
+			this.api,
+			'Staking',
+			'ErasValidatorIncentiveBudget',
+		)
 
 		// If the chain has the `erasValidatorIncentiveBudget` storage item, subscribe to it
 		if (hasValidatorIncentiveBudget) {
@@ -115,6 +122,9 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				await this.api.query.staking.erasValidatorIncentiveBudget(
 					lastEra,
 					(lastValidatorIncentiveBudget: bigint) => {
+						if (this.#disposed) {
+							return
+						}
 						this.stakingMetrics = {
 							...this.stakingMetrics,
 							lastValidatorIncentiveBudget,
@@ -122,13 +132,23 @@ export class StakingMetricsQuery<T extends StakingChain> {
 						setStakingMetrics(this.stakingMetrics)
 					},
 				)
-			this.#unsubs.push(incentiveUnsub)
+			this.#trackUnsub(incentiveUnsub)
 		}
 	}
 
+	#trackUnsub(unsub: Unsub) {
+		if (this.#disposed) {
+			void unsub()
+			return false
+		}
+		this.#unsubs.push(unsub)
+		return true
+	}
+
 	unsubscribe() {
-		for (const unsub of this.#unsubs) {
-			unsub()
+		this.#disposed = true
+		for (const unsub of this.#unsubs.splice(0)) {
+			void unsub()
 		}
 	}
 }

--- a/packages/dedot-api/src/subscribe/stakingMetrics.ts
+++ b/packages/dedot-api/src/subscribe/stakingMetrics.ts
@@ -10,7 +10,7 @@ import type { StakingChain } from '../types'
 export class StakingMetricsQuery<T extends StakingChain> {
 	stakingMetrics: StakingMetrics = defaultStakingMetrics
 
-	#unsub: Unsub | undefined = undefined
+	#unsubs: Unsub[] = []
 
 	constructor(
 		public api: DedotClient<T>,
@@ -21,7 +21,8 @@ export class StakingMetricsQuery<T extends StakingChain> {
 	}
 
 	async subscribe() {
-		this.#unsub = await this.api.queryMulti(
+		const lastEra = Math.max(this.era - 1, 0)
+		const unsub = await this.api.queryMulti(
 			[
 				{
 					fn: this.api.query.balances.totalIssuance,
@@ -45,11 +46,11 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				},
 				{
 					fn: this.api.query.staking.erasValidatorReward,
-					args: [this.era - 1],
+					args: [lastEra],
 				},
 				{
 					fn: this.api.query.staking.erasTotalStake,
-					args: [Math.max(this.era - 1, 0)],
+					args: [lastEra],
 				},
 				{
 					fn: this.api.query.staking.minNominatorBond,
@@ -82,6 +83,7 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				counterForNominators,
 			]) => {
 				this.stakingMetrics = {
+					...this.stakingMetrics,
 					totalIssuance,
 					minimumActiveStake,
 					counterForValidators,
@@ -97,9 +99,36 @@ export class StakingMetricsQuery<T extends StakingChain> {
 				setStakingMetrics(this.stakingMetrics)
 			},
 		)
+		this.#unsubs.push(unsub)
+
+		// Check if the chain has the `erasValidatorIncentiveBudget` storage item before subscribing to
+		// it
+		const hasValidatorIncentiveBudget = this.api.registry.metadata.pallets
+			.find(({ name }) => name === 'Staking')
+			?.storage?.entries.some(
+				({ name }) => name === 'ErasValidatorIncentiveBudget',
+			)
+
+		// If the chain has the `erasValidatorIncentiveBudget` storage item, subscribe to it
+		if (hasValidatorIncentiveBudget) {
+			const incentiveUnsub =
+				await this.api.query.staking.erasValidatorIncentiveBudget(
+					lastEra,
+					(lastValidatorIncentiveBudget: bigint) => {
+						this.stakingMetrics = {
+							...this.stakingMetrics,
+							lastValidatorIncentiveBudget,
+						}
+						setStakingMetrics(this.stakingMetrics)
+					},
+				)
+			this.#unsubs.push(incentiveUnsub)
+		}
 	}
 
 	unsubscribe() {
-		this.#unsub?.()
+		for (const unsub of this.#unsubs) {
+			unsub()
+		}
 	}
 }

--- a/packages/dedot-api/src/util.ts
+++ b/packages/dedot-api/src/util.ts
@@ -7,6 +7,22 @@ import type { GenericSubstrateApi } from 'dedot/types'
 import type { Bonded, ChainId, ImportedAccount } from 'types'
 import type { ServiceClass } from './types'
 
+// Gets a pallet from the active chain metadata
+export const getPallet = <T extends GenericSubstrateApi>(
+	api: DedotClient<T>,
+	palletName: string,
+) => api.registry.metadata.pallets.find(({ name }) => name === palletName)
+
+// Whether a pallet storage item exists in the active chain metadata
+export const hasStorageItem = <T extends GenericSubstrateApi>(
+	api: DedotClient<T>,
+	palletName: string,
+	storageItemName: string,
+) =>
+	getPallet(api, palletName)?.storage?.entries.some(
+		({ name }) => name === storageItemName,
+	) ?? false
+
 export const hasApiHub = (
 	instance: ServiceClass,
 ): instance is ServiceClass & { apiHub: DedotClient<GenericSubstrateApi> } =>

--- a/packages/global-bus/src/stakingMetrics/default.ts
+++ b/packages/global-bus/src/stakingMetrics/default.ts
@@ -10,6 +10,7 @@ export const defaultStakingMetrics: StakingMetrics = {
 	maxValidatorsCount: undefined,
 	validatorCount: 0,
 	lastReward: undefined,
+	lastValidatorIncentiveBudget: undefined,
 	lastTotalStake: 0n,
 	minNominatorBond: 0n,
 	minValidatorBond: 0n,

--- a/packages/locales/src/resources/de/pages.json
+++ b/packages/locales/src/resources/de/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "Belohnung der letzten 30 Tage",
 		"lastEra": "Letzte Ära",
 		"lastEraPayout": "Letzte Era-Auszahlung",
+		"lastValidatorSelfStakePayout": "Letzte Auszahlung des Validator-Eigenstakes",
 		"latestInflationRate": "Inflationsrate für Staker",
 		"leave": "Verlassen",
 		"leavingPool": "Pool wird verlassen",

--- a/packages/locales/src/resources/en/pages.json
+++ b/packages/locales/src/resources/en/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "Last 30 Days Reward",
 		"lastEra": "Last Era",
 		"lastEraPayout": "Last Era Payout",
+		"lastValidatorSelfStakePayout": "Last Validator Self Stake Payout",
 		"latestInflationRate": "Inflation Rate to Stakers",
 		"leave": "Leave",
 		"leavingPool": "Leaving Pool",

--- a/packages/locales/src/resources/es/pages.json
+++ b/packages/locales/src/resources/es/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "Recompensa de los últimos 30 días",
 		"lastEra": "Última Era",
 		"lastEraPayout": "Último Pago de Era",
+		"lastValidatorSelfStakePayout": "Último pago de stake propio de validadores",
 		"latestInflationRate": "Tasa de inflación de Staker",
 		"leave": "Salir",
 		"leavingPool": "Saliendo del Pool",

--- a/packages/locales/src/resources/fr/pages.json
+++ b/packages/locales/src/resources/fr/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "Récompense des 30 derniers jours",
 		"lastEra": "Dernière ère",
 		"lastEraPayout": "Paiement de la dernière ère",
+		"lastValidatorSelfStakePayout": "Dernier paiement de la mise propre des validateurs",
 		"latestInflationRate": "Taux d'inflation pour les stakers",
 		"leave": "Quitter",
 		"leavingPool": "Sortie du pool",

--- a/packages/locales/src/resources/ko/pages.json
+++ b/packages/locales/src/resources/ko/pages.json
@@ -81,6 +81,7 @@
 		"last30DayReward": "지난 30일 보상",
 		"lastEra": "마지막 시대",
 		"lastEraPayout": "마지막 에라 지급액",
+		"lastValidatorSelfStakePayout": "마지막 검증인 자체 스테이크 지급액",
 		"latestInflationRate": "스테이커에 대한 인플레이션율",
 		"leave": "나가기",
 		"leavingPool": "풀을 나가는 중",

--- a/packages/locales/src/resources/pt/pages.json
+++ b/packages/locales/src/resources/pt/pages.json
@@ -81,6 +81,7 @@
 		"last30DayReward": "Recompensa dos Últimos 30 Dias",
 		"lastEra": "Última Era",
 		"lastEraPayout": "Pagamento da Última Era",
+		"lastValidatorSelfStakePayout": "Último Pagamento de Stake Próprio dos Validadores",
 		"latestInflationRate": "Taxa de Inflação para Stakers",
 		"leave": "Sair",
 		"leavingPool": "Saindo do Pool",

--- a/packages/locales/src/resources/tr/pages.json
+++ b/packages/locales/src/resources/tr/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "Son 30 Günlük Ödül",
 		"lastEra": "Son Era",
 		"lastEraPayout": "Son Era Ödemesi",
+		"lastValidatorSelfStakePayout": "Son Doğrulayıcı Öz Stake Ödemesi",
 		"latestInflationRate": "Stake Edenlere Enflasyon Oranı",
 		"leave": "Ayrıl",
 		"leavingPool": "Havuzdan Ayrılınıyor",

--- a/packages/locales/src/resources/zh/pages.json
+++ b/packages/locales/src/resources/zh/pages.json
@@ -79,6 +79,7 @@
 		"last30DayReward": "过去30天的奖励",
 		"lastEra": "最后一个时代",
 		"lastEraPayout": "上Era收益",
+		"lastValidatorSelfStakePayout": "上期验证人自质押收益",
 		"latestInflationRate": "质押者的通货膨胀率",
 		"leave": "离开",
 		"leavingPool": "离开提名池中",

--- a/packages/types/src/networks.ts
+++ b/packages/types/src/networks.ts
@@ -90,6 +90,7 @@ export interface StakingMetrics {
 	maxValidatorsCount: number | undefined
 	validatorCount: number
 	lastReward: bigint | undefined
+	lastValidatorIncentiveBudget: bigint | undefined
 	lastTotalStake: bigint
 	minNominatorBond: bigint
 	minValidatorBond: bigint


### PR DESCRIPTION
Adds a new staking metric for the last era’s validator incentive/self-stake-related payout and surfaces it in the staking overview announcements, including localized UI strings.

**Changes:**
- Extend `StakingMetrics` with `lastValidatorIncentiveBudget`.
- Subscribe to `staking.erasValidatorIncentiveBudget` when available via chain metadata checks.
- Display the new metric in the Network Stats announcements with updated locale strings.
