### PR TITLE
feat: Choose another known pool in simple mode

### DIFF
--- a/packages/app-staking/src/modals/JoinPool/Choose.tsx
+++ b/packages/app-staking/src/modals/JoinPool/Choose.tsx
@@ -1,0 +1,29 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useTheme } from 'hooks/useTheme'
+import { useTranslation } from 'react-i18next'
+import { Tooltip } from 'ui-core/base'
+import { ModalActionWrapper } from './Wrappers'
+
+export const Choose = ({ onClick }: { onClick: () => void }) => {
+	const { t } = useTranslation()
+	const { themeElementRef } = useTheme()
+	const text = t('chooseAnotherPool', { ns: 'app' })
+
+	return (
+		<ModalActionWrapper>
+			<Tooltip
+				text={text}
+				side="bottom"
+				container={themeElementRef.current || undefined}
+			>
+				<button type="button" aria-label={text} onClick={onClick}>
+					<FontAwesomeIcon icon={faArrowsRotate} />
+				</button>
+			</Tooltip>
+		</ModalActionWrapper>
+	)
+}

--- a/packages/app-staking/src/modals/JoinPool/Wrappers.ts
+++ b/packages/app-staking/src/modals/JoinPool/Wrappers.ts
@@ -3,6 +3,23 @@
 
 import styled from 'styled-components'
 
+export const ModalActionWrapper = styled.div`
+  position: absolute;
+  top: 1.5rem;
+  right: 4rem;
+  z-index: 2;
+
+  > button {
+    opacity: 0.6;
+    transition: opacity var(--transition-duration) ease-in-out;
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+    }
+  }
+`
+
 export const HeaderWrapper = styled.div`
   width: 100%;
   display: flex;

--- a/packages/app-staking/src/modals/JoinPool/index.tsx
+++ b/packages/app-staking/src/modals/JoinPool/index.tsx
@@ -6,6 +6,7 @@ import { useBondedPools } from 'contexts/Pools/BondedPools'
 import { useNetwork } from 'hooks/useNetwork'
 import { useState } from 'react'
 import { Close } from 'ui-overlay'
+import { Choose } from './Choose'
 import { Form } from './Form'
 
 export const JoinPool = () => {
@@ -15,12 +16,26 @@ export const JoinPool = () => {
 	const poolIds = getNetworkKnownPoolIds(network)
 
 	// The selected bonded pool id
-	const [selectedPoolId] = useState<number>(
+	const [selectedPoolId, setSelectedPoolId] = useState<number>(
 		poolIds.length > 0
 			? poolIds[Math.floor(Math.random() * poolIds.length)]
 			: // Fallback to any bonded pool if no known pool ids are given
 				bondedPools[Math.floor(Math.random() * bondedPools.length)]?.id || 1,
 	)
+	const alternatePoolIds = poolIds.filter(
+		(poolId) =>
+			Number(poolId) !== Number(selectedPoolId) &&
+			bondedPools.some((pool) => Number(pool.id) === Number(poolId)),
+	)
+
+	// Randomly select a different known pool to display
+	const handleChooseNewPool = () => {
+		const newPoolId =
+			alternatePoolIds[Math.floor(Math.random() * alternatePoolIds.length)]
+		if (newPoolId !== undefined) {
+			setSelectedPoolId(newPoolId)
+		}
+	}
 
 	const metadata = poolsMetaData[selectedPoolId]
 	const bondedPool = bondedPools.find((pool) => pool.id === selectedPoolId)
@@ -31,6 +46,7 @@ export const JoinPool = () => {
 
 	return (
 		<>
+			{alternatePoolIds.length > 0 && <Choose onClick={handleChooseNewPool} />}
 			<Close />
 			<Form bondedPool={bondedPool} metadata={metadata} />
 		</>

--- a/packages/app-staking/src/modals/JoinPool/index.tsx
+++ b/packages/app-staking/src/modals/JoinPool/index.tsx
@@ -48,7 +48,7 @@ export const JoinPool = () => {
 		<>
 			{alternatePoolIds.length > 0 && <Choose onClick={handleChooseNewPool} />}
 			<Close />
-			<Form bondedPool={bondedPool} metadata={metadata} />
+			<Form key={bondedPool.id} bondedPool={bondedPool} metadata={metadata} />
 		</>
 	)
 }


### PR DESCRIPTION
Adds a “choose another pool” action to the **JoinPool** modal so users in simple mode can cycle through other known (and available) pools without closing/reopening the modal.

**Changes:**
- Added an icon-only “Choose another pool” action with tooltip in the JoinPool modal.
- Updated JoinPool modal state to allow switching the selected pool to another known bonded pool.
- Introduced a small styled wrapper for positioning/hover/focus behavior of the new action button.
